### PR TITLE
Cone Exchange - Solidly fork

### DIFF
--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -31,7 +31,7 @@ import { DodoV2 } from './dodo-v2';
 import { Smoothy } from './smoothy';
 import { Nerve } from './nerve/nerve';
 import { IDexHelper } from '../dex-helper';
-import { SwapSide, Network } from '../constants';
+import { SwapSide } from '../constants';
 import { Adapters } from '../types';
 import { Lido } from './lido';
 import { Excalibur } from './uniswap-v2/excalibur';
@@ -46,6 +46,7 @@ import Web3 from 'web3';
 import { Solidly } from './solidly/solidly';
 import { Velodrome } from './solidly/forks-override/velodrome';
 import { SpiritSwapV2 } from './solidly/forks-override/spiritSwapV2';
+import { Cone } from './solidly/forks-override/cone';
 
 const LegacyDexes = [
   Curve,
@@ -90,6 +91,7 @@ const Dexes = [
   Solidly,
   SpiritSwapV2,
   Velodrome,
+  Cone,
 ];
 
 export type LegacyDexConstructor = new (

--- a/src/dex/solidly/config.ts
+++ b/src/dex/solidly/config.ts
@@ -58,6 +58,20 @@ export const SolidlyConfig: DexConfigMap<DexParams> = {
       feeCode: 2,
     },
   },
+  Cone: {
+    [Network.BSC]: {
+      subgraphURL: 'https://api.thegraph.com/subgraphs/name/cone-exchange/cone',
+      factoryAddress: '0x0EFc2D2D054383462F2cD72eA2526Ef7687E1016',
+      router: '0x69a457CD13Ee72b0CA1b483aB17C36D80a23422f', // ParaSwap-compatible Router with stable pools support
+      initCode:
+        '04b89f6ddaef769d145acd66e1700a76b1b7c369dfe9558e67ed6495b3b93fe4',
+      // Variable fees. Defaults:
+      // Stable: 10000 (0,01%) ('1' in uniswap)
+      // Volatile: 2000 (0,05%) ('5' in uniswap)
+      poolGasCost: 180 * 1000,
+      feeCode: 0, // variable
+    },
+  },
 };
 
 export const Adapters: Record<number, AdapterMappings> = {
@@ -69,5 +83,9 @@ export const Adapters: Record<number, AdapterMappings> = {
   },
   [Network.OPTIMISM]: {
     [SwapSide.SELL]: [{ name: 'OptimismAdapter01', index: 8 }], // velodrome
+  },
+  [Network.BSC]: {
+    // TODO for ParaSwap: Check what it is right adapter and index for BSC for Cone
+    [SwapSide.SELL]: [{ name: 'BscAdapter01', index: 3 }], // cone
   },
 };

--- a/src/dex/solidly/forks-override/cone.ts
+++ b/src/dex/solidly/forks-override/cone.ts
@@ -1,0 +1,66 @@
+import { Solidly } from '../solidly';
+import { SolidlyPair } from '../types';
+import { Network } from '../../../constants';
+import { IDexHelper } from '../../../dex-helper';
+import { Interface } from '@ethersproject/abi';
+import { SolidlyConfig } from '../config';
+import { getDexKeysWithNetwork } from '../../../utils';
+import _ from 'lodash';
+
+const swapFeeFunctionName = 'swapFee';
+
+const ConePairABI = [
+  {
+    inputs: [],
+    name: swapFeeFunctionName,
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+const conePairIface = new Interface(ConePairABI);
+
+export class Cone extends Solidly {
+  feeFactor = 1e4;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(_.pick(SolidlyConfig, ['Cone']));
+
+  constructor(
+    protected network: Network,
+    protected dexKey: string,
+    protected dexHelper: IDexHelper,
+  ) {
+    super(
+      network,
+      dexKey,
+      dexHelper,
+      true, // dynamic fees
+    );
+  }
+
+  protected getFeesMultiCallData(pair: SolidlyPair) {
+    const callEntry = {
+      target: pair.exchange!,
+      callData: conePairIface.encodeFunctionData(swapFeeFunctionName, []),
+    };
+    const callDecoder = (values: any[]) => {
+      const fees = parseInt(
+        conePairIface
+          .decodeFunctionResult(swapFeeFunctionName, values)[0]
+          .toString(),
+      );
+      if (!fees) return 0;
+
+      // noinspection UnnecessaryLocalVariableJS
+      const feeCode = Math.ceil(this.feeFactor / fees);
+      return feeCode;
+    };
+
+    return {
+      callEntry,
+      callDecoder,
+    };
+  }
+}

--- a/src/dex/solidly/solidly-e2e.test.ts
+++ b/src/dex/solidly/solidly-e2e.test.ts
@@ -610,4 +610,205 @@ describe('Solidly E2E', () => {
       });
     });
   });
