### PR TITLE
fix: fix ABI issue for Dystopia

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.0.43",
+  "version": "2.0.45",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.0.45",
+  "version": "2.0.46",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/uniswap-v2/dystopia/dystopia.ts
+++ b/src/dex/uniswap-v2/dystopia/dystopia.ts
@@ -64,7 +64,7 @@ export class Dystopia extends UniswapV2 {
       DystopiaConfig[dexKey][network].initCode,
       DystopiaConfig[dexKey][network].feeCode,
       DystopiaConfig[dexKey][network].poolGasCost,
-      dystPairABI,
+      iface,
       Adapters[network] || undefined,
     );
 

--- a/src/dex/uniswap-v2/dystopia/dystopia.ts
+++ b/src/dex/uniswap-v2/dystopia/dystopia.ts
@@ -12,7 +12,7 @@ import { IDexHelper } from '../../../dex-helper';
 import { UniswapData, UniswapV2Data } from '../types';
 import { getBigIntPow, getDexKeysWithNetwork, wrapETH } from '../../../utils';
 import dystopiaFactoryABI from '../../../abi/uniswap-v2/DystFactory.json';
-import uniswapV2ABI from '../../../abi/uniswap-v2/uniswap-v2-pool.json';
+import dystPairABI from '../../../abi/uniswap-v2/DystPair.json';
 import _ from 'lodash';
 import { NumberAsString, SwapSide } from 'paraswap-core';
 import { DystopiaUniswapV2Pool } from './dystopia-uniswap-v2-pool';
@@ -41,7 +41,7 @@ export interface DystopiaPoolState {
   feeCode: number;
 }
 
-const iface = new Interface(uniswapV2ABI);
+const iface = new Interface(dystPairABI);
 const coder = new AbiCoder();
 
 export class Dystopia extends UniswapV2 {
@@ -64,6 +64,7 @@ export class Dystopia extends UniswapV2 {
       DystopiaConfig[dexKey][network].initCode,
       DystopiaConfig[dexKey][network].feeCode,
       DystopiaConfig[dexKey][network].poolGasCost,
+      dystPairABI,
       Adapters[network] || undefined,
     );
 

--- a/src/dex/uniswap-v2/uniswap-v2.ts
+++ b/src/dex/uniswap-v2/uniswap-v2.ts
@@ -1,4 +1,4 @@
-import { AbiCoder, Interface, JsonFragment } from '@ethersproject/abi';
+import { AbiCoder, Interface } from '@ethersproject/abi';
 import _ from 'lodash';
 import { AsyncOrSync, DeepReadonly } from 'ts-essentials';
 import erc20ABI from '../../abi/erc20.json';

--- a/src/dex/uniswap-v2/uniswap-v2.ts
+++ b/src/dex/uniswap-v2/uniswap-v2.ts
@@ -201,7 +201,6 @@ export class UniswapV2
   logger: Logger;
 
   readonly hasConstantPriceLargeAmounts = false;
-  readonly decoderIface: Interface;
 
   public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
     getDexKeysWithNetwork(UniswapV2Config);
@@ -221,7 +220,7 @@ export class UniswapV2
     protected poolGasCost: number = (UniswapV2Config[dexKey] &&
       UniswapV2Config[dexKey][network].poolGasCost) ??
       DefaultUniswapV2PoolGasCost,
-    decoderABI: JsonFragment[] = uniswapV2ABI,
+    protected decoderIface: Interface = uniswapV2Iface,
     protected adapters = (UniswapV2Config[dexKey] &&
       UniswapV2Config[dexKey][network].adapters) ??
       Adapters[network],
@@ -239,7 +238,6 @@ export class UniswapV2
 
     this.routerInterface = new Interface(ParaSwapABI);
     this.exchangeRouterInterface = new Interface(UniswapV2ExchangeRouterABI);
-    this.decoderIface = new Interface(decoderABI);
   }
 
   // getFeesMultiCallData should be override


### PR DESCRIPTION
I put `decoderABI` argument not as the last element in `UniswapV2`, because didn't want to override many default params. I checked, it shouldn't break anything.