### PR TITLE
Cone exchange 

### DIFF
--- a/src/abi/uniswap-v2/ConeFactory.json
+++ b/src/abi/uniswap-v2/ConeFactory.json
@@ -1,0 +1,279 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "stable",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pair",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "allPairsLength",
+        "type": "uint256"
+      }
+    ],
+    "name": "PairCreated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptPauser",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "allPairs",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "allPairsLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenA",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenB",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "stable",
+        "type": "bool"
+      }
+    ],
+    "name": "createPair",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "pair",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getInitializable",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "name": "getPair",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isPair",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isPaused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pairCodeHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pauser",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingPauser",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_state",
+        "type": "bool"
+      }
+    ],
+    "name": "setPause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pauser",
+        "type": "address"
+      }
+    ],
+    "name": "setPauser",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSwapFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/abi/uniswap-v2/ConePair.json
+++ b/src/abi/uniswap-v2/ConePair.json
@@ -1,0 +1,1228 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Burn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Claim",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Fees",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeesChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reserve0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reserve1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Sync",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Treasury",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PERMIT_TYPEHASH",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "blockTimestampLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "chainId",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claimFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "claimed0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "claimed1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "claimable0",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "claimable1",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "current",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentCumulativePrices",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "reserve0Cumulative",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserve1Cumulative",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "blockTimestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fees",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      }
+    ],
+    "name": "getAmountOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getReserves",
+    "outputs": [
+      {
+        "internalType": "uint112",
+        "name": "_reserve0",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint112",
+        "name": "_reserve1",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_blockTimestampLast",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "index0",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "index1",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastObservation",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "timestamp",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "reserve0Cumulative",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "reserve1Cumulative",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IPair.Observation",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "metadata",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "dec0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "dec1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "r0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "r1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "st",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "t0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "t1",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "observationLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "observations",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserve0Cumulative",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserve1Cumulative",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "points",
+        "type": "uint256"
+      }
+    ],
+    "name": "prices",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "granularity",
+        "type": "uint256"
+      }
+    ],
+    "name": "quote",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserve0",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserve0CumulativeLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserve1",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserve1CumulativeLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "points",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "window",
+        "type": "uint256"
+      }
+    ],
+    "name": "sample",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSwapFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "skim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "supplyIndex0",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "supplyIndex1",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "swap",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "swapFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sync",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tokens",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dst",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "src",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "dst",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/dex-helper/dummy-dex-helper.ts
+++ b/src/dex-helper/dummy-dex-helper.ts
@@ -11,6 +11,11 @@ import { Address, LoggerConstructor, Token } from '../types';
 import { StaticJsonRpcProvider, Provider } from '@ethersproject/providers';
 import multiABIV2 from '../abi/multi-v2.json';
 import log4js from 'log4js';
+// TODO remove
+log4js.configure({
+  appenders: { out: { type: 'stdout' } },
+  categories: { default: { appenders: ['out'], level: 'info' } },
+});
 import Web3 from 'web3';
 import { Contract } from 'web3-eth-contract';
 import { generateConfig, ConfigHelper } from '../config';

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -46,6 +46,7 @@ import Web3 from 'web3';
 import { Solidly } from './solidly/solidly';
 import { Velodrome } from './solidly/forks-override/velodrome';
 import { SpiritSwapV2 } from './solidly/forks-override/spiritSwapV2';
