### PR TITLE
feature/back-634: Capitalize ParaSwapLimitOrders name in Dex

### DIFF
--- a/src/dex-helper/dummy-limit-order-provider.ts
+++ b/src/dex-helper/dummy-limit-order-provider.ts
@@ -1,7 +1,7 @@
 import { ILimitOrderProvider } from './ilimit-order-provider';
 import {
-  ParaswapLimitOrderResponse,
-  ParaswapPriceSummaryResponse,
+  ParaSwapLimitOrderResponse,
+  ParaSwapPriceSummaryResponse,
 } from '../dex/paraswap-limit-orders/types';
 import { SwapSide, Network, LIMIT_ORDER_PROVIDERS } from '../constants';
 import { Address, BigIntAsString } from '../types';
@@ -9,18 +9,18 @@ import { Address, BigIntAsString } from '../types';
 export class DummyLimitOrderProvider
   implements
     ILimitOrderProvider<
-      ParaswapLimitOrderResponse,
-      ParaswapPriceSummaryResponse
+      ParaSwapLimitOrderResponse,
+      ParaSwapPriceSummaryResponse
     >
 {
   readonly name: LIMIT_ORDER_PROVIDERS = LIMIT_ORDER_PROVIDERS.PARASWAP;
 
   private readonly _priceSummary: {
-    [key in string]: ParaswapPriceSummaryResponse[];
+    [key in string]: ParaSwapPriceSummaryResponse[];
   } = {};
 
   private readonly _ordersToExecute: {
-    [key in number]: ParaswapLimitOrderResponse[];
+    [key in number]: ParaSwapLimitOrderResponse[];
   } = {};
 
   async fetchAndReserveOrders(
@@ -33,7 +33,7 @@ export class DummyLimitOrderProvider
     userAddress: Address,
     backupOrdersMaxPercent?: number,
     backupOrdersMinCount?: number,
-  ): Promise<ParaswapLimitOrderResponse[] | null> {
+  ): Promise<ParaSwapLimitOrderResponse[] | null> {
     return this._ordersToExecute[network]
       ? this._ordersToExecute[network]
       : null;
@@ -43,7 +43,7 @@ export class DummyLimitOrderProvider
     network: Network,
     src: Address,
     dest: Address,
-  ): Promise<ParaswapPriceSummaryResponse[] | null> {
+  ): Promise<ParaSwapPriceSummaryResponse[] | null> {
     const key = DummyLimitOrderProvider.getPriceSummaryCacheKey(
       network,
       src,
@@ -57,7 +57,7 @@ export class DummyLimitOrderProvider
     network: Network,
     src: Address,
     dest: Address,
-    priceSummary: ParaswapPriceSummaryResponse[],
+    priceSummary: ParaSwapPriceSummaryResponse[],
   ) {
     const key = DummyLimitOrderProvider.getPriceSummaryCacheKey(
       network,
@@ -67,7 +67,7 @@ export class DummyLimitOrderProvider
     this._priceSummary[key] = priceSummary;
   }
 
-  setOrdersToExecute(network: number, orders: ParaswapLimitOrderResponse[]) {
+  setOrdersToExecute(network: number, orders: ParaSwapLimitOrderResponse[]) {
     this._ordersToExecute[network] = orders;
   }
 

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -42,7 +42,7 @@ import { Platypus } from './platypus/platypus';
 import { GMX } from './gmx/gmx';
 import { WooFi } from './woo-fi/woo-fi';
 import { Dystopia } from './uniswap-v2/dystopia/dystopia';
-import { ParaswapLimitOrders } from './paraswap-limit-orders/paraswap-limit-orders';
+import { ParaSwapLimitOrders } from './paraswap-limit-orders/paraswap-limit-orders';
 import { AugustusRFQOrder } from './augustus-rfq';
 
 const LegacyDexes = [
@@ -85,7 +85,7 @@ const Dexes = [
   GMX,
   WooFi,
   Dystopia,
-  ParaswapLimitOrders,
+  ParaSwapLimitOrders,
 ];
 
 const AdapterNameAddressMap: {

--- a/src/dex/paraswap-limit-orders/config.ts
+++ b/src/dex/paraswap-limit-orders/config.ts
@@ -2,8 +2,8 @@ import { DexParams } from './types';
 import { AdapterMappings, DexConfigMap } from '../../types';
 import { Network, SwapSide } from '../../constants';
 
-export const ParaswapLimitOrdersConfig: DexConfigMap<DexParams> = {
-  ParaswapLimitOrders: {
+export const ParaSwapLimitOrdersConfig: DexConfigMap<DexParams> = {
+  ParaSwapLimitOrders: {
     [Network.ROPSTEN]: {
       rfqAddress: '0x34268C38fcbC798814b058656bC0156C7511c0E4',
     },

--- a/src/dex/paraswap-limit-orders/paraswap-limit-orders-e2e.test.ts
+++ b/src/dex/paraswap-limit-orders/paraswap-limit-orders-e2e.test.ts
@@ -11,15 +11,15 @@ import {
 } from '../../constants';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import {
-  ParaswapLimitOrderResponse,
-  ParaswapPriceSummaryResponse,
+  ParaSwapLimitOrderResponse,
+  ParaSwapPriceSummaryResponse,
 } from './types';
 import { DummyLimitOrderProvider } from '../../dex-helper/index';
 
-describe('ParaswapLimitOrders E2E', () => {
-  const dexKey = 'ParaswapLimitOrders';
+describe('ParaSwapLimitOrders E2E', () => {
+  const dexKey = 'ParaSwapLimitOrders';
 
-  describe('ParaswapLimitOrders ROPSTEN', () => {
+  describe('ParaSwapLimitOrders ROPSTEN', () => {
     const network = Network.ROPSTEN;
     const tokens = Tokens[network];
     const provider = new StaticJsonRpcProvider(ProviderURL[network], network);
@@ -48,7 +48,7 @@ describe('ParaswapLimitOrders E2E', () => {
     const maker = '0xc3643bC869DC0dcd2Df8729fC3cb768d4F86F57a';
     const taker = '0xCf8C4a46816b146Ed613d23f6D22e1711915d653';
 
-    const priceSummaryToUse: ParaswapPriceSummaryResponse[] = [
+    const priceSummaryToUse: ParaSwapPriceSummaryResponse[] = [
       {
         cumulativeMakerAmount: '10000000000000000000',
         cumulativeTakerAmount: '20000000000000000',
@@ -63,7 +63,7 @@ describe('ParaswapLimitOrders E2E', () => {
       },
     ];
 
-    const ordersToUse: ParaswapLimitOrderResponse[] = [
+    const ordersToUse: ParaSwapLimitOrderResponse[] = [
       {
         order: {
           nonceAndMeta:

--- a/src/dex/paraswap-limit-orders/paraswap-limit-orders-integration.test.ts
+++ b/src/dex/paraswap-limit-orders/paraswap-limit-orders-integration.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../dex-helper/index';
 import { Network, SwapSide } from '../../constants';
 import { BI_POWS } from '../../bigint-constants';
-import { ParaswapLimitOrders } from './paraswap-limit-orders';
+import { ParaSwapLimitOrders } from './paraswap-limit-orders';
 import {
   checkPoolPrices,
   checkPoolsLiquidity,
@@ -29,7 +29,7 @@ const amounts = [
   33n * BI_POWS[TokenA.decimals],
 ];
 
-const dexKey = 'ParaswapLimitOrders';
+const dexKey = 'ParaSwapLimitOrders';
 
 const tokenABKey = DummyLimitOrderProvider.getPriceSummaryCacheKey(
   network,
@@ -55,16 +55,16 @@ const dummyPriceSummary = {
   ],
 };
 
-describe('ParaswapLimitOrders', function () {
+describe('ParaSwapLimitOrders', function () {
   let dummyLimitOrderProvider: DummyLimitOrderProvider;
   let dexHelper: DummyDexHelper;
   let blockNumber: number;
-  let paraswapLimitOrders: ParaswapLimitOrders;
+  let paraSwapLimitOrders: ParaSwapLimitOrders;
 
   beforeAll(async () => {
     dexHelper = new DummyDexHelper(network);
     blockNumber = await dexHelper.provider.getBlockNumber();
-    paraswapLimitOrders = new ParaswapLimitOrders(network, dexKey, dexHelper);
+    paraSwapLimitOrders = new ParaSwapLimitOrders(network, dexKey, dexHelper);
     dummyLimitOrderProvider = new DummyLimitOrderProvider();
     dummyLimitOrderProvider.setPriceSummary(
       network,
@@ -73,11 +73,11 @@ describe('ParaswapLimitOrders', function () {
       dummyPriceSummary[tokenABKey],
     );
 
-    paraswapLimitOrders.limitOrderProvider = dummyLimitOrderProvider;
+    paraSwapLimitOrders.limitOrderProvider = dummyLimitOrderProvider;
   });
 
   it('getPoolIdentifiers and getPricesVolume SELL Unswappable amount', async function () {
-    const pools = await paraswapLimitOrders.getPoolIdentifiers(
+    const pools = await paraSwapLimitOrders.getPoolIdentifiers(
       TokenA,
       TokenB,
       SwapSide.SELL,
@@ -87,7 +87,7 @@ describe('ParaswapLimitOrders', function () {
 
     expect(pools.length).toBeGreaterThan(0);
 
-    const poolPrices = await paraswapLimitOrders.getPricesVolume(
+    const poolPrices = await paraSwapLimitOrders.getPricesVolume(
       TokenA,
       TokenB,
       [260n * BI_POWS[TokenA.decimals]],
@@ -101,7 +101,7 @@ describe('ParaswapLimitOrders', function () {
   });
 
   it('getPoolIdentifiers and getPricesVolume SELL', async function () {
-    const pools = await paraswapLimitOrders.getPoolIdentifiers(
+    const pools = await paraSwapLimitOrders.getPoolIdentifiers(
       TokenA,
       TokenB,
       SwapSide.SELL,
@@ -111,7 +111,7 @@ describe('ParaswapLimitOrders', function () {
 
     expect(pools.length).toBeGreaterThan(0);
 
-    const poolPrices = await paraswapLimitOrders.getPricesVolume(
+    const poolPrices = await paraSwapLimitOrders.getPricesVolume(
       TokenA,
       TokenB,
       amounts,
@@ -122,7 +122,7 @@ describe('ParaswapLimitOrders', function () {
     console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `, poolPrices);
 
     expect(poolPrices).not.toBeNull();
-    if (paraswapLimitOrders.hasConstantPriceLargeAmounts) {
+    if (paraSwapLimitOrders.hasConstantPriceLargeAmounts) {
       checkConstantPoolPrices(poolPrices!, amounts, dexKey);
     } else {
       checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
@@ -131,7 +131,7 @@ describe('ParaswapLimitOrders', function () {
 
   it('getPoolIdentifiers and getPricesVolume BUY', async function () {
     // TODO: Add buy when we support it
-    // const pools = await paraswapLimitOrders.getPoolIdentifiers(
+    // const pools = await paraSwapLimitOrders.getPoolIdentifiers(
     //   TokenA,
     //   TokenB,
     //   SwapSide.BUY,

--- a/src/dex/paraswap-limit-orders/paraswap-limit-orders.ts
+++ b/src/dex/paraswap-limit-orders/paraswap-limit-orders.ts
@@ -13,40 +13,35 @@ import {
   ExchangeTxInfo,
   PreprocessTransactionOptions,
 } from '../../types';
-import {
-  SwapSide,
-  Network,
-  LIMIT_ORDER_PROVIDERS,
-  NULL_ADDRESS,
-} from '../../constants';
+import { SwapSide, Network, LIMIT_ORDER_PROVIDERS } from '../../constants';
 import { getBigIntPow, getDexKeysWithNetwork, wrapETH } from '../../utils';
 import { IDex } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import {
-  ParaswapLimitOrdersData,
-  ParaswapLimitOrderResponse,
-  ParaswapLimitOrderPriceSummary,
-  ParaswapPriceSummaryResponse,
+  ParaSwapLimitOrdersData,
+  ParaSwapLimitOrderResponse,
+  ParaSwapLimitOrderPriceSummary,
+  ParaSwapPriceSummaryResponse,
   OrderInfo,
 } from './types';
-import { ParaswapLimitOrdersConfig, Adapters } from './config';
+import { ParaSwapLimitOrdersConfig, Adapters } from './config';
 import { LimitOrderExchange } from '../limit-order-exchange';
 import { BI_MAX_UINT } from '../../bigint-constants';
 import augustusRFQABI from '../../abi/paraswap-limit-orders/AugustusRFQ.abi.json';
 import { ONE_ORDER_GASCOST } from './constant';
 
-export class ParaswapLimitOrders
+export class ParaSwapLimitOrders
   extends LimitOrderExchange<
-    ParaswapLimitOrderResponse,
-    ParaswapPriceSummaryResponse
+    ParaSwapLimitOrderResponse,
+    ParaSwapPriceSummaryResponse
   >
-  implements IDex<ParaswapLimitOrdersData>
+  implements IDex<ParaSwapLimitOrdersData>
 {
   readonly hasConstantPriceLargeAmounts = false;
   readonly needWrapNative = true;
 
   public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
-    getDexKeysWithNetwork(ParaswapLimitOrdersConfig);
+    getDexKeysWithNetwork(ParaSwapLimitOrdersConfig);
 
   logger: Logger;
 
@@ -55,7 +50,7 @@ export class ParaswapLimitOrders
     protected dexKey: string,
     protected dexHelper: IDexHelper,
     protected adapters = Adapters[network] ? Adapters[network] : {},
-    protected augustusRFQAddress = ParaswapLimitOrdersConfig[dexKey][
+    protected augustusRFQAddress = ParaSwapLimitOrdersConfig[dexKey][
       network
     ].rfqAddress.toLowerCase(),
     protected rfqIface = new Interface(augustusRFQABI),
@@ -112,7 +107,7 @@ export class ParaswapLimitOrders
     side: SwapSide,
     blockNumber: number,
     limitPools?: string[],
-  ): Promise<null | ExchangePrices<ParaswapLimitOrdersData>> {
+  ): Promise<null | ExchangePrices<ParaSwapLimitOrdersData>> {
     if (side === SwapSide.BUY) return null;
 
     try {
@@ -179,12 +174,12 @@ export class ParaswapLimitOrders
   }
 
   async preProcessTransaction?(
-    optimalSwapExchange: OptimalSwapExchange<ParaswapLimitOrdersData>,
+    optimalSwapExchange: OptimalSwapExchange<ParaSwapLimitOrdersData>,
     srcToken: Token,
     destToken: Token,
     side: SwapSide,
     options: PreprocessTransactionOptions,
-  ): Promise<[OptimalSwapExchange<ParaswapLimitOrdersData>, ExchangeTxInfo]> {
+  ): Promise<[OptimalSwapExchange<ParaSwapLimitOrdersData>, ExchangeTxInfo]> {
     const userAddress = options.txOrigin;
     const { encodingValues, minDeadline } =
       await this._prepareOrdersForTransaction(
@@ -216,7 +211,7 @@ export class ParaswapLimitOrders
     destToken: string,
     srcAmount: string,
     destAmount: string,
-    data: ParaswapLimitOrdersData,
+    data: ParaSwapLimitOrdersData,
     side: SwapSide,
   ): AdapterExchangeParam {
     if (side === SwapSide.BUY) throw new Error(`Buy not supported`);
@@ -255,7 +250,7 @@ export class ParaswapLimitOrders
     destToken: string,
     srcAmount: string,
     destAmount: string,
-    data: ParaswapLimitOrdersData,
+    data: ParaSwapLimitOrdersData,
     side: SwapSide,
   ): Promise<SimpleExchangeParam> {
     if (side === SwapSide.BUY) throw new Error(`Buy not supported`);
@@ -294,7 +289,7 @@ export class ParaswapLimitOrders
   private async _getLatestPriceSummary(
     src: Address,
     dest: Address,
-  ): Promise<ParaswapLimitOrderPriceSummary[] | null> {
+  ): Promise<ParaSwapLimitOrderPriceSummary[] | null> {
     const priceSummaryUnparsed =
       await this._limitOrderProvider!.fetchPriceSummary(
         this.network,
@@ -387,7 +382,7 @@ export class ParaswapLimitOrders
 
   private _getPrices(
     amounts: bigint[],
-    priceSummary: ParaswapLimitOrderPriceSummary[],
+    priceSummary: ParaSwapLimitOrderPriceSummary[],
     orderCosts: bigint[],
   ): { prices: bigint[]; costs: bigint[] } {
     const prices = new Array<bigint>(amounts.length);

--- a/src/dex/paraswap-limit-orders/types.ts
+++ b/src/dex/paraswap-limit-orders/types.ts
@@ -18,17 +18,17 @@ export type AugustusOrder = {
   takerAmount: bigint;
 };
 
-export type ParaswapLimitOrderPriceSummary = {
+export type ParaSwapLimitOrderPriceSummary = {
   cumulativeMakerAmount: bigint;
   cumulativeTakerAmount: bigint;
 };
 
-export type ParaswapPriceSummaryResponse = {
+export type ParaSwapPriceSummaryResponse = {
   cumulativeMakerAmount: BigIntAsString;
   cumulativeTakerAmount: BigIntAsString;
 };
 
-export type ParaswapLimitOrdersData = {
+export type ParaSwapLimitOrdersData = {
   orderInfos: OrderInfo[] | null;
 };
 
@@ -52,4 +52,4 @@ export type OrderInfo = {
   permitMakerAsset: string;
 };
 
-export type ParaswapLimitOrderResponse = OrderInfo;
+export type ParaSwapLimitOrderResponse = OrderInfo;

--- a/src/dex/paraswap-limit-orders/utils.ts
+++ b/src/dex/paraswap-limit-orders/utils.ts
@@ -1,6 +1,0 @@
-// Rename util from here https://stackoverflow.com/questions/52702461/rename-key-of-typescript-object-type
-export type Rename<T, K extends keyof T, N extends string> = Pick<
-  T,
-  Exclude<keyof T, K>
-> &
-  { [P in N]: T[K] };

--- a/tests/generate-new-limit-order.ts
+++ b/tests/generate-new-limit-order.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import { ethers } from 'ethers';
 import { Address } from 'paraswap-core';
 import { Network, NULL_ADDRESS, ProviderURL } from '../src/constants';
-import { ParaswapLimitOrdersConfig } from '../src/dex/paraswap-limit-orders/config';
+import { ParaSwapLimitOrdersConfig } from '../src/dex/paraswap-limit-orders/config';
 
 const network = Network.ROPSTEN;
 const provider = ethers.getDefaultProvider(ProviderURL[network]);
@@ -13,9 +13,9 @@ const taker = '0xCf8C4a46816b146Ed613d23f6D22e1711915d653';
 
 const maker = new ethers.Wallet(makerPK, provider);
 
-const dexKey = 'ParaswapLimitOrders';
+const dexKey = 'ParaSwapLimitOrders';
 const rfqAddress =
-  ParaswapLimitOrdersConfig[dexKey][network].rfqAddress.toLowerCase();
+  ParaSwapLimitOrdersConfig[dexKey][network].rfqAddress.toLowerCase();
 
 const wethAddress = '0xc778417e063141139fce010982780140aa0cd5ab';
 const daiAddress = '0xad6d458402f60fd3bd25163575031acdce07538d';


### PR DESCRIPTION
Resolves: [BACK-634](https://linear.app/paraswap/issue/BACK-634/capitalize-paraswaplimitorders-name-in-dex)
Related [PR#557](https://github.com/paraswap/paraswap-api/pull/557) on API