+
+  describe('BSC', () => {
+    const network = Network.BSC;
+    const tokens = Tokens[network];
+    const holders = Holders[network];
+    const provider = new StaticJsonRpcProvider(
+      generateConfig(network).privateHttpProvider,
+      network,
+    );
+
+    describe('Cone', () => {
+      const dexKey = 'Cone';
+      const usdAmount = '1000000';
+
+      describe('Cone UniswapV2 Pools', () => {
+        const bnbAmount = '1000000000000000000';
+
+        describe('simpleSwap', () => {
+          it('BNB -> TOKEN', async () => {
+            await testE2E(
+              tokens.BNB,
+              tokens.BUSD,
+              holders.BNB,
+              bnbAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.simpleSwap,
+              network,
+              provider,
+            );
+          });
+
+          it('Token -> BNB', async () => {
+            await testE2E(
+              tokens.USDT,
+              tokens.BNB,
+              holders.USDT,
+              usdAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.simpleSwap,
+              network,
+              provider,
+            );
+          });
+
+          it('Token -> Token', async () => {
+            await testE2E(
+              tokens.WBNB,
+              tokens.CONE,
+              holders.WBNB,
+              bnbAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.simpleSwap,
+              network,
+              provider,
+            );
+          });
+        });
+
+        describe('multiSwap', () => {
+          it('BNB -> TOKEN', async () => {
+            await testE2E(
+              tokens.BNB,
+              tokens.BUSD,
+              holders.BNB,
+              bnbAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.multiSwap,
+              network,
+              provider,
+            );
+          });
+
+          it('Token -> BNB', async () => {
+            await testE2E(
+              tokens.USDT,
+              tokens.BNB,
+              holders.USDT,
+              usdAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.multiSwap,
+              network,
+              provider,
+            );
+          });
+
+          it('Token -> Token', async () => {
+            await testE2E(
+              tokens.WBNB,
+              tokens.CONE,
+              holders.WBNB,
+              bnbAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.multiSwap,
+              network,
+              provider,
+            );
+          });
+        });
+
+        describe('megaSwap', () => {
+          it('BNB -> TOKEN', async () => {
+            await testE2E(
+              tokens.USDT,
+              tokens.BNB,
+              holders.USDT,
+              usdAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.megaSwap,
+              network,
+              provider,
+            );
+          });
+
+          it('Token -> BNB', async () => {
+            await testE2E(
+              tokens.USDT,
+              tokens.BNB,
+              holders.USDT,
+              usdAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.megaSwap,
+              network,
+              provider,
+            );
+          });
+
+          it('Token -> Token', async () => {
+            await testE2E(
+              tokens.WBNB,
+              tokens.CONE,
+              holders.WBNB,
+              bnbAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.megaSwap,
+              network,
+              provider,
+            );
+          });
+        });
+      });
+
+      describe('Cone Stable Pools', () => {
+        describe('simpleSwap', () => {
+          it('Token -> Token', async () => {
+            await testE2E(
+              tokens.USDC,
+              tokens.USDT,
+              holders.USDC,
+              usdAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.simpleSwap,
+              network,
+              provider,
+            );
+          });
+        });
+
+        describe('multiSwap', () => {
+          it('Token -> Token', async () => {
+            await testE2E(
+              tokens.USDC,
+              tokens.USDT,
+              holders.USDC,
+              usdAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.multiSwap,
+              network,
+              provider,
+            );
+          });
+        });
+
+        describe('megaSwap', () => {
+          it('Token -> Token', async () => {
+            await testE2E(
+              tokens.USDC,
+              tokens.USDT,
+              holders.USDC,
+              usdAmount,
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.megaSwap,
+              network,
+              provider,
+            );
+          });
+        });
+      });
+    });
+  });
 });

--- a/src/dex/solidly/solidly-integration.test.ts
+++ b/src/dex/solidly/solidly-integration.test.ts
@@ -10,8 +10,10 @@ import { Tokens } from '../../../tests/constants-e2e';
 import { Interface, Result } from '@ethersproject/abi';
 import solidlyPairABI from '../../abi/solidly/SolidlyPair.json';
 import { SpiritSwapV2 } from './forks-override/spiritSwapV2';
+import { Cone } from './forks-override/cone';
 
 const amounts18 = [0n, BI_POWS[18], 2000000000000000000n];
