### PR TITLE
Balancer/new pool types

### DIFF
--- a/scripts/runDexIntegration.ts
+++ b/scripts/runDexIntegration.ts
@@ -58,8 +58,8 @@ async function main() {
 
   await balancerV2.setupEventPools(blocknumber);
 
-  const from = bbausdc;
-  const to = USDC;
+  const from = bbausd;
+  const to = bbadai;
 
   const pools = await balancerV2.getPoolIdentifiers(
     from,
@@ -79,11 +79,8 @@ async function main() {
   );
   console.log('WETH <> DAI Pool Prices: ', prices);
 
-  // const poolLiquidity = await balancerV2.getTopPoolsForToken(
-  //   from.address,
-  //   10,
-  // );
-  // console.log('WETH Top Pools:', poolLiquidity);
+  const poolLiquidity = await balancerV2.getTopPoolsForToken(from.address, 10);
+  console.log('WETH Top Pools:', poolLiquidity);
 }
 
 main();

--- a/scripts/runDexIntegration.ts
+++ b/scripts/runDexIntegration.ts
@@ -30,12 +30,12 @@ const wstETH = {
 // i.e. bbausd<>bbausdc for BPT>token
 // i.e. bbausdc<>bbadai for token>token
 const bbausd = {
-  address: '0x4fd63966879300cafafbb35d157dc5229278ed23',
+  address: '0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2',
   decimals: 18,
 };
 
 const bbausdc = {
-  address: '0x652d486b80c461c397b0d95612a404da936f3db3',
+  address: '0x9210f1204b5a24742eba12f710636d76240df3d0',
   decimals: 18,
 };
 
@@ -58,17 +58,20 @@ async function main() {
 
   await balancerV2.setupEventPools(blocknumber);
 
+  const from = bbausdc;
+  const to = USDC;
+
   const pools = await balancerV2.getPoolIdentifiers(
-    bbausd,
-    bbausdc,
+    from,
+    to,
     SwapSide.SELL,
     blocknumber,
   );
   console.log('WETH <> DAI Pool Ideintifiers: ', pools);
 
   const prices = await balancerV2.getPricesVolume(
-    bbausd,
-    bbausdc,
+    from,
+    to,
     amounts,
     SwapSide.SELL,
     blocknumber,
@@ -76,11 +79,11 @@ async function main() {
   );
   console.log('WETH <> DAI Pool Prices: ', prices);
 
-  const poolLiquidity = await balancerV2.getTopPoolsForToken(
-    bbadai.address,
-    10,
-  );
-  console.log('WETH Top Pools:', poolLiquidity);
+  // const poolLiquidity = await balancerV2.getTopPoolsForToken(
+  //   from.address,
+  //   10,
+  // );
+  // console.log('WETH Top Pools:', poolLiquidity);
 }
 
 main();

--- a/scripts/runDexIntegration.ts
+++ b/scripts/runDexIntegration.ts
@@ -40,7 +40,7 @@ const bbausdc = {
 };
 
 const bbadai = {
-  address: '0xa3823e50f20982656557a4a6a9c06ba5467ae908',
+  address: '0x804cdb9116a10bb78768d3252355a1b18067bf8f',
   decimals: 18,
 };
 

--- a/scripts/runDexIntegration.ts
+++ b/scripts/runDexIntegration.ts
@@ -15,6 +15,35 @@ const DAI = {
   decimals: 18,
 };
 
+const USDC = {
+  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  decimals: 6,
+};
+
+// Example for checking metaStable Pool, i.e. WETH<>wstETH
+const wstETH = {
+  address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+  decimals: 18,
+};
+
+// Example for checking PhantomStable Pool,
+// i.e. bbausd<>bbausdc for BPT>token
+// i.e. bbausdc<>bbadai for token>token
+const bbausd = {
+  address: '0x4fd63966879300cafafbb35d157dc5229278ed23',
+  decimals: 18,
+};
+
+const bbausdc = {
+  address: '0x652d486b80c461c397b0d95612a404da936f3db3',
+  decimals: 18,
+};
+
+const bbadai = {
+  address: '0xa3823e50f20982656557a4a6a9c06ba5467ae908',
+  decimals: 18,
+};
+
 const amounts = [
   BigInt('0'),
   BigInt('1000000000000000000'),
@@ -30,16 +59,16 @@ async function main() {
   await balancerV2.setupEventPools(blocknumber);
 
   const pools = await balancerV2.getPoolIdentifiers(
-    WETH,
-    DAI,
+    bbausd,
+    bbausdc,
     SwapSide.SELL,
     blocknumber,
   );
   console.log('WETH <> DAI Pool Ideintifiers: ', pools);
 
   const prices = await balancerV2.getPricesVolume(
-    WETH,
-    DAI,
+    bbausd,
+    bbausdc,
     amounts,
     SwapSide.SELL,
     blocknumber,
@@ -47,7 +76,10 @@ async function main() {
   );
   console.log('WETH <> DAI Pool Prices: ', prices);
 
-  const poolLiquidity = await balancerV2.getTopPoolsForToken(WETH.address, 10);
+  const poolLiquidity = await balancerV2.getTopPoolsForToken(
+    bbadai.address,
+    10,
+  );
   console.log('WETH Top Pools:', poolLiquidity);
 }
 

--- a/src/abi/balancer-v2/linearPoolAbi.json
+++ b/src/abi/balancer-v2/linearPoolAbi.json
@@ -1,0 +1,1062 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "vault",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "mainToken",
+        "type": "address"
+      },
+      {
+        "internalType": "contract IERC20",
+        "name": "wrappedToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "upperTarget",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pauseWindowDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bufferPeriodDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "paused",
+        "type": "bool"
+      }
+    ],
+    "name": "PausedStateChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "SwapFeePercentageChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lowerTarget",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "upperTarget",
+        "type": "uint256"
+      }
+    ],
+    "name": "TargetsSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "selector",
+        "type": "bytes4"
+      }
+    ],
+    "name": "getActionId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAuthorizer",
+    "outputs": [
+      {
+        "internalType": "contract IAuthorizer",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBptIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMainIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMainToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPausedState",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "paused",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "pauseWindowEndTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "bufferPeriodEndTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPoolId",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getScalingFactors",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getSwapFeePercentage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTargets",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "lowerTarget",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "upperTarget",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVault",
+    "outputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVirtualSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWrappedIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWrappedToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getWrappedTokenRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "balances",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastChangeBlock",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "protocolSwapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "onExitPool",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "balances",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastChangeBlock",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "protocolSwapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "onJoinPool",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "enum IVault.SwapKind",
+            "name": "kind",
+            "type": "uint8"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenIn",
+            "type": "address"
+          },
+          {
+            "internalType": "contract IERC20",
+            "name": "tokenOut",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "poolId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lastChangeBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "from",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "to",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "userData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IPoolSwapStructs.SwapRequest",
+        "name": "request",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "balances",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "indexIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "indexOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "onSwap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "balances",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastChangeBlock",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "protocolSwapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryExit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "poolId",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "balances",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastChangeBlock",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "protocolSwapFeePercentage",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "userData",
+        "type": "bytes"
+      }
+    ],
+    "name": "queryJoin",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "bptOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "poolConfig",
+        "type": "bytes"
+      }
+    ],
+    "name": "setAssetManagerPoolConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "paused",
+        "type": "bool"
+      }
+    ],
+    "name": "setPaused",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "swapFeePercentage",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSwapFeePercentage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newLowerTarget",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "newUpperTarget",
+        "type": "uint256"
+      }
+    ],
+    "name": "setTargets",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/dex/balancer-v2/LinearMath.ts
+++ b/src/dex/balancer-v2/LinearMath.ts
@@ -1,0 +1,299 @@
+import { MathSol } from './balancer-v2-math';
+
+type Params = {
+  fee: bigint;
+  lowerTarget: bigint;
+  upperTarget: bigint;
+};
+
+export function _calcBptOutPerMainIn(
+  mainIn: bigint,
+  mainBalance: bigint,
+  wrappedBalance: bigint,
+  bptSupply: bigint,
+  params: Params,
+): bigint {
+  // Amount out, so we round down overall.
+
+  if (bptSupply == BigInt(0)) {
+    return _toNominal(mainIn, params);
+  }
+
+  const previousNominalMain = _toNominal(mainBalance, params);
+  const afterNominalMain = _toNominal(mainBalance + mainIn, params);
+  const deltaNominalMain = afterNominalMain - previousNominalMain;
+  const invariant = _calcInvariantUp(previousNominalMain, wrappedBalance);
+  return MathSol.divDownFixed(
+    MathSol.mulDownFixed(bptSupply, deltaNominalMain),
+    invariant,
+  );
+}
+
+export function _calcBptInPerMainOut(
+  mainOut: bigint,
+  mainBalance: bigint,
+  wrappedBalance: bigint,
+  bptSupply: bigint,
+  params: Params,
+): bigint {
+  // Amount in, so we round up overall.
+  const previousNominalMain = _toNominal(mainBalance, params);
+  const afterNominalMain = _toNominal(mainBalance - mainOut, params);
+  const deltaNominalMain = previousNominalMain - afterNominalMain;
+  const invariant = _calcInvariantDown(previousNominalMain, wrappedBalance);
+  return MathSol.divUpFixed(
+    MathSol.mulUpFixed(bptSupply, deltaNominalMain),
+    invariant,
+  );
+}
+
+export function _calcBptInPerWrappedOut(
+  wrappedOut: bigint,
+  mainBalance: bigint,
+  wrappedBalance: bigint,
+  bptSupply: bigint,
+  params: Params,
+): bigint {
+  // Amount in, so we round up overall.
+  const nominalMain = _toNominal(mainBalance, params);
+  const previousInvariant = _calcInvariantUp(nominalMain, wrappedBalance);
+  const newWrappedBalance = wrappedBalance - wrappedOut;
+  const newInvariant = _calcInvariantDown(nominalMain, newWrappedBalance);
+  const newBptBalance = MathSol.divDownFixed(
+    MathSol.mulDownFixed(bptSupply, newInvariant),
+    previousInvariant,
+  );
+  return bptSupply - newBptBalance;
+}
+
+export function _calcWrappedOutPerMainIn(
+  mainIn: bigint,
+  mainBalance: bigint,
+  params: Params,
+): bigint {
+  // Amount out, so we round down overall.
+  const previousNominalMain = _toNominal(mainBalance, params);
+  const afterNominalMain = _toNominal(mainBalance + mainIn, params);
+  const deltaNominalMain = afterNominalMain - previousNominalMain;
+  return deltaNominalMain;
+}
+
+export function _calcWrappedInPerMainOut(
+  mainOut: bigint,
+  mainBalance: bigint,
+  params: Params,
+): bigint {
+  // Amount in, so we round up overall.
+  const previousNominalMain = _toNominal(mainBalance, params);
+  const afterNominalMain = _toNominal(mainBalance - mainOut, params);
+  const deltaNominalMain = previousNominalMain - afterNominalMain;
+  return deltaNominalMain;
+}
+
+export function _calcMainInPerBptOut(
+  bptOut: bigint,
+  mainBalance: bigint,
+  wrappedBalance: bigint,
+  bptSupply: bigint,
+  params: Params,
+): bigint {
+  // Amount in, so we round up overall.
+  if (bptSupply == BigInt(0)) {
+    return _fromNominal(bptOut, params);
+  }
+  const previousNominalMain = _toNominal(mainBalance, params);
+  const invariant = _calcInvariantUp(previousNominalMain, wrappedBalance);
+  const deltaNominalMain = MathSol.divUpFixed(
+    MathSol.mulUpFixed(invariant, bptOut),
+    bptSupply,
+  );
+  const afterNominalMain = previousNominalMain + deltaNominalMain;
+  const newMainBalance = _fromNominal(afterNominalMain, params);
+  return newMainBalance - mainBalance;
+}
+
+export function _calcMainOutPerBptIn(
+  bptIn: bigint,
+  mainBalance: bigint,
+  wrappedBalance: bigint,
+  bptSupply: bigint,
+  params: Params,
+): bigint {
+  // Amount out, so we round down overall.
+  const previousNominalMain = _toNominal(mainBalance, params);
+  const invariant = _calcInvariantDown(previousNominalMain, wrappedBalance);
+  const deltaNominalMain = MathSol.divDownFixed(
+    MathSol.mulDownFixed(invariant, bptIn),
+    bptSupply,
+  );
+  const afterNominalMain = previousNominalMain - deltaNominalMain;
+  const newMainBalance = _fromNominal(afterNominalMain, params);
+  return mainBalance - newMainBalance;
+}
+
+export function _calcMainOutPerWrappedIn(
+  wrappedIn: bigint,
+  mainBalance: bigint,
+  params: Params,
+): bigint {
+  // Amount out, so we round down overall.
+  const previousNominalMain = _toNominal(mainBalance, params);
+  const deltaNominalMain = wrappedIn;
+  const afterNominalMain = previousNominalMain - deltaNominalMain;
+  const newMainBalance = _fromNominal(afterNominalMain, params);
+  return mainBalance - newMainBalance;
+}
+
+export function _calcMainInPerWrappedOut(
+  wrappedOut: bigint,
+  mainBalance: bigint,
+  params: Params,
+): bigint {
+  // Amount in, so we round up overall.
+  const previousNominalMain = _toNominal(mainBalance, params);
+  const deltaNominalMain = wrappedOut;
+  const afterNominalMain = previousNominalMain + deltaNominalMain;
+  const newMainBalance = _fromNominal(afterNominalMain, params);
+  return newMainBalance - mainBalance;
+}
+
+export function _calcBptOutPerWrappedIn(
+  wrappedIn: bigint,
+  mainBalance: bigint,
+  wrappedBalance: bigint,
+  bptSupply: bigint,
+  params: Params,
+): bigint {
+  // Amount out, so we round down overall.
+  if (bptSupply == BigInt(0)) {
+    // Return nominal DAI
+    return wrappedIn;
+  }
+
+  const nominalMain = _toNominal(mainBalance, params);
+  const previousInvariant = _calcInvariantUp(nominalMain, wrappedBalance);
+  const newWrappedBalance = wrappedBalance + wrappedIn;
+  const newInvariant = _calcInvariantDown(nominalMain, newWrappedBalance);
+  const newBptBalance = MathSol.divDownFixed(
+    MathSol.mulDownFixed(bptSupply, newInvariant),
+    previousInvariant,
+  );
+  return newBptBalance - bptSupply;
+}
+
+export function _calcWrappedInPerBptOut(
+  bptOut: bigint,
+  mainBalance: bigint,
+  wrappedBalance: bigint,
+  bptSupply: bigint,
+  params: Params,
+): bigint {
+  // Amount in, so we round up overall.
+  if (bptSupply == BigInt(0)) {
+    // Return nominal DAI
+    return bptOut;
+  }
+
+  const nominalMain = _toNominal(mainBalance, params);
+  const previousInvariant = _calcInvariantUp(nominalMain, wrappedBalance);
+  const newBptBalance = bptSupply + bptOut;
+  const newWrappedBalance =
+    MathSol.mulUpFixed(
+      MathSol.divUpFixed(newBptBalance, bptSupply),
+      previousInvariant,
+    ) - nominalMain;
+  return newWrappedBalance - wrappedBalance;
+}
+
+export function _calcWrappedOutPerBptIn(
+  bptIn: bigint,
+  mainBalance: bigint,
+  wrappedBalance: bigint,
+  bptSupply: bigint,
+  params: Params,
+): bigint {
+  // Amount out, so we round down overall.
+  const nominalMain = _toNominal(mainBalance, params);
+  const previousInvariant = _calcInvariantUp(nominalMain, wrappedBalance);
+  const newBptBalance = bptSupply - bptIn;
+  const newWrappedBalance =
+    MathSol.mulUpFixed(
+      MathSol.divUpFixed(newBptBalance, bptSupply),
+      previousInvariant,
+    ) - nominalMain;
+  return wrappedBalance - newWrappedBalance;
+}
+
+function _calcInvariantUp(
+  nominalMainBalance: bigint,
+  wrappedBalance: bigint,
+): bigint {
+  return nominalMainBalance + wrappedBalance;
+}
+
+function _calcInvariantDown(
+  nominalMainBalance: bigint,
+  wrappedBalance: bigint,
+): bigint {
+  return nominalMainBalance + wrappedBalance;
+}
+
+function _toNominal(real: bigint, params: Params): bigint {
+  // Fees are always rounded down: either direction would work but we need to be consistent, and rounding down
+  // uses less gas.
+  if (real < params.lowerTarget) {
+    const fees = MathSol.mulDownFixed(params.lowerTarget - real, params.fee);
+    return MathSol.sub(real, fees);
+  } else if (real <= params.upperTarget) {
+    return real;
+  } else {
+    const fees = MathSol.mulDownFixed(real - params.upperTarget, params.fee);
+    return MathSol.sub(real, fees);
+  }
+}
+
+function _fromNominal(nominal: bigint, params: Params): bigint {
+  // Since real = nominal + fees, rounding down fees is equivalent to rounding down real.
+  if (nominal < params.lowerTarget) {
+    return MathSol.divDownFixed(
+      nominal + MathSol.mulDownFixed(params.fee, params.lowerTarget),
+      MathSol.ONE + params.fee,
+    );
+  } else if (nominal <= params.upperTarget) {
+    return nominal;
+  } else {
+    return MathSol.divDownFixed(
+      nominal - MathSol.mulDownFixed(params.fee, params.upperTarget),
+      MathSol.ONE - params.fee,
+    );
+  }
+}
+
+export function _calcTokensOutGivenExactBptIn(
+  balances: bigint[],
+  bptAmountIn: bigint,
+  bptTotalSupply: bigint,
+  bptIndex: number,
+): bigint[] {
+  /**********************************************************************************************
+    // exactBPTInForTokensOut                                                                    //
+    // (per token)                                                                               //
+    // aO = tokenAmountOut             /        bptIn         \                                  //
+    // b = tokenBalance      a0 = b * | ---------------------  |                                 //
+    // bptIn = bptAmountIn             \     bptTotalSupply    /                                 //
+    // bpt = bptTotalSupply                                                                      //
+    **********************************************************************************************/
+
+  // Since we're computing an amount out, we round down overall. This means rounding down on both the
+  // multiplication and division.
+
+  const bptRatio = MathSol.divDownFixed(bptAmountIn, bptTotalSupply);
+  const amountsOut: bigint[] = new Array(balances.length);
+  for (let i = 0; i < balances.length; i++) {
+    // BPT is skipped as those tokens are not the LPs, but rather the preminted and undistributed amount.
+    if (i != bptIndex) {
+      amountsOut[i] = MathSol.mulDownFixed(balances[i], bptRatio);
+    }
+  }
+  return amountsOut;
+}

