### PR TITLE
fix: Platypus liquidity calc and disable new pools

### DIFF
--- a/src/dex/platypus/config.ts
+++ b/src/dex/platypus/config.ts
@@ -18,26 +18,26 @@ export const PlatypusConfig: DexConfigMap<DexParams> = {
           address: '0x30C30d826be87Cd0A4b90855C2F38f7FcfE4eaA7',
           name: 'Alt Pool MIM',
         },
-        {
-          address: '0x4658EA7e9960D6158a261104aAA160cC953bb6ba',
-          name: 'Alt Pool sAVAX',
-        },
-        {
-          address: '0xC828D995C686AaBA78A4aC89dfc8eC0Ff4C5be83',
-          name: 'Alt Pool YUSD',
-        },
-        {
-          address: '0x233Ba46B01d2FbF1A31bDBc500702E286d6de218',
-          name: 'Factory Pool H2O',
-        },
-        {
-          address: '0x27912AE6Ba9a54219d8287C3540A8969FF35500B',
-          name: 'Factory Pool MONEY',
-        },
-        {
-          address: '0x91BB10D68C72d64a7cE10482b453153eEa03322C',
-          name: 'Factory Pool TSD',
-        },
+        //{
+        //  address: '0x4658EA7e9960D6158a261104aAA160cC953bb6ba',
+        //  name: 'Alt Pool sAVAX',
+        //},
+        //{
+        //  address: '0xC828D995C686AaBA78A4aC89dfc8eC0Ff4C5be83',
+        //  name: 'Alt Pool YUSD',
+        //},
+        //{
+        //  address: '0x233Ba46B01d2FbF1A31bDBc500702E286d6de218',
+        //  name: 'Factory Pool H2O',
+        //},
+        //{
+        //  address: '0x27912AE6Ba9a54219d8287C3540A8969FF35500B',
+        //  name: 'Factory Pool MONEY',
+        //},
+        //{
+        //  address: '0x91BB10D68C72d64a7cE10482b453153eEa03322C',
+        //  name: 'Factory Pool TSD',
+        //},
       ],
     },
   },


### PR DESCRIPTION
The new pools are not working, the implementation seems to differ on them e.g. a price oracle is not used for any of the pools, and config multicall reverts on sAVAX for some other reason.

Resolves BACK-617.