### PR TITLE
Fraxswap

### DIFF
--- a/src/dex/uniswap-v2/config.ts
+++ b/src/dex/uniswap-v2/config.ts
@@ -230,6 +230,17 @@ export const UniswapV2Config: DexConfigMap<DexParams> = {
       feeCode: 30,
     },
   },
+  Fraxswap: {
+    [Network.MAINNET]: {
+      subgraphURL:
+        'https://gateway.thegraph.com/api/9c670884f39d914802bc0a7cd9d74e4d/subgraphs/id/9MAjo2x53jaxttJpShGh2EfSVAoDMW7vK36uU5cawQz2',
+      factoryAddress: '0xB076b06F669e682609fb4a8C6646D2619717Be4b',
+      initCode:
+        '0x56d8137e6dc7681d67b2c0b0ecb99a25da51343f540d36e93a2d172fea4597f7',
+      poolGasCost: 80 * 1000,
+      feeCode: 30,
+    },
+  },
   JulSwap: {
     [Network.BSC]: {
       // subgraphURL:

--- a/src/dex/uniswap-v2/uniswap-v2-e2e-mainnet.test.ts
+++ b/src/dex/uniswap-v2/uniswap-v2-e2e-mainnet.test.ts
@@ -1049,6 +1049,52 @@ describe('UniswapV2 E2E Mainnet', () => {
     });
   });
 
+  describe('Fraxswap', () => {
+    const dexKey = 'Fraxswap';
+
+    describe('Simpleswap', () => {
+      it('ETH -> TOKEN', async () => {
+        await testE2E(
+          tokens.ETH,
+          tokens.newFRAX,
+          holders.ETH,
+          '7000000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+      it('TOKEN -> ETH', async () => {
+        await testE2E(
+          tokens.newFRAX,
+          tokens.ETH,
+          holders.newFRAX,
+          '2000000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+      it('TOKEN -> TOKEN', async () => {
+        await testE2E(
+          tokens.FXS,
+          tokens.newFRAX,
+          holders.FXS,
+          '2000000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+    });
+  });
+
   describe('SakeSwap', () => {
     const dexKey = 'SakeSwap';
 

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -221,6 +221,10 @@ export const Tokens: { [network: number]: { [symbol: string]: Token } } = {
       address: '0x853d955aCEf822Db058eb8505911ED77F175b99e',
       decimals: 18,
     },
+    FXS: {
+      address: '0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0',
+      decimals: 18,
+    },
   },
   [Network.ROPSTEN]: {
     DAI: {
@@ -521,6 +525,7 @@ export const Holders: {
     DAI: '0x0f4ee9631f4be0a63756515141281a3e2b293bbe',
     oldFRAX: '0x183d0dc5867c01bfb1dbbc41d6a9d3de6e044626',
     newFRAX: '0x183d0dc5867c01bfb1dbbc41d6a9d3de6e044626',
+    FXS: '0x183d0dc5867c01bfb1dbbc41d6a9d3de6e044626',
     FEI: '0x19c549357034d10db8d75ed812b45be1dd8a7218',
     BAL: '0x7514f531ef3721b8d2ff8d3a841d7c05011eecca',
     WISE: '0x25c315e0758beeab30ee048a4e2080e7084b64b3',


### PR DESCRIPTION
Fraxswap has both immediate AMM as well as time weighted (TWAMM) orders. The AMM portion is a fork of UniswapV2 and has the same ABI. The TWAMM component is not included in this PR for brevity's sake.