### PR TITLE
fix: WETH (un)wrapping for simpleBuy

### DIFF
--- a/src/dex/weth/types.ts
+++ b/src/dex/weth/types.ts
@@ -13,12 +13,17 @@ export enum WethFunctions {
   withdraw = 'withdraw',
 }
 
-export type DepositWithdrawReturn = {
-  opType: WethFunctions;
+export type DepositWithdrawData = {
   callee: string;
   calldata: string;
   value: string;
 };
+
+export type DepositWithdrawReturn = {
+  deposit?: DepositWithdrawData;
+  withdraw?: DepositWithdrawData;
+};
+
 export interface IWethDepositorWithdrawer {
   getDepositWithdrawParam(
     srcToken: Address,
@@ -26,5 +31,5 @@ export interface IWethDepositorWithdrawer {
     srcAmount: NumberAsString,
     destAmount: NumberAsString,
     side: SwapSide,
-  ): DepositWithdrawReturn | undefined;
+  ): DepositWithdrawReturn;
 }

--- a/src/dex/weth/weth.ts
+++ b/src/dex/weth/weth.ts
@@ -21,6 +21,7 @@ import {
   WethFunctions,
   DexParams,
   IWethDepositorWithdrawer,
+  DepositWithdrawData,
   DepositWithdrawReturn,
 } from './types';
 import { SimpleExchange } from '../simple-exchange';
@@ -159,34 +160,41 @@ export class Weth
     srcAmount: string,
     destAmount: string,
     side: SwapSide,
-  ): DepositWithdrawReturn | undefined {
+  ): DepositWithdrawReturn {
     const wethToken = Weth.getAddress(this.network);
+
+    let deposit: DepositWithdrawData | undefined;
+    let withdraw: DepositWithdrawData | undefined;
+
+    let needWithdraw = false;
 
     if (srcAmount !== '0' && isETHAddress(srcToken)) {
       const opType = WethFunctions.deposit;
       const depositWethData = this.erc20Interface.encodeFunctionData(opType);
 
-      return {
-        opType,
+      deposit = {
         callee: wethToken,
         calldata: depositWethData,
         value: srcAmount,
       };
+
+      if (side === SwapSide.BUY) needWithdraw = true;
     }
 
-    if (destAmount !== '0' && isETHAddress(destToken)) {
+    if (needWithdraw || (destAmount !== '0' && isETHAddress(destToken))) {
       const opType = WethFunctions.withdrawAllWETH;
       const withdrawWethData = this.simpleSwapHelper.encodeFunctionData(
         opType,
         [wethToken],
       );
 
-      return {
-        opType,
+      withdraw = {
         callee: this.augustusAddress,
         calldata: withdrawWethData,
         value: '0',
       };
     }
+
+    return { deposit, withdraw };
   }
 }

--- a/src/router/simpleswap.ts
+++ b/src/router/simpleswap.ts
@@ -105,18 +105,6 @@ abstract class SimpleRouter implements IRouter<SimpleSwapParam> {
         let _dest = swap.destToken;
         let wethWithdraw = 0n;
 
-        if (dex.needWrapNative) {
-          if (isETHAddress(swap.srcToken)) {
-            _src = wethAddress;
-            wethDeposit = BigInt(se.srcAmount);
-          }
-
-          if (isETHAddress(swap.destToken)) {
-            _dest = wethAddress;
-            wethWithdraw = BigInt(se.destAmount);
-          }
-        }
-
         // For case of buy apply slippage is applied to srcAmount in equal proportion as the complete swap
         // This assumes that the sum of all swaps srcAmount would sum to priceRoute.srcAmount
         // Also that it is is direct swap.
@@ -132,6 +120,18 @@ abstract class SimpleRouter implements IRouter<SimpleSwapParam> {
         // even if the individual dex is rekt by slippage the swap
         // should work if the final slippage check passes.
         const _destAmount = this.side === SwapSide.SELL ? '1' : se.destAmount;
+
+        if (dex.needWrapNative) {
+          if (isETHAddress(swap.srcToken)) {
+            _src = wethAddress;
+            wethDeposit = BigInt(_srcAmount);
+          }
+
+          if (isETHAddress(swap.destToken)) {
+            _dest = wethAddress;
+            wethWithdraw = BigInt(_destAmount);
+          }
+        }
 
         const simpleParams = await dex.getSimpleParam(
           _src,
@@ -189,14 +189,21 @@ abstract class SimpleRouter implements IRouter<SimpleSwapParam> {
     );
 
     if (maybeWethCallData) {
-      if (maybeWethCallData.opType === WethFunctions.deposit) {
-        simpleExchangeDataFlat.callees.unshift(maybeWethCallData.callee);
-        simpleExchangeDataFlat.values.unshift(maybeWethCallData.value);
-        simpleExchangeDataFlat.calldata.unshift(maybeWethCallData.calldata);
-      } else {
-        simpleExchangeDataFlat.callees.push(maybeWethCallData.callee);
-        simpleExchangeDataFlat.values.push(maybeWethCallData.value);
-        simpleExchangeDataFlat.calldata.push(maybeWethCallData.calldata);
+      if (maybeWethCallData.deposit) {
+        simpleExchangeDataFlat.callees.unshift(
+          maybeWethCallData.deposit.callee,
+        );
+        simpleExchangeDataFlat.values.unshift(maybeWethCallData.deposit.value);
+        simpleExchangeDataFlat.calldata.unshift(
+          maybeWethCallData.deposit.calldata,
+        );
+      }
+      if (maybeWethCallData.withdraw) {
+        simpleExchangeDataFlat.callees.push(maybeWethCallData.withdraw.callee);
+        simpleExchangeDataFlat.values.push(maybeWethCallData.withdraw.value);
+        simpleExchangeDataFlat.calldata.push(
+          maybeWethCallData.withdraw.calldata,
+        );
       }
     }
 
@@ -253,7 +260,7 @@ abstract class SimpleRouter implements IRouter<SimpleSwapParam> {
       swap.destToken,
       srcAmountWeth.toString(),
       destAmountWeth.toString(),
-      SwapSide.SELL,
+      this.side,
     );
   }
 }


### PR DESCRIPTION
Wrong amount was used for wrapping (no slippage amount applied).
Unused WETH wasn't withdrawn after the swap.