+import { Cone } from './uniswap-v2/cone/cone';
 
 const LegacyDexes = [
   Curve,
@@ -90,6 +91,7 @@ const Dexes = [
   Solidly,
   SpiritSwapV2,
   Velodrome,
+  Cone,
 ];
 
 export type LegacyDexConstructor = new (

--- a/src/dex/uniswap-v2/cone/cone-integration.test.ts
+++ b/src/dex/uniswap-v2/cone/cone-integration.test.ts
@@ -1,0 +1,216 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+// @ts-ignore
+import { checkPoolPrices, checkPoolsLiquidity } from '../../../../tests/utils';
+// @ts-ignore
+import { Tokens } from '../../../../tests/constants-e2e';
+import { DummyDexHelper } from '../../../dex-helper';
+import { Network, SwapSide } from '../../../constants';
+import { BI_POWS } from '../../../bigint-constants';
+import { Cone } from './cone';
+import { Interface, Result } from '@ethersproject/abi';
+import conePairABI from '../../../abi/uniswap-v2/ConePair.json';
+
+const amounts18 = [0n, BI_POWS[18], 2000000000000000000n];
+// const amounts6 = [0n, BI_POWS[6], BI_POWS[6] * 2n];
+
+const dexKey = 'Cone';
+const network = Network.BSC;
+const dexHelper = new DummyDexHelper(network);
+const cone = new Cone(network, dexKey, dexHelper);
+
+function getReaderCalldata(
+  exchangeAddress: string,
+  readerIface: Interface,
+  amounts: bigint[],
+  funcName: string,
+  tokenIn: string,
+) {
+  return amounts.map(amount => ({
+    target: exchangeAddress,
+    callData: readerIface.encodeFunctionData(funcName, [amount, tokenIn]),
+  }));
+}
+
+function decodeReaderResult(
+  results: Result,
+  readerIface: Interface,
+  funcName: string,
+) {
+  return results.map(result => {
+    const parsed = readerIface.decodeFunctionResult(funcName, result);
+    return BigInt(parsed[0]._hex);
+  });
+}
+
+async function checkOnChainPricing(
+  cone: Cone,
+  funcName: string,
+  blockNumber: number,
+  prices: bigint[],
+  exchangeAddress: string,
+  tokenIn: string,
+  amounts: bigint[],
+) {
+  const readerIface = new Interface(conePairABI as any);
+
+  const readerCallData = getReaderCalldata(
+    exchangeAddress,
+    readerIface,
+    amounts.slice(1),
+    funcName,
+    tokenIn,
+  );
+  console.log('readerCallData', readerCallData);
+  const readerResult = (
+    await dexHelper.multiContract.methods
+      .aggregate(readerCallData)
+      .call({}, blockNumber)
+  ).returnData;
+  const expectedPrices = [0n].concat(
+    decodeReaderResult(readerResult, readerIface, funcName),
+  );
+
+  console.log('prices', prices);
+  console.log('expectedPrices', expectedPrices);
+
+  expect(prices).toEqual(expectedPrices);
+}
+
+describe('Cone', function () {
+  describe('UniswapV2 like pool', function () {
+    const TokenASymbol = 'WBNB';
+    const tokenA = Tokens[network][TokenASymbol];
+    const TokenBSymbol = 'CONE';
+    const tokenB = Tokens[network][TokenBSymbol];
+
+    const amounts = amounts18;
+
+    it('getPoolIdentifiers and getPricesVolume', async function () {
+      const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      const cone = new Cone(network, dexKey, dexHelper);
+      const pools = await cone.getPoolIdentifiers(
+        tokenA,
+        tokenB,
+        SwapSide.SELL,
+        blocknumber,
+      );
+      console.log(
+        `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+        pools,
+      );
+
+      expect(pools.length).toBeGreaterThan(0);
+
+      const poolPrices = await cone.getPricesVolume(
+        tokenA,
+        tokenB,
+        amounts,
+        SwapSide.SELL,
+        blocknumber,
+        pools,
+      );
+      console.log(
+        `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+        poolPrices,
+      );
+
+      expect(poolPrices).not.toBeNull();
+
+      // Check if onchain pricing equals to calculated ones
+
+      for (const i in poolPrices || []) {
+        await checkOnChainPricing(
+          cone,
+          'getAmountOut',
+          blocknumber,
+          poolPrices![i].prices,
+          poolPrices![i].poolAddresses![0],
+          tokenA.address,
+          amounts,
+        );
+      }
+
+      checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+    });
+
+    it('getTopPoolsForToken', async function () {
+      const dexHelper = new DummyDexHelper(network);
+      const cone = new Cone(network, dexKey, dexHelper);
+
+      const poolLiquidity = await cone.getTopPoolsForToken(tokenA.address, 10);
+      console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
+
+      checkPoolsLiquidity(poolLiquidity, tokenA.address, dexKey);
+    });
+  });
+
+  describe('Curve like stable pool', function () {
+    const TokenASymbol = 'USDT'; // 'USDT';
+    const tokenA = Tokens[network][TokenASymbol];
+    const TokenBSymbol = 'BUSD';
+    const tokenB = Tokens[network][TokenBSymbol];
+
+    const amounts = amounts18; // amounts6;
+
+    it('getPoolIdentifiers and getPricesVolume', async function () {
+      const dexHelper = new DummyDexHelper(network);
+      const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      const pools = await cone.getPoolIdentifiers(
+        tokenA,
+        tokenB,
+        SwapSide.SELL,
+        blocknumber,
+      );
+      console.log(
+        `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+        pools,
+      );
+
+      expect(pools.length).toBeGreaterThan(0);
+
+      const poolPrices = await cone.getPricesVolume(
+        tokenA,
+        tokenB,
+        amounts,
+        SwapSide.SELL,
+        blocknumber,
+        pools,
+      );
+      console.log(
+        `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+        poolPrices,
+      );
+
+      expect(poolPrices).not.toBeNull();
+      checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+      // Check if onchain pricing equals to calculated ones
+      for (const i in poolPrices || []) {
+        await checkOnChainPricing(
+          cone,
+          'getAmountOut',
+          blocknumber,
+          poolPrices![i].prices,
+          poolPrices![i].poolAddresses![0],
+          tokenA.address,
+          amounts,
+        );
+      }
+    });
+
+    it('getTopPoolsForToken', async function () {
+      const dexHelper = new DummyDexHelper(network);
+      const coneStable = new Cone(network, dexKey, dexHelper);
+
+      const poolLiquidity = await coneStable.getTopPoolsForToken(
+        tokenA.address,
+        10,
+      );
+      console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
+
+      checkPoolsLiquidity(poolLiquidity, tokenA.address, dexKey);
+    });
+  });
+});

--- a/src/dex/uniswap-v2/cone/cone-stable-pool.ts
+++ b/src/dex/uniswap-v2/cone/cone-stable-pool.ts
@@ -1,0 +1,95 @@
+import { RESERVE_LIMIT } from '../uniswap-v2';
+import { BI_POWS } from '../../../bigint-constants';
+import { ConePoolOrderedParams } from './cone';
+
+const e18 = BI_POWS[18];
+
+function _k(
+  x: bigint,
+  y: bigint,
+  decimals0: bigint,
+  decimals1: bigint,
+): bigint {
+  const _x = (x * e18) / decimals0;
+  const _y = (y * e18) / decimals1;
+  const _a = (_x * _y) / e18;
+  const _b = (_x * _x) / e18 + (_y * _y) / e18;
+  // x3y+y3x >= k
+  return (_a * _b) / e18;
+}
+
+function _f(x0: bigint, y: bigint): bigint {
+  return (
+    (x0 * ((((y * y) / e18) * y) / e18)) / e18 +
+    (((((x0 * x0) / e18) * x0) / e18) * y) / e18
+  );
+}
+
+function _d(x0: bigint, y: bigint): bigint {
+  return (3n * x0 * ((y * y) / e18)) / e18 + (((x0 * x0) / e18) * x0) / e18;
+}
+
+function _getY(x0: bigint, xy: bigint, y: bigint): bigint {
+  for (let i = 0; i < 255; i++) {
+    const yPrev = y;
+    const k = _f(x0, y);
+    if (k < xy) {
+      const dy = ((xy - k) * e18) / _d(x0, y);
+      y = y + dy;
+    } else {
+      const dy = ((k - xy) * e18) / _d(x0, y);
+      y = y - dy;
+    }
+    if (_closeTo(y, yPrev, 1n)) {
+      break;
+    }
+  }
+  return y;
+}
+
+function _closeTo(a: bigint, b: bigint, target: bigint) {
+  if (a > b) {
+    if (a - b <= target) {
+      return true;
+    }
+  } else {
+    if (b - a <= target) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export class ConeStablePool {
+  static async getSellPrice(
+    priceParams: ConePoolOrderedParams,
+    srcAmount: bigint,
+  ): Promise<bigint> {
+    if (srcAmount === 0n) return 0n;
+
+    const { reservesIn, reservesOut, decimalsIn, decimalsOut, fee } =
+      priceParams;
+    const feeBI = BigInt(fee);
+    console.log('ConeStablePool fee', fee);
+
+    if (BigInt(reservesIn) + srcAmount > RESERVE_LIMIT) {
+      return 0n;
+    }
+
+    const amountIn = srcAmount - srcAmount / feeBI;
+
+    const reservesInN = BigInt(reservesIn);
+    const reservesOutN = BigInt(reservesOut);
+    const decimalsInN = 10n ** BigInt(decimalsIn);
+    const decimalsOutN = 10n ** BigInt(decimalsOut);
+
+    const xy = _k(reservesInN, reservesOutN, decimalsInN, decimalsOutN);
+    const reserveA = (reservesInN * e18) / decimalsInN;
+    const reserveB = (reservesOutN * e18) / decimalsOutN;
+    const amountInNorm = (amountIn * e18) / decimalsInN;
+    const y = reserveB - _getY(amountInNorm + reserveA, xy, reserveB);
+    const price = (y * decimalsOutN) / e18;
+    console.log('price', price);
+    return price;
+  }
+}

--- a/src/dex/uniswap-v2/cone/cone-uniswap-v2-pool.ts
+++ b/src/dex/uniswap-v2/cone/cone-uniswap-v2-pool.ts
@@ -1,0 +1,44 @@
+import { RESERVE_LIMIT } from '../uniswap-v2';
+import { UniswapV2PoolOrderedParams } from '../types';
+import { BI_MAX_UINT } from '../../../bigint-constants';
+
+export class ConeUniswapV2Pool {
+  // Cone non-stable pools has almost same formula like uniswap2,
+  // but little changed in contract.
+  // So we repeat formulas here to have same output.
+  static async getSellPrice(
+    priceParams: UniswapV2PoolOrderedParams,
+    srcAmount: bigint,
+  ): Promise<bigint> {
+    if (srcAmount === 0n) return 0n;
+    const { reservesIn, reservesOut, fee } = priceParams;
+    const feeBI = BigInt(fee);
+    console.log('ConeUniswapV2Pool fee', fee);
+
+    if (BigInt(reservesIn) + srcAmount > RESERVE_LIMIT) {
+      return 0n;
+    }
+
+    const amountInWithFee = srcAmount * (feeBI - 1n);
+
+    const numerator = amountInWithFee * BigInt(reservesOut);
+
+    const denominator = BigInt(reservesIn) * feeBI + amountInWithFee;
+
+    return denominator === 0n ? 0n : numerator / denominator;
+  }
+
+  static async getBuyPrice(
+    priceParams: UniswapV2PoolOrderedParams,
+    destAmount: bigint,
+  ): Promise<bigint> {
+    const { reservesIn, reservesOut, fee } = priceParams;
+    const feeBI = BigInt(fee);
+
+    const numerator = BigInt(reservesIn) * destAmount * feeBI;
+    const denominator = (feeBI - 1n) * (BigInt(reservesOut) - destAmount);
+
+    if (denominator <= 0n) return BI_MAX_UINT;
+    return 1n + numerator / denominator;
+  }
+}

--- a/src/dex/uniswap-v2/cone/cone.ts
+++ b/src/dex/uniswap-v2/cone/cone.ts
@@ -1,0 +1,551 @@
+import { UniswapV2, UniswapV2Pair } from '../uniswap-v2';
+import { Network, NULL_ADDRESS, SUBGRAPH_TIMEOUT } from '../../../constants';
+import {
+  AdapterExchangeParam,
+  Address,
+  ExchangePrices,
+  PoolLiquidity,
+  SimpleExchangeParam,
+  Token,
+} from '../../../types';
+import { IDexHelper } from '../../../dex-helper';
+import { UniswapData, UniswapV2Data } from '../types';
+import { getBigIntPow, getDexKeysWithNetwork } from '../../../utils';
+import coneFactoryABI from '../../../abi/uniswap-v2/ConeFactory.json';
+import conePairABI from '../../../abi/uniswap-v2/ConePair.json';
+import _ from 'lodash';
+import { NumberAsString, SwapSide } from 'paraswap-core';
+import { ConeUniswapV2Pool } from './cone-uniswap-v2-pool';
+import { ConeStablePool } from './cone-stable-pool';
+import { Adapters, ConeConfig } from './config';
+import { AbiCoder, Interface } from '@ethersproject/abi';
+
+// to calculate prices for stable pool, we need decimals of the stable tokens
+// so, we are extending UniswapV2PoolOrderedParams with token decimals
+export interface ConePoolOrderedParams {
+  tokenIn: string;
+  tokenOut: string;
+  reservesIn: string;
+  reservesOut: string;
+  fee: string;
+  direction: boolean;
+  exchange: string;
+  decimalsIn: number;
+  decimalsOut: number;
+  stable: boolean;
+}
+
+export interface ConePoolState {
+  reserves0: string;
+  reserves1: string;
+  feeCode: number;
+}
+
+const iface = new Interface(conePairABI);
+const coder = new AbiCoder();
+
+export class Cone extends UniswapV2 {
+  feeFactor = 0;
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(ConeConfig);
+
+  constructor(
+    protected network: Network,
+    protected dexKey: string,
+    protected dexHelper: IDexHelper,
+    isDynamicFees = true,
+    factoryAddress?: Address,
+    subgraphURL?: string,
+    initCode?: string,
+    feeCode?: number,
+    poolGasCost?: number,
+    routerAddress?: Address,
+  ) {
+    super(
+      network,
+      dexKey,
+      dexHelper,
+      isDynamicFees,
+      factoryAddress !== undefined
+        ? factoryAddress
+        : ConeConfig[dexKey][network].factoryAddress,
+      subgraphURL === ''
+        ? undefined
+        : subgraphURL !== undefined
+        ? subgraphURL
+        : ConeConfig[dexKey][network].subgraphURL,
+      initCode !== undefined ? initCode : ConeConfig[dexKey][network].initCode,
+      feeCode !== undefined ? feeCode : ConeConfig[dexKey][network].feeCode,
+      poolGasCost !== undefined
+        ? poolGasCost
+        : ConeConfig[dexKey][network].poolGasCost,
+      iface,
+      Adapters[network] || undefined,
+    );
+
+    this.factory = new dexHelper.web3Provider.eth.Contract(
+      coneFactoryABI as any,
+      factoryAddress !== undefined
+        ? factoryAddress
+        : ConeConfig[dexKey][network].factoryAddress,
+    );
+
+    this.router =
+      routerAddress !== undefined
+        ? routerAddress
+        : ConeConfig[dexKey][network].router || '';
+  }
+
+  async findConePair(from: Token, to: Token, stable: boolean) {
+    if (from.address.toLowerCase() === to.address.toLowerCase()) return null;
+    const [token0, token1] =
+      from.address.toLowerCase() < to.address.toLowerCase()
+        ? [from, to]
+        : [to, from];
+
+    const typePostfix = this.poolPostfix(stable);
+    const key = `${token0.address.toLowerCase()}-${token1.address.toLowerCase()}-${typePostfix}`;
+    let pair = this.pairs[key];
+    if (pair) return pair;
+
+    let exchange = await this.factory.methods
+      // Cone has additional boolean parameter "StablePool"
+      // At first we look for uniswap-like volatile pool
+      .getPair(token0.address, token1.address, stable)
+      .call();
+
+    if (exchange === NULL_ADDRESS) {
+      pair = { token0, token1 };
+    } else {
+      pair = { token0, token1, exchange };
+    }
+    this.pairs[key] = pair;
+    return pair;
+  }
+
+  async batchCatchUpPairs(pairs: [Token, Token][], blockNumber: number) {
+    if (!blockNumber) return;
+    const pairsToFetch: UniswapV2Pair[] = [];
+    for (const _pair of pairs) {
+      for (const stable of [false, true]) {
+        const pair = await this.findConePair(_pair[0], _pair[1], stable);
+        if (!(pair && pair.exchange)) continue;
+        if (!pair.pool) {
+          pairsToFetch.push(pair);
+        } else if (!pair.pool.getState(blockNumber)) {
+          pairsToFetch.push(pair);
+        }
+      }
+    }
+
+    if (!pairsToFetch.length) return;
+
+    const reserves = await this.getManyPoolReserves(pairsToFetch, blockNumber);
+    console.log('reserves', reserves);
+
+    if (reserves.length !== pairsToFetch.length) {
+      this.logger.error(
+        `Error_getManyPoolReserves didn't get any pool reserves`,
+      );
+    }
+
+    for (let i = 0; i < pairsToFetch.length; i++) {
+      const pairState = reserves[i];
+      const pair = pairsToFetch[i];
+      if (!pair.pool) {
+        await this.addPool(
+          pair,
+          pairState.reserves0,
+          pairState.reserves1,
+          pairState.feeCode,
+          blockNumber,
+        );
+      } else pair.pool.setState(pairState, blockNumber);
+    }
+  }
+
+  async getManyPoolReserves(
+    pairs: UniswapV2Pair[],
+    blockNumber: number,
+  ): Promise<ConePoolState[]> {
+    try {
+      const multiCallFeeData = pairs.map(pair =>
+        this.getFeesMultiCallData(pair),
+      );
+      const calldata = pairs
+        .map((pair, i) => {
+          let calldata = [
+            {
+              target: pair.exchange,
+              callData: iface.encodeFunctionData('getReserves', []),
+            },
+          ];
+          calldata.push(multiCallFeeData[i]!.callEntry);
+          return calldata;
+        })
+        .flat();
+
+      const data: { returnData: any[] } =
+        await this.dexHelper.multiContract.methods
+          .aggregate(calldata)
+          .call({}, blockNumber);
+
+      const returnData = _.chunk(data.returnData, 2);
+      console.log('returnData', returnData);
+
+      return pairs.map((pair, i) => {
+        const reservesDecodedData = coder.decode(
+          ['uint112', 'uint112', 'uint32'],
+          returnData[i][0],
+        );
+        const feeCode = multiCallFeeData[i]!.callDecoder(returnData[i][1]);
+        console.log('feeCode', feeCode);
+        return {
+          reserves0: reservesDecodedData[0].toString(),
+          reserves1: reservesDecodedData[1].toString(),
+          feeCode,
+        };
+      });
+    } catch (e) {
+      this.logger.error(
+        `Error_getManyPoolReserves could not get reserves with error:`,
+        e,
+      );
+      return [];
+    }
+  }
+
+  async getSellPrice(
+    priceParams: ConePoolOrderedParams,
+    srcAmount: bigint,
+  ): Promise<bigint> {
+    return priceParams.stable
+      ? ConeStablePool.getSellPrice(priceParams, srcAmount)
+      : ConeUniswapV2Pool.getSellPrice(priceParams, srcAmount);
+  }
+
+  async getBuyPrice(
+    priceParams: ConePoolOrderedParams,
+    srcAmount: bigint,
+  ): Promise<bigint> {
+    if (priceParams.stable) throw new Error(`Buy not supported`);
+    return ConeUniswapV2Pool.getBuyPrice(priceParams, srcAmount);
+  }
+
+  async getPricesVolume(
+    _from: Token,
+    _to: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    // list of pool identifiers to use for pricing, if undefined use all pools
+    limitPools?: string[],
+  ): Promise<ExchangePrices<UniswapV2Data> | null> {
+    try {
+      if (side === SwapSide.BUY) return null; // Buy side not implemented
+      const from = this.dexHelper.config.wrapETH(_from);
+      const to = this.dexHelper.config.wrapETH(_to);
+
+      if (from.address.toLowerCase() === to.address.toLowerCase()) {
+        return null;
+      }
+
+      const tokenAddress = [
+        from.address.toLowerCase(),
+        to.address.toLowerCase(),
+      ]
+        .sort((a, b) => (a > b ? 1 : -1))
+        .join('_');
+
+      await this.batchCatchUpPairs([[from, to]], blockNumber);
+
+      const resultPromises = [false, true].map(async stable => {
+        const poolIdentifier =
+          `${this.dexKey}_${tokenAddress}` + this.poolPostfix(stable);
+
+        if (limitPools && limitPools.every(p => p !== poolIdentifier))
+          return null;
+
+        const pairParam = await this.getConePairOrderedParams(
+          from,
+          to,
+          blockNumber,
+          stable,
+        );
+
+        if (!pairParam) return null;
+
+        const unitAmount = getBigIntPow(
+          // @ts-expect-error Buy side is not implemented yet
+          side === SwapSide.BUY ? to.decimals : from.decimals,
+        );
+        const unit =
+          // @ts-expect-error Buy side is not implemented yet
+          side === SwapSide.BUY
+            ? await this.getBuyPricePath(unitAmount, [pairParam])
+            : await this.getSellPricePath(unitAmount, [pairParam]);
+
+        const prices =
+          // @ts-expect-error Buy side is not implemented yet
+          side === SwapSide.BUY
+            ? await Promise.all(
+                amounts.map(amount =>
+                  this.getBuyPricePath(amount, [pairParam]),
+                ),
+              )
+            : await Promise.all(
+                amounts.map(amount =>
+                  this.getSellPricePath(amount, [pairParam]),
+                ),
+              );
+
+        return {
+          prices: prices,
+          unit: unit,
+          data: {
+            router: this.router,
+            path: [from.address.toLowerCase(), to.address.toLowerCase()],
+            factory: this.factoryAddress,
+            initCode: this.initCode,
+            feeFactor: this.feeFactor,
+            pools: [
+              {
+                address: pairParam.exchange,
+                fee: parseInt(pairParam.fee),
+                direction: pairParam.direction,
+              },
+            ],
+          },
+          exchange: this.dexKey,
+          poolIdentifier,
+          gasCost: this.poolGasCost,
+          poolAddresses: [pairParam.exchange],
+        };
+      });
+
+      const resultPools = (await Promise.all(
+        resultPromises,
+      )) as ExchangePrices<UniswapV2Data>;
+      const resultPoolsFiltered = resultPools.filter(item => !!item); // filter null elements
+      return resultPoolsFiltered.length > 0 ? resultPoolsFiltered : null;
+    } catch (e) {
+      if (blockNumber === 0)
+        this.logger.error(
+          `Error_getPricesVolume: Aurelius block manager not yet instantiated`,
+        );
+      this.logger.error(`Error_getPrices:`, e);
+      return null;
+    }
+  }
+
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    count: number,
+  ): Promise<PoolLiquidity[]> {
+    if (!this.subgraphURL) return [];
+    const query = `query ($token: Bytes!, $count: Int) {
+      pools0: pairs(first: $count, orderBy: reserveUSD, orderDirection: desc, where: {token0: $token, reserve0_gt: 1, reserve1_gt: 1}) {
+        id
+        isStable
+        token0 {
+          id
+          decimals
+        }
+        token1 {
+          id
+          decimals
+        }
+        reserveUSD
+      }
+      pools1: pairs(first: $count, orderBy: reserveUSD, orderDirection: desc, where: {token1: $token, reserve0_gt: 1, reserve1_gt: 1}) {
+        id
+        isStable
+        token0 {
+          id
+          decimals
+        }
+        token1 {
+          id
+          decimals
+        }
+        reserveUSD
+      }
+    }`;
+
+    const { data } = await this.dexHelper.httpRequest.post(
+      this.subgraphURL,
+      {
+        query,
+        variables: { token: tokenAddress.toLowerCase(), count },
+      },
+      SUBGRAPH_TIMEOUT,
+    );
+
+    if (!(data && data.pools0 && data.pools1))
+      throw new Error("Couldn't fetch the pools from the subgraph");
+    const pools0 = _.map(data.pools0, pool => ({
+      exchange: this.dexKey,
+      stable: pool.isStable,
+      address: pool.id.toLowerCase(),
+      connectorTokens: [
+        {
+          address: pool.token1.id.toLowerCase(),
+          decimals: parseInt(pool.token1.decimals),
+        },
+      ],
+      liquidityUSD: parseFloat(pool.reserveUSD),
+    }));
+
+    const pools1 = _.map(data.pools1, pool => ({
+      exchange: this.dexKey,
+      stable: pool.isStable,
+      address: pool.id.toLowerCase(),
+      connectorTokens: [
+        {
+          address: pool.token0.id.toLowerCase(),
+          decimals: parseInt(pool.token0.decimals),
+        },
+      ],
+      liquidityUSD: parseFloat(pool.reserveUSD),
+    }));
+
+    return _.slice(
+      _.sortBy(_.concat(pools0, pools1), [pool => -1 * pool.liquidityUSD]),
+      0,
+      count,
+    );
+  }
+
+  // Same as at uniswap-v2-pool.json, but extended with decimals and stable
+
+  async getConePairOrderedParams(
+    from: Token,
+    to: Token,
+    blockNumber: number,
+    stable: boolean,
+  ): Promise<ConePoolOrderedParams | null> {
+    const pair = await this.findConePair(from, to, stable);
+    if (!(pair && pair.pool && pair.exchange)) return null;
+    const pairState = pair.pool.getState(blockNumber);
+    if (!pairState) {
+      this.logger.error(
+        `Error_orderPairParams expected reserves, got none (maybe the pool doesn't exist) ${
+          from.symbol || from.address
+        } ${to.symbol || to.address}`,
+      );
+      return null;
+    }
+
+    const pairReversed =
+      pair.token1.address.toLowerCase() === from.address.toLowerCase();
+    if (pairReversed) {
+      return {
+        tokenIn: from.address,
+        tokenOut: to.address,
+        reservesIn: pairState.reserves1,
+        reservesOut: pairState.reserves0,
+        fee: pairState.feeCode.toString(),
+        direction: false,
+        exchange: pair.exchange,
+        decimalsIn: from.decimals,
+        decimalsOut: to.decimals,
+        stable,
+      };
+    }
+    return {
+      tokenIn: from.address,
+      tokenOut: to.address,
+      reservesIn: pairState.reserves0,
+      reservesOut: pairState.reserves1,
+      fee: pairState.feeCode.toString(),
+      direction: true,
+      exchange: pair.exchange,
+      decimalsIn: from.decimals,
+      decimalsOut: to.decimals,
+      stable,
+    };
+  }
+
+  async getPoolIdentifiers(
+    _from: Token,
+    _to: Token,
+    side: SwapSide,
+    blockNumber: number,
+  ): Promise<string[]> {
+    if (side === SwapSide.BUY) return [];
+
+    const from = this.dexHelper.config.wrapETH(_from);
+    const to = this.dexHelper.config.wrapETH(_to);
+
+    if (from.address.toLowerCase() === to.address.toLowerCase()) {
+      return [];
+    }
+
+    const tokenAddress = [from.address.toLowerCase(), to.address.toLowerCase()]
+      .sort((a, b) => (a > b ? 1 : -1))
+      .join('_');
+
+    const poolIdentifier = `${this.dexKey}_${tokenAddress}`;
+    const poolIdentifierUniswap = poolIdentifier + this.poolPostfix(false);
+    const poolIdentifierStable = poolIdentifier + this.poolPostfix(true);
+    return [poolIdentifierUniswap, poolIdentifierStable];
+  }
+
+  poolPostfix(stable: boolean) {
+    return stable ? 'S' : 'U';
+  }
+
+  async getSimpleParam(
+    src: Address,
+    dest: Address,
+    srcAmount: NumberAsString,
+    destAmount: NumberAsString,
+    data: UniswapData,
+    side: SwapSide,
+  ): Promise<SimpleExchangeParam> {
+    if (side === SwapSide.BUY) throw new Error(`Buy not supported`);
+    return super.getSimpleParam(src, dest, srcAmount, destAmount, data, side);
+  }
+
+  getAdapterParam(
+    srcToken: Address,
+    destToken: Address,
+    srcAmount: NumberAsString,
+    toAmount: NumberAsString, // required for buy case
+    data: UniswapData,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    if (side === SwapSide.BUY) throw new Error(`Buy not supported`);
+    return super.getAdapterParam(
+      srcToken,
+      destToken,
+      srcAmount,
+      toAmount,
+      data,
+      side,
+    );
+  }
+
+  protected getFeesMultiCallData(pair: UniswapV2Pair):
+    | undefined
+    | {
+        callEntry: { target: Address; callData: string };
+        callDecoder: (values: any[]) => number;
+      } {
+    const callEntry = {
+      target: pair.exchange!,
+      callData: iface.encodeFunctionData('swapFee', []),
+    };
+    const callDecoder = (values: any[]) => {
+      const feeStr = iface
+        .decodeFunctionResult('swapFee', values)[0]
+        .toString();
+      // fee in cone is denominator only (10_000 for stable and 2_000 for volatile pools
+      return parseInt(feeStr);
+    };
+    return {
+      callEntry,
+      callDecoder,
+    };
+  }
+}

--- a/src/dex/uniswap-v2/cone/config.ts
+++ b/src/dex/uniswap-v2/cone/config.ts
@@ -1,0 +1,24 @@
+import { AdapterMappings, DexConfigMap } from '../../../types';
+import { DexParams } from '../types';
+import { Network, SwapSide } from '../../../constants';
+
+export const ConeConfig: DexConfigMap<DexParams> = {
+  Cone: {
+    [Network.BSC]: {
+      subgraphURL: 'https://api.thegraph.com/subgraphs/name/cone-exchange/cone',
+      factoryAddress: '0x0EFc2D2D054383462F2cD72eA2526Ef7687E1016',
+      // ParaSwap-compatible Router with stable pools support
+      router: '0x69a457CD13Ee72b0CA1b483aB17C36D80a23422f',
+      initCode:
+        '04b89f6ddaef769d145acd66e1700a76b1b7c369dfe9558e67ed6495b3b93fe4',
+      feeCode: 5,
+      poolGasCost: 180 * 1000,
+    },
+  },
+};
+
+export const Adapters: Record<number, AdapterMappings> = {
+  [Network.BSC]: {
+    [SwapSide.SELL]: [{ name: 'BscAdapter01', index: 3 }],
+  },
+};

--- a/src/dex/uniswap-v2/uniswap-v2-e2e-bsc.test.ts
+++ b/src/dex/uniswap-v2/uniswap-v2-e2e-bsc.test.ts
@@ -1406,4 +1406,145 @@ describe('UniswapV2 E2E BSC', () => {
       });
     });
   });