+const amounts6 = [0n, BI_POWS[6], 2000000n];
 
 function getReaderCalldata(
   exchangeAddress: string,
@@ -476,6 +478,146 @@ describe('Solidly integration tests', () => {
 
         it('getTopPoolsForToken', async function () {
           const poolLiquidity = await dystopia.getTopPoolsForToken(
+            tokenA.address,
+            10,
+          );
+          console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
+
+          checkPoolsLiquidity(poolLiquidity, tokenA.address, dexKey);
+        });
+      });
+    });
+  });
+
+  describe('BSC', () => {
+    const network = Network.BSC;
+    const dexHelper = new DummyDexHelper(network);
+    const checkOnChainPricing = constructCheckOnChainPricing(dexHelper);
+
+    describe('Cone', function () {
+      const dexKey = 'Cone';
+      const cone = new Cone(network, dexKey, dexHelper);
+
+      describe('UniswapV2 like pool', function () {
+        const TokenASymbol = 'WBNB';
+        const tokenA = Tokens[network][TokenASymbol];
+        const TokenBSymbol = 'BUSD';
+        const tokenB = Tokens[network][TokenBSymbol];
+
+        const amounts = amounts18;
+
+        it('getPoolIdentifiers and getPricesVolume', async function () {
+          const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+          const pools = await cone.getPoolIdentifiers(
+            tokenA,
+            tokenB,
+            SwapSide.SELL,
+            blocknumber,
+          );
+          console.log(
+            `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+            pools,
+          );
+
+          expect(pools.length).toBeGreaterThan(0);
+
+          const poolPrices = await cone.getPricesVolume(
+            tokenA,
+            tokenB,
+            amounts,
+            SwapSide.SELL,
+            blocknumber,
+            pools,
+          );
+          console.log(
+            `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+            poolPrices,
+          );
+
+          expect(poolPrices).not.toBeNull();
+          checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+          // Check if onchain pricing equals to calculated ones
+
+          for (const i in poolPrices || []) {
+            await checkOnChainPricing(
+              cone,
+              'getAmountOut',
+              blocknumber,
+              poolPrices![i].prices,
+              poolPrices![i].poolAddresses![0],
+              tokenA.address,
+              amounts,
+            );
+          }
+        });
+
+        it('getTopPoolsForToken', async function () {
+          const poolLiquidity = await cone.getTopPoolsForToken(
+            tokenA.address,
+            10,
+          );
+          console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
+
+          checkPoolsLiquidity(poolLiquidity, tokenA.address, dexKey);
+        });
+      });
+
+      describe('Curve like stable pool', function () {
+        const TokenASymbol = 'USDT';
+        const tokenA = Tokens[network][TokenASymbol];
+        const TokenBSymbol = 'BUSD';
+        const tokenB = Tokens[network][TokenBSymbol];
+
+        const amounts = amounts6;
+
+        it('getPoolIdentifiers and getPricesVolume', async function () {
+          const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+          const pools = await cone.getPoolIdentifiers(
+            tokenA,
+            tokenB,
+            SwapSide.SELL,
+            blocknumber,
+          );
+          console.log(
+            `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+            pools,
+          );
+
+          expect(pools.length).toBeGreaterThan(0);
+
+          const poolPrices = await cone.getPricesVolume(
+            tokenA,
+            tokenB,
+            amounts,
+            SwapSide.SELL,
+            blocknumber,
+            pools,
+          );
+          console.log(
+            `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+            poolPrices,
+          );
+
+          expect(poolPrices).not.toBeNull();
+          checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+          // Check if onchain pricing equals to calculated ones
+          for (const i in poolPrices || []) {
+            await checkOnChainPricing(
+              cone,
+              'getAmountOut',
+              blocknumber,
+              poolPrices![i].prices,
+              poolPrices![i].poolAddresses![0],
+              tokenA.address,
+              amounts,
+            );
+          }
+        });
+
+        it('getTopPoolsForToken', async function () {
+          const poolLiquidity = await cone.getTopPoolsForToken(
             tokenA.address,
             10,
           );

--- a/src/dex/solidly/solidly.ts
+++ b/src/dex/solidly/solidly.ts
@@ -32,7 +32,9 @@ export class Solidly extends UniswapV2 {
   volatileFee?: number;
 
   public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
-    getDexKeysWithNetwork(_.omit(SolidlyConfig, ['Velodrome', 'SpiritSwapV2']));
+    getDexKeysWithNetwork(
+      _.omit(SolidlyConfig, ['Velodrome', 'SpiritSwapV2', 'Cone']),
+    );
 
   constructor(
     protected network: Network,

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -389,6 +389,10 @@ export const Tokens: { [network: number]: { [symbol: string]: Token } } = {
       address: '0x23b891e5C62E0955ae2bD185990103928Ab817b3',
       decimals: 18,
     },
+    CONE: {
+      address: '0xA60205802E1B5C6EC1CAFA3cAcd49dFeECe05AC9',
+      decimals: 18,
+    },
   },
   [Network.AVALANCHE]: {
     USDCe: {


### PR DESCRIPTION
This is PR, replacing https://github.com/paraswap/paraswap-dex-lib/pull/176

# Cone Exchange
https://www.cone.exchange/
### BSC
Solidly (actually Dystopia) fork but with variable fees.
Fee number used as divider.

Fees defaults:
- Stable: 10000 (0,01%) ('1' in uniswap)
- Volatile: 2000 (0,05%) ('5' in uniswap)

But fees may be changed.

### ParaSwapTODO: 
SimpleSwap tests passed, but for Muti and Mega swaps 
Cone need to set up right BSC Adapter and index at the `solidly\config.ts`

