### PR TITLE
feature/back-635 - Wrap tokens before preprocess transaction in LO Dex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.0.58",
+  "version": "2.0.59",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/paraswap-limit-orders/paraswap-limit-orders.ts
+++ b/src/dex/paraswap-limit-orders/paraswap-limit-orders.ts
@@ -181,10 +181,14 @@ export class ParaSwapLimitOrders
     options: PreprocessTransactionOptions,
   ): Promise<[OptimalSwapExchange<ParaSwapLimitOrdersData>, ExchangeTxInfo]> {
     const userAddress = options.txOrigin;
+
+    const srcWrapped = wrapETH(srcToken, this.network).address.toLowerCase();
+    const destWrapped = wrapETH(destToken, this.network).address.toLowerCase();
+
     const { encodingValues, minDeadline } =
       await this._prepareOrdersForTransaction(
-        srcToken.address,
-        destToken.address,
+        srcWrapped,
+        destWrapped,
         optimalSwapExchange.srcAmount,
         optimalSwapExchange.destAmount,
         side,


### PR DESCRIPTION
Resolves [BACK-635](https://linear.app/paraswap/issue/BACK-635/fix-lo-wrapping-issue-when-building-transaction)