### PR TITLE
fix/solidly-log-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/uniswap-v2/uniswap-v2.ts
+++ b/src/dex/uniswap-v2/uniswap-v2.ts
@@ -51,6 +51,10 @@ const DefaultUniswapV2PoolGasCost = 90 * 1000;
 
 export const RESERVE_LIMIT = 2n ** 112n - 1n;
 
+const LogCallTopics = [
+  '0xcf2aa50876cdfbb541206f89af0ee78d44a2abf8d328e37fa4917f982149848a', // event Sync(uint reserve0, uint reserve1)
+];
+
 interface UniswapV2PoolState {
   reserves0: string;
   reserves1: string;
@@ -110,6 +114,8 @@ export class UniswapV2EventPool extends StatefulEventSubscriber<UniswapV2PoolSta
     state: DeepReadonly<UniswapV2PoolState>,
     log: Readonly<Log>,
   ): AsyncOrSync<DeepReadonly<UniswapV2PoolState> | null> {
+    if (!LogCallTopics.includes(log.topics[0])) return null;
+
     const event = this.decoder(log);
     switch (event.name) {
       case 'Sync':


### PR DESCRIPTION
filtering out unhandled events based on topic hash to avoid unnecessary error logs