--- a/src/dex/balancer-v2/LinearPool.ts
+++ b/src/dex/balancer-v2/LinearPool.ts
@@ -360,7 +360,8 @@ export class LinearPool extends BasePool {
   }
 
   /*
-  TO DO - Waiting for confirmation of a good/quick estimate to use here.
+  Swapping to BPT allows for a very large amount as pre-minted.
+  Swapping to main token - you can use 99% of the balance of the main token (Dani)
   */
   checkBalance(
     balanceOut: bigint,

--- a/src/dex/balancer-v2/LinearPool.ts
+++ b/src/dex/balancer-v2/LinearPool.ts
@@ -210,33 +210,34 @@ export class LinearPool extends BasePool {
   /*
     Helper function to parse pool data into params for onSell function.
     */
-  parsePoolPairDataBigInt(
+  parsePoolPairData(
     pool: SubgraphPoolBase,
     poolState: PoolState,
     tokenIn: string,
     tokenOut: string,
   ): LinearPoolPairData {
-    const indexIn = pool.tokens.findIndex(
-      t => t.address.toLowerCase() === tokenIn.toLowerCase(),
-    );
-    const indexOut = pool.tokens.findIndex(
-      t => t.address.toLowerCase() === tokenOut.toLowerCase(),
-    );
-    const bptIndex = pool.tokens.findIndex(
-      t => t.address.toLowerCase() === pool.address.toLowerCase(),
-    );
-    const tokenAddresses = pool.tokens.map(t => t.address);
-    const balances = pool.tokens.map(
-      t => poolState.tokens[t.address.toLowerCase()].balance,
-    );
-    const scalingFactors = pool.tokens.map(
-      t => poolState.tokens[t.address.toLowerCase()].scalingFactor || BigInt(0),
-    );
+    let indexIn = 0,
+      indexOut = 0,
+      bptIndex = 0;
+    const balances: BigInt[] = [];
+    const scalingFactors: BigInt[] = [];
+
+    const tokens = pool.tokens.map((t, i) => {
+      if (t.address.toLowerCase() === tokenIn.toLowerCase()) indexIn = i;
+      if (t.address.toLowerCase() === tokenOut.toLowerCase()) indexOut = i;
+      if (t.address.toLowerCase() === pool.address.toLowerCase()) bptIndex = i;
+
+      balances.push(poolState.tokens[t.address.toLowerCase()].balance);
+      scalingFactors.push(
+        poolState.tokens[t.address.toLowerCase()].scalingFactor || BigInt(0),
+      );
+      return t.address;
+    });
     const poolPairData: LinearPoolPairData = {
-      tokens: tokenAddresses,
+      tokens,
       balances,
-      indexIn: indexIn,
-      indexOut: indexOut,
+      indexIn,
+      indexOut,
       scalingFactors,
       bptIndex,
       swapFee: poolState.swapFee,

--- a/src/dex/balancer-v2/LinearPool.ts
+++ b/src/dex/balancer-v2/LinearPool.ts
@@ -275,18 +275,6 @@ export class LinearPool extends BasePool {
       target: pool.address,
       callData: poolInterface.encodeFunctionData('getScalingFactors'),
     });
-    poolCallData.push({
-      target: pool.address,
-      callData: poolInterface.encodeFunctionData('getMainIndex'),
-    });
-    poolCallData.push({
-      target: pool.address,
-      callData: poolInterface.encodeFunctionData('getWrappedIndex'),
-    });
-    poolCallData.push({
-      target: pool.address,
-      callData: poolInterface.encodeFunctionData('getBptIndex'),
-    });
     // returns lowerTarget, upperTarget
     poolCallData.push({
       target: pool.address,
@@ -325,31 +313,20 @@ export class LinearPool extends BasePool {
       data.returnData[startIndex++],
     )[0];
 
-    const mainIndex = poolInterface.decodeFunctionResult(
-      'getMainIndex',
-      data.returnData[startIndex++],
-    );
-
-    const wrappedIndex = poolInterface.decodeFunctionResult(
-      'getWrappedIndex',
-      data.returnData[startIndex++],
-    );
-
-    const bptIndex = poolInterface.decodeFunctionResult(
-      'getBptIndex',
-      data.returnData[startIndex++],
-    );
-
     const [lowerTarget, upperTarget] = poolInterface.decodeFunctionResult(
       'getTargets',
       data.returnData[startIndex++],
     );
 
+    const bptIndex = pool.tokens.findIndex(
+      t => t.address.toLowerCase() === pool.address.toLowerCase(),
+    );
+
     const poolState: PoolState = {
       swapFee: BigInt(swapFee.toString()),
-      mainIndex: Number(mainIndex),
-      wrappedIndex: Number(wrappedIndex),
-      bptIndex: Number(bptIndex),
+      mainIndex: Number(pool.mainIndex),
+      wrappedIndex: Number(pool.wrappedIndex),
+      bptIndex,
       lowerTarget: BigInt(lowerTarget.toString()),
       upperTarget: BigInt(upperTarget.toString()),
       tokens: poolTokens.tokens.reduce(

--- a/src/dex/balancer-v2/LinearPool.ts
+++ b/src/dex/balancer-v2/LinearPool.ts
@@ -1,0 +1,360 @@
+import { Interface } from '@ethersproject/abi';
+import { BigNumber } from '@ethersproject/bignumber';
+import { isSameAddress, getTokenScalingFactor } from './utils';
+import * as LinearMath from './LinearMath';
+import { BZERO } from './balancer-v2-math';
+import { BasePool } from './balancer-v2-pool';
+import { callData, SubgraphPoolBase, PoolState, TokenState } from './types';
+
+export enum PairTypes {
+  BptToMainToken,
+  MainTokenToBpt,
+  MainTokenToWrappedToken,
+  WrappedTokenToMainToken,
+  BptToWrappedToken,
+  WrappedTokenToBpt,
+}
+
+type LinearPoolPairData = {
+  tokens: string[];
+  balances: BigInt[];
+  indexIn: number;
+  indexOut: number;
+  scalingFactors: BigInt[];
+  bptIndex: number;
+  swapFee: BigInt;
+  amp: BigInt;
+  wrappedIndex: number;
+  mainIndex: number;
+  lowerTarget: BigInt;
+  upperTarget: BigInt;
+};
+
+/*
+Linear (Boosted) Pools are designed to facilitate trades between stablecoins while simultaneously forwarding much of the pool's 
+liquidity to external protocols, such as Aave. 
+One of the key features that makes trades through Boosted Pools so simple is the use of Phantom BPT. Normally when a Liquidity 
+Provider joins/exits a pool, the pool mints/burns pool tokens as needed. This is gas intensive and requires users to execute a join or exit. 
+In pools that use Phantom BPT, however, all pool tokens are minted at the time of pool creation and are held by the pool itself. 
+With Phantom BPT, Liquidity Providers use a swap (or more likely a batchSwap) to trade to or from a pool token to join or exit, respectively. 
+*/
+export class LinearPool extends BasePool {
+  // This is the maximum token amount the Vault can hold. In regular operation, the total BPT supply remains constant
+  // and equal to _INITIAL_BPT_SUPPLY, but most of it remains in the Pool, waiting to be exchanged for tokens. The
+  // actual amount of BPT in circulation is the total supply minus the amount held by the Pool, and is known as the
+  // 'virtual supply'.
+  static MAX_TOKEN_BALANCE = BigNumber.from('2').pow('112').sub('1');
+
+  /*
+    scaling factors should include rate:
+    The wrapped token's scaling factor is not constant, but increases over time as the wrapped token increases in value.
+    i.e. 
+    scalingFactors: pool.tokens.map(({ decimals, priceRate }) =>
+        MathSol.mulDownFixed(getTokenScalingFactor(decimals), priceRate)
+    )
+    */
+  onSell(
+    amounts: bigint[],
+    tokens: string[],
+    balances: bigint[],
+    indexIn: number,
+    indexOut: number,
+    bptIndex: number,
+    wrappedIndex: number,
+    mainIndex: number,
+    scalingFactors: bigint[],
+    swapFeePercentage: bigint,
+    lowerTarget: bigint,
+    upperTarget: bigint,
+  ): bigint[] {
+    return this._swapGivenIn(
+      amounts,
+      tokens,
+      balances,
+      indexIn,
+      indexOut,
+      bptIndex,
+      wrappedIndex,
+      mainIndex,
+      scalingFactors,
+      swapFeePercentage,
+      lowerTarget,
+      upperTarget,
+    );
+  }
+
+  _swapGivenIn(
+    tokenAmountsIn: bigint[],
+    tokens: string[],
+    balances: bigint[],
+    indexIn: number,
+    indexOut: number,
+    bptIndex: number,
+    wrappedIndex: number,
+    mainIndex: number,
+    scalingFactors: bigint[],
+    swapFeePercentage: bigint,
+    lowerTarget: bigint,
+    upperTarget: bigint,
+  ): bigint[] {
+    /* 
+        Linear pools allow trading between:
+        wrappedToken <> mainToken
+        wrappedToken <> BPT
+        mainToken <> BPT
+        */
+    let pairType: PairTypes;
+    if (isSameAddress(tokens[indexIn], tokens[bptIndex])) {
+      if (isSameAddress(tokens[indexOut], tokens[wrappedIndex]))
+        pairType = PairTypes.BptToWrappedToken;
+      else pairType = PairTypes.BptToMainToken;
+    } else if (isSameAddress(tokens[indexOut], tokens[bptIndex])) {
+      if (isSameAddress(tokens[indexIn], tokens[wrappedIndex]))
+        pairType = PairTypes.WrappedTokenToBpt;
+      else pairType = PairTypes.MainTokenToBpt;
+    } else {
+      if (isSameAddress(tokens[indexIn], tokens[wrappedIndex]))
+        pairType = PairTypes.WrappedTokenToMainToken;
+      else pairType = PairTypes.MainTokenToWrappedToken;
+    }
+
+    const balancesUpscaled = this._upscaleArray(balances, scalingFactors);
+    const tokenAmountsInScaled = tokenAmountsIn.map(a =>
+      this._upscale(a, scalingFactors[indexIn]),
+    );
+
+    // VirtualBPTSupply must be used for the maths
+    const virtualBptSupply = LinearPool.MAX_TOKEN_BALANCE.sub(
+      balances[bptIndex],
+    ).toBigInt();
+
+    const amountsOut = this._onSwapGivenIn(
+      tokenAmountsInScaled,
+      balancesUpscaled[mainIndex],
+      balancesUpscaled[wrappedIndex],
+      swapFeePercentage,
+      lowerTarget,
+      upperTarget,
+      virtualBptSupply,
+      pairType,
+    );
+
+    // amountOut tokens are exiting the Pool, so we round down.
+    return amountsOut.map(a =>
+      this._downscaleDown(a, scalingFactors[indexOut]),
+    );
+  }
+
+  /*
+     Called when a swap with the Pool occurs, where the amount of tokens entering the Pool is known.
+     All amounts are upscaled.
+     Swap fee is NOT already deducted.
+     The return value is also considered upscaled, and should be downscaled (rounding down)
+     */
+  _onSwapGivenIn(
+    tokenAmountsIn: bigint[],
+    mainBalance: bigint,
+    wrappedBalance: bigint,
+    fee: bigint,
+    lowerTarget: bigint,
+    upperTarget: bigint,
+    virtualBptSupply: bigint,
+    pairType: PairTypes,
+  ): bigint[] {
+    const amountsOut: bigint[] = [];
+
+    if (pairType === PairTypes.MainTokenToBpt) {
+      tokenAmountsIn.forEach(amountIn => {
+        let amt: bigint;
+        try {
+          amt = LinearMath._calcBptOutPerMainIn(
+            amountIn,
+            mainBalance,
+            wrappedBalance,
+            virtualBptSupply,
+            {
+              fee: fee,
+              lowerTarget: lowerTarget,
+              upperTarget: upperTarget,
+            },
+          );
+        } catch (err) {
+          amt = BZERO;
+        }
+        amountsOut.push(amt);
+      });
+    } else if (pairType === PairTypes.BptToMainToken) {
+      tokenAmountsIn.forEach(amountIn => {
+        let amt: bigint;
+        try {
+          amt = LinearMath._calcMainOutPerBptIn(
+            amountIn,
+            mainBalance,
+            wrappedBalance,
+            virtualBptSupply,
+            {
+              fee: fee,
+              lowerTarget: lowerTarget,
+              upperTarget: upperTarget,
+            },
+          );
+        } catch (err) {
+          amt = BZERO;
+        }
+        amountsOut.push(amt);
+      });
+    } else amountsOut.push(BZERO);
+    return amountsOut;
+  }
+
+  /*
+    Helper function to parse pool data into params for onSell function.
+    */
+  parsePoolPairDataBigInt(
+    pool: SubgraphPoolBase,
+    poolState: PoolState,
+    tokenIn: string,
+    tokenOut: string,
+  ): LinearPoolPairData {
+    const indexIn = pool.tokens.findIndex(
+      t => t.address.toLowerCase() === tokenIn.toLowerCase(),
+    );
+    const indexOut = pool.tokens.findIndex(
+      t => t.address.toLowerCase() === tokenOut.toLowerCase(),
+    );
+    const bptIndex = pool.tokens.findIndex(
+      t => t.address.toLowerCase() === pool.address.toLowerCase(),
+    );
+    const tokenAddresses = pool.tokens.map(t => t.address);
+    const balances = pool.tokens.map(
+      t => poolState.tokens[t.address.toLowerCase()].balance,
+    );
+    const scalingFactors = pool.tokens.map(
+      t => poolState.tokens[t.address.toLowerCase()].scalingFactor || BigInt(0),
+    );
+    const poolPairData: LinearPoolPairData = {
+      tokens: tokenAddresses,
+      balances,
+      indexIn: indexIn,
+      indexOut: indexOut,
+      scalingFactors,
+      bptIndex,
+      swapFee: poolState.swapFee,
+      amp: poolState.amp || BigInt(0),
+      wrappedIndex: poolState.wrappedIndex || 0,
+      mainIndex: poolState.mainIndex || 0,
+      lowerTarget: poolState.lowerTarget || BigInt(0),
+      upperTarget: poolState.upperTarget || BigInt(0),
+    };
+    return poolPairData;
+  }
+
+  /*
+    Helper function to construct onchain multicall data for Linear Pool.
+    */
+  static getOnChainCalls(
+    pool: SubgraphPoolBase,
+    poolInterface: Interface,
+  ): callData[] {
+    // Assumes poolTokens and swapFee callData are already added in main getOnChainState
+    const poolCallData: callData[] = [];
+    poolCallData.push({
+      target: pool.address,
+      callData: poolInterface.encodeFunctionData('getScalingFactors'),
+    });
+    poolCallData.push({
+      target: pool.address,
+      callData: poolInterface.encodeFunctionData('getMainIndex'),
+    });
+    poolCallData.push({
+      target: pool.address,
+      callData: poolInterface.encodeFunctionData('getWrappedIndex'),
+    });
+    poolCallData.push({
+      target: pool.address,
+      callData: poolInterface.encodeFunctionData('getBptIndex'),
+    });
+    // returns lowerTarget, upperTarget
+    poolCallData.push({
+      target: pool.address,
+      callData: poolInterface.encodeFunctionData('getTargets'),
+    });
+    return poolCallData;
+  }
+
+  /*
+    Helper function to decodes multicall data for a Linear Pool.
+    data must contain returnData
+    startIndex is where to start in returnData. Allows this decode function to be called along with other pool types.
+    */
+  static decodeOnChainCalls(
+    pool: SubgraphPoolBase,
+    poolInterfaces: { [type: string]: Interface },
+    vaultInterface: Interface,
+    data: any,
+    startIndex: number,
+  ): [{ [address: string]: PoolState }, number] {
+    const pools = {} as { [address: string]: PoolState };
+
+    const poolTokens = vaultInterface.decodeFunctionResult(
+      'getPoolTokens',
+      data.returnData[startIndex++],
+    );
+
+    const swapFee = poolInterfaces['Linear'].decodeFunctionResult(
+      'getSwapFeePercentage',
+      data.returnData[startIndex++],
+    )[0];
+
+    const scalingFactors = poolInterfaces['Linear'].decodeFunctionResult(
+      'getScalingFactors',
+      data.returnData[startIndex++],
+    )[0];
+
+    const mainIndex = poolInterfaces['Linear'].decodeFunctionResult(
+      'getMainIndex',
+      data.returnData[startIndex++],
+    );
+
+    const wrappedIndex = poolInterfaces['Linear'].decodeFunctionResult(
+      'getWrappedIndex',
+      data.returnData[startIndex++],
+    );
+
+    const bptIndex = poolInterfaces['Linear'].decodeFunctionResult(
+      'getBptIndex',
+      data.returnData[startIndex++],
+    );
+
+    const [lowerTarget, upperTarget] = poolInterfaces[
+      'Linear'
+    ].decodeFunctionResult('getTargets', data.returnData[startIndex++]);
+
+    const poolState: PoolState = {
+      swapFee: BigInt(swapFee.toString()),
+      mainIndex: Number(mainIndex),
+      wrappedIndex: Number(wrappedIndex),
+      bptIndex: Number(bptIndex),
+      lowerTarget: BigInt(lowerTarget.toString()),
+      upperTarget: BigInt(upperTarget.toString()),
+      tokens: poolTokens.tokens.reduce(
+        (ptAcc: { [address: string]: TokenState }, pt: string, j: number) => {
+          const tokenState: TokenState = {
+            balance: BigInt(poolTokens.balances[j].toString()),
+          };
+
+          if (scalingFactors)
+            tokenState.scalingFactor = BigInt(scalingFactors[j].toString());
+
+          ptAcc[pt.toLowerCase()] = tokenState;
+          return ptAcc;
+        },
+        {},
+      ),
+    };
+
+    pools[pool.address] = poolState;
+
+    return [pools, startIndex];
+  }
+}

--- a/src/dex/balancer-v2/LinearPool.ts
+++ b/src/dex/balancer-v2/LinearPool.ts
@@ -358,4 +358,22 @@ export class LinearPool extends BasePool {
 
     return [pools, startIndex];
   }
+
+  /*
+  TO DO - Waiting for confirmation of a good/quick estimate to use here.
+  */
+  checkBalance(
+    balanceOut: bigint,
+    scalingFactor: bigint,
+    amounts: bigint[],
+    unitVolume: bigint,
+  ): boolean {
+    const swapMax =
+      (this._upscale(balanceOut, scalingFactor) * BigInt(99)) / BigInt(100);
+    const swapAmount =
+      amounts[amounts.length - 1] > unitVolume
+        ? amounts[amounts.length - 1]
+        : unitVolume;
+    return swapMax > swapAmount;
+  }
 }

--- a/src/dex/balancer-v2/PhantomStablePool.ts
+++ b/src/dex/balancer-v2/PhantomStablePool.ts
@@ -259,9 +259,10 @@ export class PhantomStablePool extends BasePool {
     const balances = pool.tokens.map(
       t => poolState.tokens[t.address.toLowerCase()].balance,
     );
-    const scalingFactors = pool.tokens.map(t =>
-      getTokenScalingFactor(t.decimals),
+    const scalingFactors = pool.tokens.map(
+      t => poolState.tokens[t.address.toLowerCase()].scalingFactor || BigInt(0),
     );
+
     const poolPairData: PhantomStablePoolPairData = {
       tokens: tokenAddresses,
       balances,

--- a/src/dex/balancer-v2/PhantomStablePool.ts
+++ b/src/dex/balancer-v2/PhantomStablePool.ts
@@ -1,0 +1,277 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { BasePool } from './balancer-v2-pool';
+import { isSameAddress } from './utils';
+import * as StableMath from './StableMath';
+import { BZERO } from './balancer-v2-math';
+import { SubgraphPoolBase, PoolState } from './types';
+import { getTokenScalingFactor } from './utils';
+
+enum PairTypes {
+  BptToToken,
+  TokenToBpt,
+  TokenToToken,
+}
+
+type PhantomStablePoolPairData = {
+  tokens: string[];
+  balances: BigInt[];
+  indexIn: number;
+  indexOut: number;
+  scalingFactors: BigInt[];
+  bptIndex: number;
+  swapFee: BigInt;
+  amp: BigInt;
+};
+
+/*
+/**
+ * StablePool with preminted BPT and rate providers for each token, allowing for e.g. wrapped tokens with a known
+ * price ratio, such as Compound's cTokens.
+ * BPT is preminted on Pool initialization and registered as one of the Pool's tokens, allowing for swaps to behave as
+ * single-token joins or exits (by swapping a token for BPT). Regular joins and exits are disabled, since no BPT is
+ * minted or burned after initialization.
+ * Preminted BPT is sometimes called Phantom BPT, as the preminted BPT (which is deposited in the Vault as balance of
+ * the Pool) doesn't belong to any entity until transferred out of the Pool. The Pool's arithmetic behaves as if it
+ * didn't exist, and the BPT total supply is not a useful value: we rely on the 'virtual supply' (how much BPT is
+ * actually owned by some entity) instead.
+ */
+export class PhantomStablePool extends BasePool {
+  // This is the maximum token amount the Vault can hold. In regular operation, the total BPT supply remains constant
+  // and equal to _INITIAL_BPT_SUPPLY, but most of it remains in the Pool, waiting to be exchanged for tokens. The
+  // actual amount of BPT in circulation is the total supply minus the amount held by the Pool, and is known as the
+  // 'virtual supply'.
+  static MAX_TOKEN_BALANCE = BigNumber.from('2').pow('112').sub('1');
+
+  /*
+    scaling factors should include rate:
+    i.e.
+    scalingFactors: pool.tokens.map(({ decimals, priceRate }) =>
+        MathSol.mulDownFixed(getTokenScalingFactor(decimals), priceRate)
+    )
+    */
+  onSell(
+    amounts: bigint[],
+    tokens: string[],
+    balances: bigint[],
+    indexIn: number,
+    indexOut: number,
+    bptIndex: number,
+    scalingFactors: bigint[],
+    swapFeePercentage: bigint,
+    amplificationParameter: bigint,
+  ): bigint[] {
+    return this._swapGivenIn(
+      amounts,
+      tokens,
+      balances,
+      indexIn,
+      indexOut,
+      bptIndex,
+      scalingFactors,
+      swapFeePercentage,
+      amplificationParameter,
+    );
+  }
+
+  // StablePool's `_onSwapGivenIn` and `_onSwapGivenOut` handlers are meant to process swaps between Pool tokens.
+  // Since one of the Pool's tokens is the preminted BPT, we neeed to a) handle swaps where that tokens is involved
+  // separately (as they are effectively single-token joins or exits), and b) remove BPT from the balances array when
+  // processing regular swaps before delegating those to StablePool's handler.
+  removeBPT(
+    balances: bigint[],
+    tokenIndexIn: number,
+    tokenIndexOut: number,
+    bptIndex: number,
+  ): {
+    balances: bigint[];
+    indexIn: number;
+    indexOut: number;
+  } {
+    if (bptIndex != -1) {
+      balances.splice(bptIndex, 1);
+      if (bptIndex < tokenIndexIn) tokenIndexIn -= 1;
+      if (bptIndex < tokenIndexOut) tokenIndexOut -= 1;
+    }
+    return {
+      balances,
+      indexIn: tokenIndexIn,
+      indexOut: tokenIndexOut,
+    };
+  }
+
+  _swapGivenIn(
+    tokenAmountsIn: bigint[],
+    tokens: string[],
+    balances: bigint[],
+    indexIn: number,
+    indexOut: number,
+    bptIndex: number,
+    scalingFactors: bigint[],
+    swapFeePercentage: bigint,
+    amplificationParameter: bigint,
+  ): bigint[] {
+    // Phantom pools allow trading between token and pool BPT
+    let pairType: PairTypes;
+    if (isSameAddress(tokens[indexIn], tokens[bptIndex])) {
+      pairType = PairTypes.BptToToken;
+    } else if (isSameAddress(tokens[indexOut], tokens[bptIndex])) {
+      pairType = PairTypes.TokenToBpt;
+    } else {
+      pairType = PairTypes.TokenToToken;
+    }
+
+    // Fees are subtracted before scaling, to reduce the complexity of the rounding direction analysis.
+    const tokenAmountsInWithFee = tokenAmountsIn.map(a =>
+      this._subtractSwapFeeAmount(a, swapFeePercentage),
+    );
+    const balancesUpscaled = this._upscaleArray(balances, scalingFactors);
+    const tokenAmountsInScaled = tokenAmountsInWithFee.map(a =>
+      this._upscale(a, scalingFactors[indexIn]),
+    );
+
+    // VirtualBPTSupply must be used for the maths
+    const virtualBptSupply = PhantomStablePool.MAX_TOKEN_BALANCE.sub(
+      balances[bptIndex],
+    ).toBigInt();
+
+    const droppedBpt = this.removeBPT(
+      balancesUpscaled,
+      indexIn,
+      indexOut,
+      bptIndex,
+    );
+
+    const amountsOut = this._onSwapGivenIn(
+      tokenAmountsInScaled,
+      droppedBpt.balances,
+      droppedBpt.indexIn,
+      droppedBpt.indexOut,
+      amplificationParameter,
+      virtualBptSupply,
+      pairType,
+    );
+
+    // amountOut tokens are exiting the Pool, so we round down.
+    return amountsOut.map(a =>
+      this._downscaleDown(a, scalingFactors[indexOut]),
+    );
+  }
+
+  /*
+     Called when a swap with the Pool occurs, where the amount of tokens entering the Pool is known.
+     All amounts are upscaled.
+     Swap fee is already deducted.
+     The return value is also considered upscaled, and should be downscaled (rounding down)
+     */
+  _onSwapGivenIn(
+    tokenAmountsIn: bigint[],
+    balances: bigint[],
+    indexIn: number,
+    indexOut: number,
+    _amplificationParameter: bigint,
+    virtualBptSupply: bigint,
+    pairType: PairTypes,
+  ): bigint[] {
+    const invariant = StableMath._calculateInvariant(
+      _amplificationParameter,
+      balances,
+      true,
+    );
+
+    const amountsOut: bigint[] = [];
+
+    if (pairType === PairTypes.TokenToBpt) {
+      tokenAmountsIn.forEach(amountIn => {
+        let amt: bigint;
+        try {
+          const amountsInBigInt = Array(balances.length).fill(BZERO);
+          amountsInBigInt[indexIn] = amountIn;
+
+          amt = StableMath._calcBptOutGivenExactTokensIn(
+            _amplificationParameter,
+            balances,
+            amountsInBigInt,
+            virtualBptSupply,
+            invariant,
+          );
+        } catch (err) {
+          amt = BZERO;
+        }
+        amountsOut.push(amt);
+      });
+    } else if (pairType === PairTypes.BptToToken) {
+      tokenAmountsIn.forEach(amountIn => {
+        let amt: bigint;
+        try {
+          amt = StableMath._calcTokenOutGivenExactBptIn(
+            _amplificationParameter,
+            balances,
+            indexOut,
+            amountIn,
+            virtualBptSupply,
+            invariant,
+          );
+        } catch (err) {
+          amt = BZERO;
+        }
+        amountsOut.push(amt);
+      });
+    } else {
+      tokenAmountsIn.forEach(amountIn => {
+        let amt: bigint;
+        try {
+          amt = StableMath._calcOutGivenIn(
+            _amplificationParameter,
+            balances,
+            indexIn,
+            indexOut,
+            amountIn,
+            invariant,
+          );
+        } catch (err) {
+          amt = BZERO;
+        }
+        amountsOut.push(amt);
+      });
+    }
+    return amountsOut;
+  }
+
+  /*
+    Helper function to parse pool data into params for onSell function.
+    */
+  parsePoolPairDataBigInt(
+    pool: SubgraphPoolBase,
+    poolState: PoolState,
+    tokenIn: string,
+    tokenOut: string,
+  ): PhantomStablePoolPairData {
+    const indexIn = pool.tokens.findIndex(
+      t => t.address.toLowerCase() === tokenIn.toLowerCase(),
+    );
+    const indexOut = pool.tokens.findIndex(
+      t => t.address.toLowerCase() === tokenOut.toLowerCase(),
+    );
+    const bptIndex = pool.tokens.findIndex(
+      t => t.address.toLowerCase() === pool.address.toLowerCase(),
+    );
+    const tokenAddresses = pool.tokens.map(t => t.address);
+    const balances = pool.tokens.map(
+      t => poolState.tokens[t.address.toLowerCase()].balance,
+    );
+    const scalingFactors = pool.tokens.map(t =>
+      getTokenScalingFactor(t.decimals),
+    );
+    const poolPairData: PhantomStablePoolPairData = {
+      tokens: tokenAddresses,
+      balances,
+      indexIn: indexIn,
+      indexOut: indexOut,
+      scalingFactors,
+      bptIndex,
+      swapFee: poolState.swapFee,
+      amp: poolState.amp ? poolState.amp : BigInt(0),
+    };
+    return poolPairData;
+  }
+}

--- a/src/dex/balancer-v2/PhantomStablePool.ts
+++ b/src/dex/balancer-v2/PhantomStablePool.ts
@@ -275,4 +275,22 @@ export class PhantomStablePool extends BasePool {
     };
     return poolPairData;
   }
+
+  /*
+  For stable pools there is no Swap limit. As an approx - use almost the total balance of token out as we can add any amount of tokenIn and expect some back.
+  */
+  checkBalance(
+    balanceOut: bigint,
+    scalingFactor: bigint,
+    amounts: bigint[],
+    unitVolume: bigint,
+  ): boolean {
+    const swapMax =
+      (this._upscale(balanceOut, scalingFactor) * BigInt(99)) / BigInt(100);
+    const swapAmount =
+      amounts[amounts.length - 1] > unitVolume
+        ? amounts[amounts.length - 1]
+        : unitVolume;
+    return swapMax > swapAmount;
+  }
 }

--- a/src/dex/balancer-v2/StableMath.ts
+++ b/src/dex/balancer-v2/StableMath.ts
@@ -1,0 +1,413 @@
+import { MathSol, BZERO } from './balancer-v2-math';
+
+const AMP_PRECISION = BigInt(1e3);
+
+export function _calculateInvariant(
+  amp: bigint,
+  balances: bigint[],
+  roundUp: boolean,
+): bigint {
+  /**********************************************************************************************
+      // invariant                                                                                 //
+      // D = invariant                                                  D^(n+1)                    //
+      // A = amplification coefficient      A  n^n S + D = A D n^n + -----------                   //
+      // S = sum of balances                                             n^n P                     //
+      // P = product of balances                                                                   //
+      // n = number of tokens                                                                      //
+      *********x************************************************************************************/
+
+  // We support rounding up or down.
+
+  let sum = BZERO;
+  const numTokens = balances.length;
+  for (let i = 0; i < numTokens; i++) {
+    sum = sum + balances[i];
+  }
+  if (sum == BZERO) {
+    return BZERO;
+  }
+
+  let prevInvariant = BZERO;
+  let invariant = sum;
+  const ampTimesTotal = amp * BigInt(numTokens);
+
+  for (let i = 0; i < 255; i++) {
+    let P_D = balances[0] * BigInt(numTokens);
+    for (let j = 1; j < numTokens; j++) {
+      P_D = MathSol.div(
+        MathSol.mul(MathSol.mul(P_D, balances[j]), BigInt(numTokens)),
+        invariant,
+        roundUp,
+      );
+    }
+    prevInvariant = invariant;
+    invariant = MathSol.div(
+      MathSol.mul(MathSol.mul(BigInt(numTokens), invariant), invariant) +
+        MathSol.div(
+          MathSol.mul(MathSol.mul(ampTimesTotal, sum), P_D),
+          AMP_PRECISION,
+          roundUp,
+        ),
+      MathSol.mul(BigInt(numTokens + 1), invariant) +
+        // No need to use checked arithmetic for the amp precision, the amp is guaranteed to be at least 1
+        MathSol.div(
+          MathSol.mul(ampTimesTotal - AMP_PRECISION, P_D),
+          AMP_PRECISION,
+          !roundUp,
+        ),
+      roundUp,
+    );
+
+    if (invariant > prevInvariant) {
+      if (invariant - prevInvariant <= 1) {
+        return invariant;
+      }
+    } else if (prevInvariant - invariant <= 1) {
+      return invariant;
+    }
+  }
+
+  throw new Error('Errors.STABLE_INVARIANT_DIDNT_CONVERGE');
+}
+
+// PairType = 'token->token'
+// SwapType = 'swapExactIn'
+export function _calcOutGivenIn(
+  amp: bigint,
+  balances: bigint[],
+  tokenIndexIn: number,
+  tokenIndexOut: number,
+  amountIn: bigint,
+  invariant?: bigint,
+): bigint {
+  balances = [...balances];
+  // Given that we need to have a greater final balance out, the invariant needs to be rounded up
+  if (!invariant) invariant = _calculateInvariant(amp, balances, true);
+
+  const initBalance = balances[tokenIndexIn];
+  balances[tokenIndexIn] = initBalance + amountIn;
+  const finalBalanceOut = _getTokenBalanceGivenInvariantAndAllOtherBalances(
+    amp,
+    balances,
+    invariant,
+    tokenIndexOut,
+  );
+  return balances[tokenIndexOut] - finalBalanceOut - BigInt(1);
+}
+
+export function _calcInGivenOut(
+  amp: bigint,
+  balances: bigint[],
+  tokenIndexIn: number,
+  tokenIndexOut: number,
+  amountOut: bigint,
+  fee: bigint,
+  invariant?: bigint,
+): bigint {
+  balances = [...balances];
+  if (!invariant) invariant = _calculateInvariant(amp, balances, true);
+  balances[tokenIndexOut] = MathSol.sub(balances[tokenIndexOut], amountOut);
+
+  const finalBalanceIn = _getTokenBalanceGivenInvariantAndAllOtherBalances(
+    amp,
+    balances,
+    invariant,
+    tokenIndexIn,
+  );
+
+  let amountIn = MathSol.add(
+    MathSol.sub(finalBalanceIn, balances[tokenIndexIn]),
+    BigInt(1),
+  );
+  amountIn = addFee(amountIn, fee);
+  return amountIn;
+}
+
+export function _calcBptOutGivenExactTokensIn(
+  amp: bigint,
+  balances: bigint[],
+  amountsIn: bigint[],
+  bptTotalSupply: bigint,
+  invariant?: bigint,
+): bigint {
+  if (!invariant) invariant = _calculateInvariant(amp, balances, true);
+  // BPT out, so we round down overall.
+
+  // First loop calculates the sum of all token balances, which will be used to calculate
+  // the current weights of each token, relative to this sum
+  let sumBalances = BigInt(0);
+  for (let i = 0; i < balances.length; i++) {
+    sumBalances = sumBalances + balances[i];
+  }
+
+  // Calculate the weighted balance ratio without considering fees
+  const balanceRatiosWithFee: bigint[] = new Array(amountsIn.length);
+  // The weighted sum of token balance ratios with fee
+  let invariantRatioWithFees = BigInt(0);
+  for (let i = 0; i < balances.length; i++) {
+    const currentWeight = MathSol.divDownFixed(balances[i], sumBalances);
+    balanceRatiosWithFee[i] = MathSol.divDownFixed(
+      balances[i] + amountsIn[i],
+      balances[i],
+    );
+    invariantRatioWithFees =
+      invariantRatioWithFees +
+      MathSol.mulDownFixed(balanceRatiosWithFee[i], currentWeight);
+  }
+
+  // Second loop calculates new amounts in, taking into account the fee on the percentage excess
+  const newBalances: bigint[] = new Array(balances.length);
+  for (let i = 0; i < balances.length; i++) {
+    let amountInWithoutFee: bigint;
+
+    // Check if the balance ratio is greater than the ideal ratio to charge fees or not
+    if (balanceRatiosWithFee[i] > invariantRatioWithFees) {
+      const nonTaxableAmount = MathSol.mulDownFixed(
+        balances[i],
+        invariantRatioWithFees - MathSol.ONE,
+      );
+      const taxableAmount = amountsIn[i] - nonTaxableAmount;
+      // No need to use checked arithmetic for the swap fee, it is guaranteed to be lower than 50%
+      // amountInWithoutFee =
+      //     nonTaxableAmount +
+      //     MathSol.mulDownFixed(
+      //         taxableAmount,
+      //         MathSol.ONE - swapFeePercentage
+      //     );
+      amountInWithoutFee = nonTaxableAmount + taxableAmount;
+    } else {
+      amountInWithoutFee = amountsIn[i];
+    }
+    newBalances[i] = balances[i] + amountInWithoutFee;
+  }
+
+  // Get current and new invariants, taking swap fees into account
+  const currentInvariant = _calculateInvariant(amp, balances, true);
+  const newInvariant = _calculateInvariant(amp, newBalances, false);
+  const invariantRatio = MathSol.divDownFixed(newInvariant, currentInvariant);
+
+  // If the invariant didn't increase for any reason, we simply don't mint BPT
+  if (invariantRatio > MathSol.ONE) {
+    return MathSol.mulDownFixed(bptTotalSupply, invariantRatio - MathSol.ONE);
+  } else {
+    return BigInt(0);
+  }
+}
+
+/*
+Flow of calculations:
+amountsTokenOut -> amountsOutProportional ->
+amountOutPercentageExcess -> amountOutBeforeFee -> newInvariant -> amountBPTIn
+*/
+export function _calcBptInGivenExactTokensOut(
+  amp: bigint,
+  balances: bigint[],
+  amountsOut: bigint[],
+  bptTotalSupply: bigint,
+  swapFeePercentage: bigint,
+  invariant?: bigint,
+): bigint {
+  if (!invariant) invariant = _calculateInvariant(amp, balances, true);
+  // BPT in, so we round up overall.
+
+  // First loop calculates the sum of all token balances, which will be used to calculate
+  // the current weights of each token relative to this sum
+  let sumBalances = BigInt(0);
+  for (let i = 0; i < balances.length; i++) {
+    sumBalances = sumBalances + balances[i];
+  }
+
+  // Calculate the weighted balance ratio without considering fees
+  const balanceRatiosWithoutFee: bigint[] = new Array(amountsOut.length);
+  let invariantRatioWithoutFees = BigInt(0);
+  for (let i = 0; i < balances.length; i++) {
+    const currentWeight = MathSol.divUpFixed(balances[i], sumBalances);
+    balanceRatiosWithoutFee[i] = MathSol.divUpFixed(
+      balances[i] - amountsOut[i],
+      balances[i],
+    );
+    invariantRatioWithoutFees =
+      invariantRatioWithoutFees +
+      MathSol.mulUpFixed(balanceRatiosWithoutFee[i], currentWeight);
+  }
+
+  // Second loop calculates new amounts in, taking into account the fee on the percentage excess
+  const newBalances: bigint[] = new Array(balances.length);
+  for (let i = 0; i < balances.length; i++) {
+    // Swap fees are typically charged on 'token in', but there is no 'token in' here, so we apply it to
+    // 'token out'. This results in slightly larger price impact.
+
+    let amountOutWithFee: bigint;
+    if (invariantRatioWithoutFees > balanceRatiosWithoutFee[i]) {
+      const nonTaxableAmount = MathSol.mulDownFixed(
+        balances[i],
+        MathSol.complementFixed(invariantRatioWithoutFees),
+      );
+      const taxableAmount = amountsOut[i] - nonTaxableAmount;
+      // No need to use checked arithmetic for the swap fee, it is guaranteed to be lower than 50%
+      amountOutWithFee =
+        nonTaxableAmount +
+        MathSol.divUpFixed(taxableAmount, MathSol.ONE - swapFeePercentage);
+    } else {
+      amountOutWithFee = amountsOut[i];
+    }
+    newBalances[i] = balances[i] - amountOutWithFee;
+  }
+
+  // Get current and new invariants, taking into account swap fees
+  const currentInvariant = _calculateInvariant(amp, balances, true);
+  const newInvariant = _calculateInvariant(amp, newBalances, false);
+  const invariantRatio = MathSol.divDownFixed(newInvariant, currentInvariant);
+
+  // return amountBPTIn
+  return MathSol.mulUpFixed(
+    bptTotalSupply,
+    MathSol.complementFixed(invariantRatio),
+  );
+}
+
+export function _calcTokenOutGivenExactBptIn(
+  amp: bigint,
+  balances: bigint[],
+  tokenIndex: number,
+  bptAmountIn: bigint,
+  bptTotalSupply: bigint,
+  invariant?: bigint,
+): bigint {
+  if (!invariant) invariant = _calculateInvariant(amp, balances, true);
+  // Token out, so we round down overall.
+
+  // Get the current and new invariants. Since we need a bigger new invariant, we round the current one up.
+  const currentInvariant = _calculateInvariant(amp, balances, true);
+  const newInvariant = MathSol.mulUpFixed(
+    MathSol.divUpFixed(bptTotalSupply - bptAmountIn, bptTotalSupply),
+    currentInvariant,
+  );
+
+  // Calculate amount out without fee
+  const newBalanceTokenIndex =
+    _getTokenBalanceGivenInvariantAndAllOtherBalances(
+      amp,
+      balances,
+      newInvariant,
+      tokenIndex,
+    );
+  const amountOutWithoutFee = balances[tokenIndex] - newBalanceTokenIndex;
+
+  // First calculate the sum of all token balances, which will be used to calculate
+  // the current weight of each token
+  let sumBalances = BigInt(0);
+  for (let i = 0; i < balances.length; i++) {
+    sumBalances = sumBalances + balances[i];
+  }
+
+  // We can now compute how much excess balance is being withdrawn as a result of the virtual swaps, which result
+  // in swap fees.
+  const currentWeight = MathSol.divDownFixed(balances[tokenIndex], sumBalances);
+  const taxablePercentage = MathSol.complementFixed(currentWeight);
+
+  // Swap fees are typically charged on 'token in', but there is no 'token in' here, so we apply it
+  // to 'token out'. This results in slightly larger price impact. Fees are rounded up.
+  const taxableAmount = MathSol.mulUpFixed(
+    amountOutWithoutFee,
+    taxablePercentage,
+  );
+  const nonTaxableAmount = amountOutWithoutFee - taxableAmount;
+
+  // No need to use checked arithmetic for the swap fee, it is guaranteed to be lower than 50%
+  return nonTaxableAmount + taxableAmount;
+}
+
+export function _calcTokensOutGivenExactBptIn(
+  balances: bigint[],
+  bptAmountIn: bigint,
+  bptTotalSupply: bigint,
+): bigint[] {
+  /**********************************************************************************************
+    // exactBPTInForTokensOut                                                                    //
+    // (per token)                                                                               //
+    // aO = tokenAmountOut             /        bptIn         \                                  //
+    // b = tokenBalance      a0 = b * | ---------------------  |                                 //
+    // bptIn = bptAmountIn             \     bptTotalSupply    /                                 //
+    // bpt = bptTotalSupply                                                                      //
+    **********************************************************************************************/
+
+  // Since we're computing an amount out, we round down overall. This means rounding down on both the
+  // multiplication and division.
+
+  const bptRatio = MathSol.divDownFixed(bptAmountIn, bptTotalSupply);
+
+  const amountsOut: bigint[] = new Array(balances.length);
+  for (let i = 0; i < balances.length; i++) {
+    amountsOut[i] = MathSol.mulDownFixed(balances[i], bptRatio);
+  }
+
+  return amountsOut;
+}
+
+function _getTokenBalanceGivenInvariantAndAllOtherBalances(
+  amp: bigint,
+  balances: bigint[],
+  invariant: bigint,
+  tokenIndex: number,
+): bigint {
+  // Rounds result up overall
+
+  const ampTimesTotal = amp * BigInt(balances.length);
+  let sum = balances[0];
+  let P_D = balances[0] * BigInt(balances.length);
+  for (let j = 1; j < balances.length; j++) {
+    P_D = MathSol.divDown(
+      MathSol.mul(MathSol.mul(P_D, balances[j]), BigInt(balances.length)),
+      invariant,
+    );
+    sum = sum + balances[j];
+  }
+  // No need to use safe math, based on the loop above `sum` is greater than or equal to `balances[tokenIndex]`
+  sum = sum - balances[tokenIndex];
+
+  const inv2 = MathSol.mul(invariant, invariant);
+  // We remove the balance fromm c by multiplying it
+  const c = MathSol.mul(
+    MathSol.mul(
+      MathSol.divUp(inv2, MathSol.mul(ampTimesTotal, P_D)),
+      AMP_PRECISION,
+    ),
+    balances[tokenIndex],
+  );
+  const b =
+    sum + MathSol.mul(MathSol.divDown(invariant, ampTimesTotal), AMP_PRECISION);
+
+  // We iterate to find the balance
+  let prevTokenBalance = BZERO;
+  // We multiply the first iteration outside the loop with the invariant to set the value of the
+  // initial approximation.
+  let tokenBalance = MathSol.divUp(inv2 + c, invariant + b);
+
+  for (let i = 0; i < 255; i++) {
+    prevTokenBalance = tokenBalance;
+
+    tokenBalance = MathSol.divUp(
+      MathSol.mul(tokenBalance, tokenBalance) + c,
+      MathSol.mul(tokenBalance, BigInt(2)) + b - invariant,
+    );
+
+    if (tokenBalance > prevTokenBalance) {
+      if (tokenBalance - prevTokenBalance <= 1) {
+        return tokenBalance;
+      }
+    } else if (prevTokenBalance - tokenBalance <= 1) {
+      return tokenBalance;
+    }
+  }
+  throw new Error('Errors.STABLE_GET_BALANCE_DIDNT_CONVERGE');
+}
+
+export function subtractFee(amount: bigint, fee: bigint): bigint {
+  const feeAmount = MathSol.mulUpFixed(amount, fee);
+  return amount - feeAmount;
+}
+
+export function addFee(amount: bigint, fee: bigint): bigint {
+  return MathSol.divUpFixed(amount, MathSol.complementFixed(fee));
+}

--- a/src/dex/balancer-v2/balancer-v2-pool.ts
+++ b/src/dex/balancer-v2/balancer-v2-pool.ts
@@ -4,7 +4,7 @@ const _require = (b: boolean, message: string) => {
   if (!b) throw new Error(message);
 };
 
-class BasePool {
+export class BasePool {
   _subtractSwapFeeAmount(amount: bigint, _swapFeePercentage: bigint): bigint {
     // This returns amount - fee amount, so we round up (favoring a higher fee amount).
     const feeAmount = MathSol.mulUpFixed(amount, _swapFeePercentage);

--- a/src/dex/balancer-v2/balancer-v2-pool.ts
+++ b/src/dex/balancer-v2/balancer-v2-pool.ts
@@ -11,16 +11,17 @@ class BasePool {
     return amount - feeAmount;
   }
 
+  // These methods use fixed versions to match SC scaling
   _upscaleArray(amounts: bigint[], scalingFactors: bigint[]): bigint[] {
-    return amounts.map((a, i) => MathSol.mul(a, scalingFactors[i]));
+    return amounts.map((a, i) => MathSol.mulUpFixed(a, scalingFactors[i]));
   }
 
   _upscale(amount: bigint, scalingFactor: bigint): bigint {
-    return MathSol.mul(amount, scalingFactor);
+    return MathSol.mulUpFixed(amount, scalingFactor);
   }
 
   _downscaleDown(amount: bigint, scalingFactor: bigint): bigint {
-    return MathSol.divDown(amount, scalingFactor);
+    return MathSol.divDownFixed(amount, scalingFactor);
   }
 }
 

--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -48,6 +48,8 @@ const fetchAllPools = `query ($count: Int) {
       address
       decimals
     }
+    mainIndex
+    wrappedIndex
   }
 }`;
 

--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -42,6 +42,7 @@ import {
   SwapTypes,
   DexParams,
 } from './types';
+import { getTokenScalingFactor } from './utils';
 import { SimpleExchange } from '../simple-exchange';
 import { BalancerConfig } from './config';
 
@@ -285,7 +286,7 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
             ? pool.tokens.map(
                 t => poolState.tokens[t.address.toLowerCase()].scalingFactor,
               )
-            : pool.tokens.map(t => BigInt(10 ** (18 - t.decimals)));
+            : pool.tokens.map(t => getTokenScalingFactor(t.decimals));
 
         const _prices = this.poolMaths['Stable'].onSell(
           _amounts,
@@ -320,8 +321,8 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
         const tokenInWeight = poolState.tokens[inAddress].weight;
         const tokenOutWeight = poolState.tokens[outAddress].weight;
 
-        const tokenInScalingFactor = BigInt(10 ** (18 - tokenIn.decimals));
-        const tokenOutScalingFactor = BigInt(10 ** (18 - tokenOut.decimals));
+        const tokenInScalingFactor = getTokenScalingFactor(tokenIn.decimals);
+        const tokenOutScalingFactor = getTokenScalingFactor(tokenOut.decimals);
 
         const _prices = this.poolMaths['Weighted'].onSell(
           _amounts,

--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -346,9 +346,12 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
       }
 
       case 'StablePhantom': {
-        const poolPairData = this.poolMaths[
-          'StablePhantom'
-        ].parsePoolPairDataBigInt(pool, poolState, from.address, to.address);
+        const poolPairData = this.poolMaths['StablePhantom'].parsePoolPairData(
+          pool,
+          poolState,
+          from.address,
+          to.address,
+        );
         const _prices = this.poolMaths['StablePhantom'].onSell(
           _amounts,
           poolPairData.tokens,
@@ -364,9 +367,12 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
       }
 
       case 'AaveLinear': {
-        const poolPairData = this.poolMaths[
-          'AaveLinear'
-        ].parsePoolPairDataBigInt(pool, poolState, from.address, to.address);
+        const poolPairData = this.poolMaths['AaveLinear'].parsePoolPairData(
+          pool,
+          poolState,
+          from.address,
+          to.address,
+        );
         const _prices = this.poolMaths['AaveLinear'].onSell(
           _amounts,
           poolPairData.tokens,

--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -22,28 +22,18 @@ import {
 import { StablePool, WeightedPool } from './balancer-v2-pool';
 import { PhantomStablePool } from './PhantomStablePool';
 import { LinearPool } from './LinearPool';
-import StablePoolABI from '../../abi/balancer-v2/stable-pool.json';
-import WeightedPoolABI from '../../abi/balancer-v2/weighted-pool.json';
-import MetaStablePoolABI from '../../abi/balancer-v2/meta-stable-pool.json';
-import LinearPoolABI from '../../abi/balancer-v2/linearPoolAbi.json';
 import VaultABI from '../../abi/balancer-v2/vault.json';
 import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
 import { wrapETH, getDexKeysWithNetwork } from '../../utils';
 import { IDex } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import {
-  TokenState,
   PoolState,
-  SubgraphToken,
   SubgraphPoolBase,
-  BalancerSwapsV2,
   BalancerV2Data,
-  BalancerFunds,
-  BalancerSwap,
   BalancerParam,
   OptimizedBalancerV2Data,
   SwapTypes,
-  DexParams,
 } from './types';
 import { getTokenScalingFactor } from './utils';
 import { SimpleExchange } from '../simple-exchange';
@@ -101,7 +91,6 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
   } = {};
 
   poolMaths: { [type: string]: any };
-  poolInterfaces: { [type: string]: Interface };
 
   public allPools: SubgraphPoolBase[] = [];
   vaultDecoder: (log: Log) => any;
@@ -113,8 +102,6 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
     'Weighted',
     'LiquidityBootstrapping',
     'Investment',
-    'StablePhantom',
-    'AaveLinear',
   ];
 
   constructor(
@@ -131,12 +118,6 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
       Weighted: new WeightedPool(),
       StablePhantom: new PhantomStablePool(),
       AaveLinear: new LinearPool(),
-    };
-    this.poolInterfaces = {
-      Stable: new Interface(StablePoolABI),
-      Weighted: new Interface(WeightedPoolABI),
-      MetaStable: new Interface(MetaStablePoolABI),
-      Linear: new Interface(LinearPoolABI),
     };
     this.vaultInterface = new Interface(VaultABI);
     this.vaultDecoder = (log: Log) => this.vaultInterface.parseLog(log);
@@ -428,59 +409,49 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
   ): Promise<PoolStateMap> {
     const multiCallData = subgraphPoolBase
       .map(pool => {
-        let poolCallData = [
-          {
-            target: this.vaultAddress,
-            callData: this.vaultInterface.encodeFunctionData('getPoolTokens', [
-              pool.id,
-            ]),
-          },
-          {
-            target: pool.address,
-            callData: this.poolInterfaces['Weighted'].encodeFunctionData(
-              'getSwapFeePercentage',
-            ), // different function for element pool
-          },
-        ];
-
-        if (['MetaStable', 'StablePhantom'].includes(pool.poolType)) {
-          poolCallData.push({
-            target: pool.address,
-            callData:
-              this.poolInterfaces['MetaStable'].encodeFunctionData(
-                'getScalingFactors',
-              ),
-          });
-        }
+        let poolCallData = [];
         if (
           ['Weighted', 'LiquidityBootstrapping', 'Investment'].includes(
             pool.poolType,
           )
         ) {
-          poolCallData.push({
-            target: pool.address,
-            callData: this.poolInterfaces['Weighted'].encodeFunctionData(
-              'getNormalizedWeights',
-            ),
-          });
+          // Will create onchain call data for WeightedPool types
+          const weightedCalls = WeightedPool.getOnChainCalls(
+            pool,
+            this.vaultAddress,
+            this.vaultInterface,
+          );
+          poolCallData.push(...weightedCalls);
         }
-        if (['Stable', 'MetaStable', 'StablePhantom'].includes(pool.poolType)) {
-          poolCallData.push({
-            target: pool.address,
-            callData: this.poolInterfaces['Stable'].encodeFunctionData(
-              'getAmplificationParameter',
-            ),
-          });
+
+        if (['Stable'].includes(pool.poolType)) {
+          // Will create onchain call data for StablePool
+          const stableCalls = StablePool.getOnChainCalls(
+            pool,
+            this.vaultAddress,
+            this.vaultInterface,
+          );
+          poolCallData.push(...stableCalls);
         }
 
         if (['AaveLinear'].includes(pool.poolType)) {
           // Will create onchain call data for linearPools
-          // Assumes getPoolTokens + getSwapFeePercentage call data is added separately (see above)
           const linearCalls = LinearPool.getOnChainCalls(
             pool,
-            this.poolInterfaces['Linear'],
+            this.vaultAddress,
+            this.vaultInterface,
           );
           poolCallData.push(...linearCalls);
+        }
+
+        if (['MetaStable', 'StablePhantom'].includes(pool.poolType)) {
+          // Will create onchain call data for Meta/PhantomStablePool
+          const metaStableCalls = PhantomStablePool.getOnChainCalls(
+            pool,
+            this.vaultAddress,
+            this.vaultInterface,
+          );
+          poolCallData.push(...metaStableCalls);
         }
 
         return poolCallData;
@@ -497,11 +468,14 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
     let i = 0;
     const onChainStateMap = subgraphPoolBase.reduce(
       (acc: { [address: string]: PoolState }, pool) => {
-        if (['AaveLinear'].includes(pool.poolType)) {
-          // This will decode multicall data for all pools associated with linear pool
-          const [decoded, newIndex] = LinearPool.decodeOnChainCalls(
+        if (
+          ['Weighted', 'LiquidityBootstrapping', 'Investment'].includes(
+            pool.poolType,
+          )
+        ) {
+          // This will decode multicall data for all pools associated with Weighted pools
+          const [decoded, newIndex] = WeightedPool.decodeOnChainCalls(
             pool,
-            this.poolInterfaces,
             this.vaultInterface,
             data,
             i,
@@ -511,75 +485,45 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
           return acc;
         }
 
-        const poolTokens = this.vaultInterface.decodeFunctionResult(
-          'getPoolTokens',
-          data.returnData[i++],
-        );
-
-        const swapFee = this.poolInterfaces['Weighted'].decodeFunctionResult(
-          'getSwapFeePercentage',
-          data.returnData[i++],
-        )[0];
-
-        const scalingFactors = ['MetaStable', 'StablePhantom'].includes(
-          pool.poolType,
-        )
-          ? this.poolInterfaces['MetaStable'].decodeFunctionResult(
-              'getScalingFactors',
-              data.returnData[i++],
-            )[0]
-          : undefined;
-
-        const normalisedWeights = [
-          'Weighted',
-          'LiquidityBootstrapping',
-          'Investment',
-        ].includes(pool.poolType)
-          ? this.poolInterfaces['Weighted'].decodeFunctionResult(
-              'getNormalizedWeights',
-              data.returnData[i++],
-            )[0]
-          : undefined;
-
-        const amp = ['Stable', 'MetaStable', 'StablePhantom'].includes(
-          pool.poolType,
-        )
-          ? this.poolInterfaces['Stable'].decodeFunctionResult(
-              'getAmplificationParameter',
-              data.returnData[i++],
-            )
-          : undefined;
-
-        let poolState: PoolState = {
-          swapFee: BigInt(swapFee.toString()),
-          tokens: poolTokens.tokens.reduce(
-            (
-              ptAcc: { [address: string]: TokenState },
-              pt: string,
-              j: number,
-            ) => {
-              let tokenState: TokenState = {
-                balance: BigInt(poolTokens.balances[j].toString()),
-              };
-
-              if (scalingFactors)
-                tokenState.scalingFactor = BigInt(scalingFactors[j].toString());
-
-              if (normalisedWeights)
-                tokenState.weight = BigInt(normalisedWeights[j].toString());
-
-              ptAcc[pt.toLowerCase()] = tokenState;
-              return ptAcc;
-            },
-            {},
-          ),
-        };
-
-        if (amp) {
-          poolState.amp = BigInt(amp.value.toString());
+        if (['AaveLinear'].includes(pool.poolType)) {
+          // This will decode multicall data for all pools associated with linear pool
+          const [decoded, newIndex] = LinearPool.decodeOnChainCalls(
+            pool,
+            this.vaultInterface,
+            data,
+            i,
+          );
+          i = newIndex;
+          acc = { ...acc, ...decoded };
+          return acc;
         }
 
-        acc[pool.address.toLowerCase()] = poolState;
+        if (['Stable'].includes(pool.poolType)) {
+          // This will decode multicall data for Stable pools
+          const [decoded, newIndex] = StablePool.decodeOnChainCalls(
+            pool,
+            this.vaultInterface,
+            data,
+            i,
+          );
+          i = newIndex;
+          acc = { ...acc, ...decoded };
+          return acc;
+        }
+
+        if (['MetaStable', 'StablePhantom'].includes(pool.poolType)) {
+          // This will decode multicall data for Meta/PhantomStable pools
+          const [decoded, newIndex] = PhantomStablePool.decodeOnChainCalls(
+            pool,
+            this.vaultInterface,
+            data,
+            i,
+          );
+          i = newIndex;
+          acc = { ...acc, ...decoded };
+          return acc;
+        }
+
         return acc;
       },
       {},

--- a/src/dex/balancer-v2/types.ts
+++ b/src/dex/balancer-v2/types.ts
@@ -30,6 +30,8 @@ export interface SubgraphPoolBase {
   address: string;
   poolType: string;
   tokens: SubgraphToken[];
+  mainIndex: number;
+  wrappedIndex: number;
 }
 
 export type BalancerSwapsV2 = {

--- a/src/dex/balancer-v2/types.ts
+++ b/src/dex/balancer-v2/types.ts
@@ -12,6 +12,12 @@ export type PoolState = {
   };
   swapFee: bigint;
   amp?: bigint;
+  // Linear Pools
+  mainIndex?: number;
+  wrappedIndex?: number;
+  bptIndex?: number;
+  lowerTarget?: bigint;
+  upperTarget?: bigint;
 };
 
 export type SubgraphToken = {
@@ -73,3 +79,8 @@ export type DexParams = {
   subgraphURL: string;
   vaultAddress: Address;
 };
+
+export interface callData {
+  target: string;
+  callData: string;
+}

--- a/src/dex/balancer-v2/utils.ts
+++ b/src/dex/balancer-v2/utils.ts
@@ -1,3 +1,8 @@
+import { getAddress } from '@ethersproject/address';
+
+export const isSameAddress = (address1: string, address2: string): boolean =>
+  getAddress(address1) === getAddress(address2);
+
 export function getTokenScalingFactor(tokenDecimals: number): bigint {
   return BigInt(1e18) * BigInt(10) ** BigInt(18 - tokenDecimals);
 }

--- a/src/dex/balancer-v2/utils.ts
+++ b/src/dex/balancer-v2/utils.ts
@@ -1,0 +1,3 @@
+export function getTokenScalingFactor(tokenDecimals: number): bigint {
+  return BigInt(1e18) * BigInt(10) ** BigInt(18 - tokenDecimals);
+}


### PR DESCRIPTION
* Added new PhantomStable and Linear pool types with associated maths and onchain data calls.
* Added checkBalance functions for each pool type. E.g. weighted pools have 30% swap limit but stable pools do not have this.
* Added extra tokens to runDexIntegrations.ts for easier testing of different pool types.
* Changed BasePool to use mul/divFixed versions to maintain same scaling as SC - different pool types were using different priceRate scaling i.e. Weighted would use 1 for priceRate but meta would use 1e18. This leads to larger number of decimal places after scaling and result was inaccurate compared to EVM maths.