+
+  describe('Cone', () => {
+    const dexKey = 'Cone';
+
+    describe('Simpleswap', () => {
+      it('BNB -> BUSD', async () => {
+        await testE2E(
+          tokens.BNB,
+          tokens.BUSD,
+          holders.BNB,
+          '100000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+      it('BUSD -> BNB', async () => {
+        await testE2E(
+          tokens.BUSD,
+          tokens.BNB,
+          holders.BUSD,
+          '30000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+      it('WBNB -> BUSD', async () => {
+        await testE2E(
+          tokens.WBNB,
+          tokens.BUSD,
+          holders.WBNB,
+          '30000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+      it('WBNB -> CONE', async () => {
+        await testE2E(
+          tokens.WBNB,
+          tokens.CONE,
+          holders.WBNB,
+          '30000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+    });
+    describe('Multi', () => {
+      it('BNB -> BUSD', async () => {
+        await testE2E(
+          tokens.BNB,
+          tokens.BUSD,
+          holders.BNB,
+          '30000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.multiSwap,
+          network,
+          provider,
+        );
+      });
+      it('BUSD -> BNB', async () => {
+        await testE2E(
+          tokens.BUSD,
+          tokens.BNB,
+          holders.BUSD,
+          '30000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.multiSwap,
+          network,
+          provider,
+        );
+      });
+      it('WBNB -> BUSD', async () => {
+        await testE2E(
+          tokens.WBNB,
+          tokens.BUSD,
+          holders.WBNB,
+          '30000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.multiSwap,
+          network,
+          provider,
+        );
+      });
+    });
+    describe('Mega', () => {
+      it('BNB -> BUSD', async () => {
+        await testE2E(
+          tokens.BNB,
+          tokens.BUSD,
+          holders.BNB,
+          '30000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.megaSwap,
+          network,
+          provider,
+        );
+      });
+      it('BUSD -> BNB', async () => {
+        await testE2E(
+          tokens.BUSD,
+          tokens.BNB,
+          holders.BUSD,
+          '30000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.megaSwap,
+          network,
+          provider,
+        );
+      });
+      it('BNB -> BUSD', async () => {
+        await testE2E(
+          tokens.BNB,
+          tokens.BUSD,
+          holders.BNB,
+          '30000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.megaSwap,
+          network,
+          provider,
+        );
+      });
+    });
+  });
 });

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -389,6 +389,10 @@ export const Tokens: { [network: number]: { [symbol: string]: Token } } = {
       address: '0x23b891e5C62E0955ae2bD185990103928Ab817b3',
       decimals: 18,
     },
+    CONE: {
+      address: '0xA60205802E1B5C6EC1CAFA3cAcd49dFeECe05AC9',
+      decimals: 18,
+    },
   },
   [Network.AVALANCHE]: {
     USDCe: {


### PR DESCRIPTION
This is PR, replacing https://github.com/paraswap/paraswap-dex-lib/pull/170 

# Cone Exchange
https://www.cone.exchange/
### BSC
Solidly (actually Dystopia) fork but with variable fees.
Fee number used as divider.

Fees defaults:
- Stable: 10000 (0,01%) ('1' in uniswap)
- Volatile: 2000 (0,05%) ('5' in uniswap)

But fees may be changed.

### ParaSwapTODO: 
SimpleSwap tests passed, but for Muti and Mega swaps
!!! Cone needs same router like Dystopia, but on BSC network.

See `encodePools` at `cone.ts`
