### PR TITLE
Added Metavault.Trade Dex

### DIFF
--- a/src/abi/metavault-trade/fast-price-events.json
+++ b/src/abi/metavault-trade/fast-price-events.json
@@ -1,0 +1,108 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "priceFeed",
+        "type": "address"
+      }
+    ],
+    "name": "PriceUpdate",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_price",
+        "type": "uint256"
+      }
+    ],
+    "name": "emitPriceEvent",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gov",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isPriceFeed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_gov",
+        "type": "address"
+      }
+    ],
+    "name": "setGov",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_priceFeed",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isPriceFeed",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsPriceFeed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/abi/metavault-trade/fast-price-events.json
+++ b/src/abi/metavault-trade/fast-price-events.json
@@ -26,16 +26,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "_token",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_price",
-        "type": "uint256"
-      }
+      { "internalType": "address", "name": "_token", "type": "address" },
+      { "internalType": "uint256", "name": "_price", "type": "uint256" }
     ],
     "name": "emitPriceEvent",
     "outputs": [],
@@ -45,42 +37,20 @@
   {
     "inputs": [],
     "name": "gov",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
     "name": "isPriceFeed",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
     "stateMutability": "view",
     "type": "function"
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "_gov",
-        "type": "address"
-      }
+      { "internalType": "address", "name": "_gov", "type": "address" }
     ],
     "name": "setGov",
     "outputs": [],
@@ -89,16 +59,8 @@
   },
   {
     "inputs": [
-      {
-        "internalType": "address",
-        "name": "_priceFeed",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_isPriceFeed",
-        "type": "bool"
-      }
+      { "internalType": "address", "name": "_priceFeed", "type": "address" },
+      { "internalType": "bool", "name": "_isPriceFeed", "type": "bool" }
     ],
     "name": "setIsPriceFeed",
     "outputs": [],

--- a/src/abi/metavault-trade/fast-price-feed.json
+++ b/src/abi/metavault-trade/fast-price-feed.json
@@ -1,0 +1,788 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_priceDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minBlockInterval",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxDeviationBasisPoints",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_fastPriceEvents",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenManager",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_positionRouter",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      }
+    ],
+    "name": "DisableFastPrice",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "signer",
+        "type": "address"
+      }
+    ],
+    "name": "EnableFastPrice",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BASIS_POINTS_DIVISOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_PRICE_DURATION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_BITMASK",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disableFastPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "disableFastPriceVoteCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "disableFastPriceVotes",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "enableFastPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fastPriceEvents",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "favorFastPrice",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_refPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_maximise",
+        "type": "bool"
+      }
+    ],
+    "name": "getPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gov",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minAuthorizations",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_signers",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_updaters",
+        "type": "address[]"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isInitialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isSigner",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isSpreadEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isUpdater",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastUpdatedAt",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastUpdatedBlock",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxDeviationBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxTimeDeviation",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minAuthorizations",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minBlockInterval",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "positionRouter",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceDuration",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "prices",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_priceBitArray",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "setCompactedPrices",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_fastPriceEvents",
+        "type": "address"
+      }
+    ],
+    "name": "setFastPriceEvents",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_gov",
+        "type": "address"
+      }
+    ],
+    "name": "setGov",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isSpreadEnabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsSpreadEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_lastUpdatedAt",
+        "type": "uint256"
+      }
+    ],
+    "name": "setLastUpdatedAt",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_maxDeviationBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxDeviationBasisPoints",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_maxTimeDeviation",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxTimeDeviation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minAuthorizations",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMinAuthorizations",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minBlockInterval",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMinBlockInterval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_priceDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPriceDuration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_prices",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPrices",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_priceBits",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPricesWithBits",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_priceBits",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_timestamp",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_endIndexForIncreasePositions",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_endIndexForDecreasePositions",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPricesWithBitsAndExecute",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isActive",
+        "type": "bool"
+      }
+    ],
+    "name": "setSigner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenManager",
+        "type": "address"
+      }
+    ],
+    "name": "setTokenManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_tokenPrecisions",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "setTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isActive",
+        "type": "bool"
+      }
+    ],
+    "name": "setUpdater",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_volBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "setVolBasisPoints",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "tokenManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenPrecisions",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokens",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "volBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abi/metavault-trade/fast-price-feed.json
+++ b/src/abi/metavault-trade/fast-price-feed.json
@@ -8,6 +8,11 @@
       },
       {
         "internalType": "uint256",
+        "name": "_maxPriceUpdateDelay",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "_minBlockInterval",
         "type": "uint256"
       },
@@ -62,8 +67,134 @@
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "refPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fastPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cumulativeRefDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cumulativeFastDelta",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxCumulativeDeltaDiffExceeded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "refPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fastPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cumulativeRefDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cumulativeFastDelta",
+        "type": "uint256"
+      }
+    ],
+    "name": "PriceData",
+    "type": "event"
+  },
+  {
     "inputs": [],
     "name": "BASIS_POINTS_DIVISOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "BITMASK_32",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CUMULATIVE_DELTA_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_CUMULATIVE_FAST_DELTA",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_CUMULATIVE_REF_DELTA",
     "outputs": [
       {
         "internalType": "uint256",
@@ -89,7 +220,7 @@
   },
   {
     "inputs": [],
-    "name": "PRICE_BITMASK",
+    "name": "MAX_REF_PRICE",
     "outputs": [
       {
         "internalType": "uint256",
@@ -173,7 +304,13 @@
     "type": "function"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
     "name": "favorFastPrice",
     "outputs": [
       {
@@ -205,6 +342,40 @@
     ],
     "name": "getPrice",
     "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getPriceData",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
       {
         "internalType": "uint256",
         "name": "",
@@ -341,8 +512,40 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxCumulativeDeltaDiffs",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "maxDeviationBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxPriceUpdateDelay",
     "outputs": [
       {
         "internalType": "uint256",
@@ -400,6 +603,53 @@
         "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "priceData",
+    "outputs": [
+      {
+        "internalType": "uint160",
+        "name": "refPrice",
+        "type": "uint160"
+      },
+      {
+        "internalType": "uint32",
+        "name": "refTime",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "cumulativeRefDelta",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint32",
+        "name": "cumulativeFastDelta",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceDataInterval",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -510,12 +760,43 @@
   {
     "inputs": [
       {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_maxCumulativeDeltaDiffs",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "setMaxCumulativeDeltaDiffs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint256",
         "name": "_maxDeviationBasisPoints",
         "type": "uint256"
       }
     ],
     "name": "setMaxDeviationBasisPoints",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_maxPriceUpdateDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxPriceUpdateDelay",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -555,6 +836,19 @@
       }
     ],
     "name": "setMinBlockInterval",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_priceDataInterval",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPriceDataInterval",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -634,6 +928,16 @@
         "internalType": "uint256",
         "name": "_endIndexForDecreasePositions",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxIncreasePositions",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxDecreasePositions",
+        "type": "uint256"
       }
     ],
     "name": "setPricesWithBitsAndExecute",
@@ -655,6 +959,32 @@
       }
     ],
     "name": "setSigner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_spreadBasisPointsIfChainError",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSpreadBasisPointsIfChainError",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_spreadBasisPointsIfInactive",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSpreadBasisPointsIfInactive",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -711,14 +1041,40 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "_vaultPriceFeed",
+        "type": "address"
+      }
+    ],
+    "name": "setVaultPriceFeed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "spreadBasisPointsIfChainError",
+    "outputs": [
+      {
         "internalType": "uint256",
-        "name": "_volBasisPoints",
+        "name": "",
         "type": "uint256"
       }
     ],
-    "name": "setVolBasisPoints",
-    "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "spreadBasisPointsIfInactive",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -774,12 +1130,12 @@
   },
   {
     "inputs": [],
-    "name": "volBasisPoints",
+    "name": "vaultPriceFeed",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "address",
         "name": "",
-        "type": "uint256"
+        "type": "address"
       }
     ],
     "stateMutability": "view",

--- a/src/abi/metavault-trade/reader.json
+++ b/src/abi/metavault-trade/reader.json
@@ -1,0 +1,623 @@
+[
+  {
+    "inputs": [],
+    "name": "BASIS_POINTS_DIVISOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "POSITION_PROPS_LENGTH",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "USDM_DECIMALS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAmountOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "getFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getFees",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_weth",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdmAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getFullVaultTokenInfo",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_weth",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getFundingRates",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVault",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenOut",
+        "type": "address"
+      }
+    ],
+    "name": "getMaxAmountIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_factory",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getPairInfo",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_collateralTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_indexTokens",
+        "type": "address[]"
+      },
+      {
+        "internalType": "bool[]",
+        "name": "_isLong",
+        "type": "bool[]"
+      }
+    ],
+    "name": "getPositions",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVaultPriceFeed",
+        "name": "_priceFeed",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getPrices",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_yieldTrackers",
+        "type": "address[]"
+      }
+    ],
+    "name": "getStakingInfo",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getTokenBalances",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getTokenBalancesWithSupplies",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_excludedAccounts",
+        "type": "address[]"
+      }
+    ],
+    "name": "getTokenSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_accounts",
+        "type": "address[]"
+      }
+    ],
+    "name": "getTotalBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_yieldTokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getTotalStaked",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_weth",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdmAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getVaultTokenInfo",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_vault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_weth",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdmAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "getVaultTokenInfoV2",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_vesters",
+        "type": "address[]"
+      }
+    ],
+    "name": "getVestingInfo",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gov",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hasMaxGlobalShortSizes",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_hasMaxGlobalShortSizes",
+        "type": "bool"
+      }
+    ],
+    "name": "setConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_gov",
+        "type": "address"
+      }
+    ],
+    "name": "setGov",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/abi/metavault-trade/vault-price-feed.json
+++ b/src/abi/metavault-trade/vault-price-feed.json
@@ -1,0 +1,888 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "BASIS_POINTS_DIVISOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_ADJUSTMENT_BASIS_POINTS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_ADJUSTMENT_INTERVAL",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_SPREAD_BASIS_POINTS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ONE_USD",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "adjustmentBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bnb",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bnbBusd",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "btc",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "btcBnb",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "chainlinkFlags",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eth",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ethBnb",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "favorPrimaryPrice",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getAmmPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_maximise",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_primaryPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAmmPriceV2",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pair",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_divByReserve0",
+        "type": "bool"
+      }
+    ],
+    "name": "getPairPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_maximise",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_includeAmmPrice",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "name": "getPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_maximise",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_includeAmmPrice",
+        "type": "bool"
+      }
+    ],
+    "name": "getPriceV1",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_maximise",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_includeAmmPrice",
+        "type": "bool"
+      }
+    ],
+    "name": "getPriceV2",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_maximise",
+        "type": "bool"
+      }
+    ],
+    "name": "getPrimaryPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_referencePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_maximise",
+        "type": "bool"
+      }
+    ],
+    "name": "getSecondaryPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gov",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isAdjustmentAdditive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isAmmEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isSecondaryPriceEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "lastAdjustmentTimings",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxStrictPriceDeviation",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "priceDecimals",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "priceFeeds",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceSampleSpace",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "secondaryPriceFeed",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isAdditive",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_adjustmentBps",
+        "type": "uint256"
+      }
+    ],
+    "name": "setAdjustment",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_chainlinkFlags",
+        "type": "address"
+      }
+    ],
+    "name": "setChainlinkFlags",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_favorPrimaryPrice",
+        "type": "bool"
+      }
+    ],
+    "name": "setFavorPrimaryPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_gov",
+        "type": "address"
+      }
+    ],
+    "name": "setGov",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isEnabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsAmmEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isEnabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsSecondaryPriceEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_maxStrictPriceDeviation",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxStrictPriceDeviation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_bnbBusd",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_ethBnb",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_btcBnb",
+        "type": "address"
+      }
+    ],
+    "name": "setPairs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_priceSampleSpace",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPriceSampleSpace",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_secondaryPriceFeed",
+        "type": "address"
+      }
+    ],
+    "name": "setSecondaryPriceFeed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_spreadBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSpreadBasisPoints",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_spreadThresholdBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "setSpreadThresholdBasisPoints",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_priceFeed",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_priceDecimals",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isStrictStable",
+        "type": "bool"
+      }
+    ],
+    "name": "setTokenConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_btc",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_eth",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_bnb",
+        "type": "address"
+      }
+    ],
+    "name": "setTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_useV2Pricing",
+        "type": "bool"
+      }
+    ],
+    "name": "setUseV2Pricing",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "spreadBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "spreadThresholdBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "strictStableTokens",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "useV2Pricing",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abi/metavault-trade/vault-price-feed.json
+++ b/src/abi/metavault-trade/vault-price-feed.json
@@ -103,97 +103,6 @@
   },
   {
     "inputs": [],
-    "name": "bnb",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "bnbBusd",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "btc",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "btcBnb",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "chainlinkFlags",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "eth",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ethBnb",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
     "name": "favorPrimaryPrice",
     "outputs": [
       {
@@ -213,60 +122,7 @@
         "type": "address"
       }
     ],
-    "name": "getAmmPrice",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_token",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_maximise",
-        "type": "bool"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_primaryPrice",
-        "type": "uint256"
-      }
-    ],
-    "name": "getAmmPriceV2",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_pair",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_divByReserve0",
-        "type": "bool"
-      }
-    ],
-    "name": "getPairPrice",
+    "name": "getLatestPrimaryPrice",
     "outputs": [
       {
         "internalType": "uint256",
@@ -291,7 +147,7 @@
       },
       {
         "internalType": "bool",
-        "name": "_includeAmmPrice",
+        "name": "",
         "type": "bool"
       },
       {
@@ -322,43 +178,9 @@
         "internalType": "bool",
         "name": "_maximise",
         "type": "bool"
-      },
-      {
-        "internalType": "bool",
-        "name": "_includeAmmPrice",
-        "type": "bool"
       }
     ],
     "name": "getPriceV1",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_token",
-        "type": "address"
-      },
-      {
-        "internalType": "bool",
-        "name": "_maximise",
-        "type": "bool"
-      },
-      {
-        "internalType": "bool",
-        "name": "_includeAmmPrice",
-        "type": "bool"
-      }
-    ],
-    "name": "getPriceV2",
     "outputs": [
       {
         "internalType": "uint256",
@@ -444,19 +266,6 @@
       }
     ],
     "name": "isAdjustmentAdditive",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "isAmmEnabled",
     "outputs": [
       {
         "internalType": "bool",
@@ -602,19 +411,6 @@
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "_chainlinkFlags",
-        "type": "address"
-      }
-    ],
-    "name": "setChainlinkFlags",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
         "internalType": "bool",
         "name": "_favorPrimaryPrice",
         "type": "bool"
@@ -646,19 +442,6 @@
         "type": "bool"
       }
     ],
-    "name": "setIsAmmEnabled",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bool",
-        "name": "_isEnabled",
-        "type": "bool"
-      }
-    ],
     "name": "setIsSecondaryPriceEnabled",
     "outputs": [],
     "stateMutability": "nonpayable",
@@ -673,29 +456,6 @@
       }
     ],
     "name": "setMaxStrictPriceDeviation",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_bnbBusd",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_ethBnb",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_btcBnb",
-        "type": "address"
-      }
-    ],
-    "name": "setPairs",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -789,42 +549,6 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "_btc",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_eth",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_bnb",
-        "type": "address"
-      }
-    ],
-    "name": "setTokens",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bool",
-        "name": "_useV2Pricing",
-        "type": "bool"
-      }
-    ],
-    "name": "setUseV2Pricing",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
         "name": "",
         "type": "address"
       }
@@ -862,19 +586,6 @@
       }
     ],
     "name": "strictStableTokens",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "useV2Pricing",
     "outputs": [
       {
         "internalType": "bool",

--- a/src/abi/metavault-trade/vault.json
+++ b/src/abi/metavault-trade/vault.json
@@ -1,0 +1,3213 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "usdmAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "BuyUSDM",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "averagePrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "entryFundingRate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reserveAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "realisedPnl",
+        "type": "int256"
+      }
+    ],
+    "name": "ClosePosition",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeUsd",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeTokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollectMarginFees",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeUsd",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeTokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "CollectSwapFees",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DecreaseGuaranteedUsd",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DecreasePoolAmount",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "collateralToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isLong",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "name": "DecreasePosition",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DecreaseReservedAmount",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DecreaseUsdmAmount",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "DirectPoolDeposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "IncreaseGuaranteedUsd",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "IncreasePoolAmount",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "collateralToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateralDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isLong",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fee",
+        "type": "uint256"
+      }
+    ],
+    "name": "IncreasePosition",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "IncreaseReservedAmount",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "IncreaseUsdmAmount",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "collateralToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "indexToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isLong",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reserveAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "realisedPnl",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "markPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "LiquidatePosition",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "usdmAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tokenAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "SellUSDM",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOutAfterFees",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "feeBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fundingRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdateFundingRate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "hasProfit",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "delta",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdatePnl",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "key",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "averagePrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "entryFundingRate",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reserveAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "realisedPnl",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "markPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "UpdatePosition",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BASIS_POINTS_DIVISOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "FUNDING_RATE_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_FEE_BASIS_POINTS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_FUNDING_RATE_FACTOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_LIQUIDATION_FEE_USD",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_FUNDING_RATE_INTERVAL",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_LEVERAGE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PRICE_PRECISION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "USDM_DECIMALS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_router",
+        "type": "address"
+      }
+    ],
+    "name": "addRouter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenDiv",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenMul",
+        "type": "address"
+      }
+    ],
+    "name": "adjustForDecimals",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "allWhitelistedTokens",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "allWhitelistedTokensLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "approvedRouters",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "bufferAmounts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      }
+    ],
+    "name": "buyUSDM",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "clearTokenConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "cumulativeFundingRates",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_collateralDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      }
+    ],
+    "name": "decreasePosition",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "directPoolDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "errorController",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "errors",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "feeReserves",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fundingInterval",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fundingRateFactor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_size",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_averagePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_lastIncreasedTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "getDelta",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      }
+    ],
+    "name": "getEntryFundingRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdmDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_feeBasisPoints",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_taxBasisPoints",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_increment",
+        "type": "bool"
+      }
+    ],
+    "name": "getFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_size",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_entryFundingRate",
+        "type": "uint256"
+      }
+    ],
+    "name": "getFundingFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getGlobalShortDelta",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getMaxPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getMinPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_size",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_averagePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_nextPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_lastIncreasedTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNextAveragePrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getNextFundingRate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_nextPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      }
+    ],
+    "name": "getNextGlobalShortAveragePrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      }
+    ],
+    "name": "getPosition",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      }
+    ],
+    "name": "getPositionDelta",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPositionFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      }
+    ],
+    "name": "getPositionKey",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      }
+    ],
+    "name": "getPositionLeverage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdmAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRedemptionAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getRedemptionCollateral",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getRedemptionCollateralUsd",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getTargetUsdmAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "getUtilisation",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "globalShortAveragePrices",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "globalShortSizes",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gov",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "guaranteedUsd",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hasDynamicFees",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "inManagerMode",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "inPrivateLiquidationMode",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "includeAmmPrice",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_sizeDelta",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      }
+    ],
+    "name": "increasePosition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_router",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_usdm",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_priceFeed",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_liquidationFeeUsd",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_fundingRateFactor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_stableFundingRateFactor",
+        "type": "uint256"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isInitialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isLeverageEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isLiquidator",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isManager",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isSwapEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "lastFundingTimes",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "_feeReceiver",
+        "type": "address"
+      }
+    ],
+    "name": "liquidatePosition",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "liquidationFeeUsd",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "marginFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxGasPrice",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxGlobalShortSizes",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxLeverage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "maxUsdmAmounts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "minProfitBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minProfitTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintBurnFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "poolAmounts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "positions",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "size",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "collateral",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "averagePrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "entryFundingRate",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserveAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int256",
+        "name": "realisedPnl",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lastIncreasedTime",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceFeed",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_router",
+        "type": "address"
+      }
+    ],
+    "name": "removeRouter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "reservedAmounts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "router",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      }
+    ],
+    "name": "sellUSDM",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setBufferAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_errorCode",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "_error",
+        "type": "string"
+      }
+    ],
+    "name": "setError",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_errorController",
+        "type": "address"
+      }
+    ],
+    "name": "setErrorController",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_taxBasisPoints",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_stableTaxBasisPoints",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_mintBurnFeeBasisPoints",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_swapFeeBasisPoints",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_stableSwapFeeBasisPoints",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_marginFeeBasisPoints",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_liquidationFeeUsd",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minProfitTime",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_hasDynamicFees",
+        "type": "bool"
+      }
+    ],
+    "name": "setFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_fundingInterval",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_fundingRateFactor",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_stableFundingRateFactor",
+        "type": "uint256"
+      }
+    ],
+    "name": "setFundingRate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_gov",
+        "type": "address"
+      }
+    ],
+    "name": "setGov",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_inManagerMode",
+        "type": "bool"
+      }
+    ],
+    "name": "setInManagerMode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_inPrivateLiquidationMode",
+        "type": "bool"
+      }
+    ],
+    "name": "setInPrivateLiquidationMode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isLeverageEnabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsLeverageEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_isSwapEnabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsSwapEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_liquidator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isActive",
+        "type": "bool"
+      }
+    ],
+    "name": "setLiquidator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_manager",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isManager",
+        "type": "bool"
+      }
+    ],
+    "name": "setManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_maxGasPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxGasPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxGlobalShortSize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_maxLeverage",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxLeverage",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_priceFeed",
+        "type": "address"
+      }
+    ],
+    "name": "setPriceFeed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenDecimals",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenWeight",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minProfitBps",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxUsdmAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isStable",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isShortable",
+        "type": "bool"
+      }
+    ],
+    "name": "setTokenConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "setUsdmAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IVaultUtils",
+        "name": "_vaultUtils",
+        "type": "address"
+      }
+    ],
+    "name": "setVaultUtils",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "shortableTokens",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stableFundingRateFactor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stableSwapFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "stableTaxBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "stableTokens",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      }
+    ],
+    "name": "swap",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "swapFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "taxBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "tokenBalances",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "tokenDecimals",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tokenAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenToUsdMin",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "tokenWeights",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalTokenWeights",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      }
+    ],
+    "name": "updateCumulativeFundingRate",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_newVault",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "upgradeVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_price",
+        "type": "uint256"
+      }
+    ],
+    "name": "usdToToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "usdToTokenMax",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_usdAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "usdToTokenMin",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "usdm",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "usdmAmounts",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "useSwapPricing",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_collateralToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_indexToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_isLong",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "_raise",
+        "type": "bool"
+      }
+    ],
+    "name": "validateLiquidation",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vaultUtils",
+    "outputs": [
+      {
+        "internalType": "contract IVaultUtils",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "whitelistedTokenCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "whitelistedTokens",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_receiver",
+        "type": "address"
+      }
+    ],
+    "name": "withdrawFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -49,6 +49,7 @@ import { Velodrome } from './solidly/forks-override/velodrome';
 import { SpiritSwapV2 } from './solidly/forks-override/spiritSwapV2';
 import { Synthetix } from './synthetix/synthetix';
 import { Cone } from './solidly/forks-override/cone';
+import { MetavaultTrade } from './metavault-trade/metavault-trade';
 
 const LegacyDexes = [
   Curve,
@@ -96,6 +97,7 @@ const Dexes = [
   Velodrome,
   Cone,
   Synthetix,
+  MetavaultTrade,
 ];
 
 export type LegacyDexConstructor = new (

--- a/src/dex/metavault-trade/config.ts
+++ b/src/dex/metavault-trade/config.ts
@@ -5,27 +5,18 @@ import { Network, SwapSide } from '../../constants';
 export const MetavaultTradeConfig: DexConfigMap<DexParams> = {
   MetavaultTrade: {
     [Network.POLYGON]: {
-      vault: '0x32848e2d3aecfa7364595609fb050a301050a6b4',
-      reader: '0x01dd8b434a83cbddfa24f2ef1fe2d6920ca03734',
-      priceFeed: '0xb022b0353fe4c4af6fb3f5b1243a8dA8a12E7c42',
-      fastPriceFeed: '0x44ea6da1cd01899b0f4f17a09cd89eda49eb2b0a',
-      fastPriceEvents: '0xac68262df02052f7a22a4251f13447c5e2f35db6',
-      usdm: '0x533403a3346ca31d67c380917ffaf185c24e7333',
+      vault: '0x32848E2d3aeCFA7364595609FB050A301050A6B4',
+      reader: '0x01dd8B434A83cbdDFa24f2ef1fe2D6920ca03734',
+      priceFeed: '0x133f4D5e703d68eEf3Ea22037C410F042C1642b2',
+      fastPriceFeed: '0xf21bd514bAcBAd2559e41b1819838eE0Dd6ac8F0',
+      fastPriceEvents: '0xac68262DF02052F7A22a4251F13447C5e2f35db6',
+      usdm: '0x533403a3346cA31D67c380917ffaF185c24e7333',
     },
   },
 };
 
-export const Adapters: {
-  [chainId: number]: {
-    [side: string]: { name: string; index: number }[] | null;
-  };
-} = {
+export const Adapters: Record<number, AdapterMappings> = {
   [Network.POLYGON]: {
-    [SwapSide.SELL]: [
-      {
-        name: 'NEW_ADAPTER_HERE', // TODO: New adaptor which contains MetavaultTrade's Swap Route should come here
-        index: 1,
-      },
-    ],
+    [SwapSide.SELL]: [{ name: 'NEW_ADAPTER_COME_HERE', index: 13 }],
   },
 };

--- a/src/dex/metavault-trade/config.ts
+++ b/src/dex/metavault-trade/config.ts
@@ -1,0 +1,31 @@
+import { DexParams } from './types';
+import { DexConfigMap, AdapterMappings } from '../../types';
+import { Network, SwapSide } from '../../constants';
+
+export const MetavaultTradeConfig: DexConfigMap<DexParams> = {
+  MetavaultTrade: {
+    [Network.POLYGON]: {
+      vault: '0x32848e2d3aecfa7364595609fb050a301050a6b4',
+      reader: '0x01dd8b434a83cbddfa24f2ef1fe2d6920ca03734',
+      priceFeed: '0xb022b0353fe4c4af6fb3f5b1243a8dA8a12E7c42',
+      fastPriceFeed: '0x44ea6da1cd01899b0f4f17a09cd89eda49eb2b0a',
+      fastPriceEvents: '0xac68262df02052f7a22a4251f13447c5e2f35db6',
+      usdm: '0x533403a3346ca31d67c380917ffaf185c24e7333',
+    },
+  },
+};
+
+export const Adapters: {
+  [chainId: number]: {
+    [side: string]: { name: string; index: number }[] | null;
+  };
+} = {
+  [Network.POLYGON]: {
+    [SwapSide.SELL]: [
+      {
+        name: 'NEW_ADAPTER_HERE', // TODO: New adaptor which contains MetavaultTrade's Swap Route should come here...
+        index: 1,
+      },
+    ],
+  },
+};

--- a/src/dex/metavault-trade/config.ts
+++ b/src/dex/metavault-trade/config.ts
@@ -23,7 +23,7 @@ export const Adapters: {
   [Network.POLYGON]: {
     [SwapSide.SELL]: [
       {
-        name: 'NEW_ADAPTER_HERE', // TODO: New adaptor which contains MetavaultTrade's Swap Route should come here...
+        name: 'NEW_ADAPTER_HERE', // TODO: New adaptor which contains MetavaultTrade's Swap Route should come here
         index: 1,
       },
     ],

--- a/src/dex/metavault-trade/fast-price-feed.ts
+++ b/src/dex/metavault-trade/fast-price-feed.ts
@@ -1,0 +1,231 @@
+import _ from 'lodash';
+import { Interface } from '@ethersproject/abi';
+import { DeepReadonly } from 'ts-essentials';
+import { PartialEventSubscriber } from '../../composed-event-subscriber';
+import {
+  Address,
+  MultiCallInput,
+  MultiCallOutput,
+  Logger,
+  Log,
+  BlockHeader,
+} from '../../types';
+import { FastPriceFeedConfig, FastPriceFeedState } from './types';
+import FastPriceFeedAbi from '../../abi/metavault-trade/fast-price-feed.json';
+import FastPriceEventsAbi from '../../abi/metavault-trade/fast-price-events.json';
+import { Lens } from '../../lens';
+
+export class FastPriceFeed<State> extends PartialEventSubscriber<
+  State,
+  FastPriceFeedState
+> {
+  static readonly interface = new Interface(FastPriceFeedAbi);
+  static readonly fastPriceEventsInterface = new Interface(FastPriceEventsAbi);
+
+  BASIS_POINTS_DIVISOR = 10000n;
+  protected priceDuration: number;
+  protected maxDeviationBasisPoints: bigint;
+  protected favorFastPrice: boolean;
+  protected volBasisPoints: bigint;
+
+  constructor(
+    private fastPriceFeedAddress: Address,
+    private fastPriceEventsAddress: Address,
+    private tokenAddresses: Address[],
+    config: FastPriceFeedConfig,
+    lens: Lens<DeepReadonly<State>, DeepReadonly<FastPriceFeedState>>,
+    logger: Logger,
+  ) {
+    super([fastPriceEventsAddress], lens, logger);
+    this.priceDuration = config.priceDuration;
+    this.maxDeviationBasisPoints = config.maxDeviationBasisPoints;
+    this.favorFastPrice = config.favorFastPrice;
+    this.volBasisPoints = config.volBasisPoints;
+  }
+
+  public processLog(
+    state: DeepReadonly<FastPriceFeedState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): DeepReadonly<FastPriceFeedState> | null {
+    try {
+      const parsed = FastPriceFeed.fastPriceEventsInterface.parseLog(log);
+      switch (parsed.name) {
+        case 'PriceUpdate': {
+          const _state: FastPriceFeedState = _.cloneDeep(state);
+          _state.lastUpdatedAt =
+            typeof blockHeader.timestamp === 'string'
+              ? parseInt(blockHeader.timestamp)
+              : blockHeader.timestamp;
+          const tokenAddress = parsed.args.token.toLowerCase();
+          if (tokenAddress in state.prices)
+            _state.prices[tokenAddress] = BigInt(parsed.args.price.toString());
+          return _state;
+        }
+        default:
+          return null;
+      }
+    } catch (e) {
+      this.logger.error('Failed to parse log', e);
+      return null;
+    }
+  }
+
+  getPrice(
+    _state: DeepReadonly<State>,
+    _token: Address,
+    _refPrice: bigint,
+    _maximise: boolean,
+  ) {
+    const state = this.lens.get()(_state);
+
+    const timestamp = Math.floor(Date.now() / 1000);
+
+    if (timestamp > state.lastUpdatedAt + this.priceDuration) {
+      return _refPrice;
+    }
+
+    const fastPrice = state.prices[_token];
+    if (fastPrice == 0n) {
+      return _refPrice;
+    }
+
+    const maxPrice =
+      (_refPrice * (this.BASIS_POINTS_DIVISOR + this.maxDeviationBasisPoints)) /
+      this.BASIS_POINTS_DIVISOR;
+    const minPrice =
+      (_refPrice * (this.BASIS_POINTS_DIVISOR - this.maxDeviationBasisPoints)) /
+      this.BASIS_POINTS_DIVISOR;
+
+    if (this.favorFastPrice) {
+      if (fastPrice >= minPrice && fastPrice <= maxPrice) {
+        if (_maximise) {
+          if (_refPrice > fastPrice) {
+            const volPrice =
+              (fastPrice * (this.BASIS_POINTS_DIVISOR + this.volBasisPoints)) /
+              this.BASIS_POINTS_DIVISOR;
+            // the volPrice should not be more than _refPrice
+            return volPrice > _refPrice ? _refPrice : volPrice;
+          }
+          return fastPrice;
+        }
+
+        if (_refPrice < fastPrice) {
+          const volPrice =
+            (fastPrice * (this.BASIS_POINTS_DIVISOR - this.volBasisPoints)) /
+            this.BASIS_POINTS_DIVISOR;
+          // the volPrice should not be less than _refPrice
+          return volPrice < _refPrice ? _refPrice : volPrice;
+        }
+
+        return fastPrice;
+      }
+    }
+
+    if (_maximise) {
+      if (_refPrice > fastPrice) {
+        return _refPrice;
+      }
+      return fastPrice > maxPrice ? maxPrice : fastPrice;
+    }
+
+    if (_refPrice < fastPrice) {
+      return _refPrice;
+    }
+    return fastPrice < minPrice ? minPrice : fastPrice;
+  }
+
+  static getConfigMulticallInputs(
+    fastPriceFeedAddress: Address,
+  ): MultiCallInput[] {
+    return [
+      {
+        target: fastPriceFeedAddress,
+        callData: FastPriceFeed.interface.encodeFunctionData('priceDuration'),
+      },
+      {
+        target: fastPriceFeedAddress,
+        callData: FastPriceFeed.interface.encodeFunctionData(
+          'maxDeviationBasisPoints',
+        ),
+      },
+      {
+        target: fastPriceFeedAddress,
+        callData: FastPriceFeed.interface.encodeFunctionData('favorFastPrice'),
+      },
+      {
+        target: fastPriceFeedAddress,
+        callData: FastPriceFeed.interface.encodeFunctionData('volBasisPoints'),
+      },
+    ];
+  }
+
+  static getConfig(multicallOutputs: MultiCallOutput[]): FastPriceFeedConfig {
+    return {
+      priceDuration: parseInt(
+        FastPriceFeed.interface
+          .decodeFunctionResult('priceDuration', multicallOutputs[0])[0]
+          .toString(),
+      ),
+      maxDeviationBasisPoints: BigInt(
+        FastPriceFeed.interface
+          .decodeFunctionResult(
+            'maxDeviationBasisPoints',
+            multicallOutputs[1],
+          )[0]
+          .toString(),
+      ),
+      favorFastPrice: Boolean(
+        FastPriceFeed.interface
+          .decodeFunctionResult('favorFastPrice', multicallOutputs[2])[0]
+          .toString(),
+      ),
+      volBasisPoints: BigInt(
+        FastPriceFeed.interface
+          .decodeFunctionResult('volBasisPoints', multicallOutputs[2])[0]
+          .toString(),
+      ),
+    };
+  }
+
+  public getGenerateStateMultiCallInputs(): MultiCallInput[] {
+    const pricesEntries = this.tokenAddresses.map((t: Address) => ({
+      target: this.fastPriceFeedAddress,
+      callData: FastPriceFeed.interface.encodeFunctionData('prices', [t]),
+    }));
+    return [
+      ...pricesEntries,
+      {
+        target: this.fastPriceFeedAddress,
+        callData: FastPriceFeed.interface.encodeFunctionData('lastUpdatedAt'),
+      },
+    ];
+  }
+
+  public generateState(
+    multicallOutputs: MultiCallOutput[],
+    blockNumber?: number | 'latest',
+  ): DeepReadonly<FastPriceFeedState> {
+    let fastPriceFeedState: FastPriceFeedState = {
+      prices: {},
+      lastUpdatedAt: 0,
+    };
+    this.tokenAddresses.forEach(
+      (t: Address, i: number) =>
+        (fastPriceFeedState.prices[t] = BigInt(
+          FastPriceFeed.interface
+            .decodeFunctionResult('prices', multicallOutputs[i])[0]
+            .toString(),
+        )),
+    );
+    fastPriceFeedState.lastUpdatedAt = parseInt(
+      FastPriceFeed.interface
+        .decodeFunctionResult(
+          'lastUpdatedAt',
+          multicallOutputs[this.tokenAddresses.length],
+        )[0]
+        .toString(),
+    );
+    return fastPriceFeedState;
+  }
+}

--- a/src/dex/metavault-trade/fast-price-feed.ts
+++ b/src/dex/metavault-trade/fast-price-feed.ts
@@ -25,12 +25,14 @@ export class FastPriceFeed<State> extends PartialEventSubscriber<
   BASIS_POINTS_DIVISOR = 10000n;
   protected priceDuration: number;
   protected maxDeviationBasisPoints: bigint;
-  protected favorFastPrice: boolean;
-  protected volBasisPoints: bigint;
+  protected favorFastPrice: Record<string, boolean>;
+  private spreadBasisPointsIfInactive: bigint;
+  private spreadBasisPointsIfChainError: bigint;
+  private maxPriceUpdateDelay: number;
 
   constructor(
     private fastPriceFeedAddress: Address,
-    private fastPriceEventsAddress: Address,
+    fastPriceEventsAddress: Address,
     private tokenAddresses: Address[],
     config: FastPriceFeedConfig,
     lens: Lens<DeepReadonly<State>, DeepReadonly<FastPriceFeedState>>,
@@ -40,7 +42,9 @@ export class FastPriceFeed<State> extends PartialEventSubscriber<
     this.priceDuration = config.priceDuration;
     this.maxDeviationBasisPoints = config.maxDeviationBasisPoints;
     this.favorFastPrice = config.favorFastPrice;
-    this.volBasisPoints = config.volBasisPoints;
+    this.spreadBasisPointsIfInactive = config.spreadBasisPointsIfInactive;
+    this.spreadBasisPointsIfChainError = config.spreadBasisPointsIfChainError;
+    this.maxPriceUpdateDelay = config.maxPriceUpdateDelay;
   }
 
   public processLog(
@@ -81,62 +85,67 @@ export class FastPriceFeed<State> extends PartialEventSubscriber<
 
     const timestamp = Math.floor(Date.now() / 1000);
 
+    if (timestamp > state.lastUpdatedAt + this.maxPriceUpdateDelay) {
+      if (_maximise) {
+        return (
+          (_refPrice *
+            (this.BASIS_POINTS_DIVISOR + this.spreadBasisPointsIfChainError)) /
+          this.BASIS_POINTS_DIVISOR
+        );
+      }
+
+      return (
+        (_refPrice *
+          (this.BASIS_POINTS_DIVISOR - this.spreadBasisPointsIfChainError)) /
+        this.BASIS_POINTS_DIVISOR
+      );
+    }
+
     if (timestamp > state.lastUpdatedAt + this.priceDuration) {
-      return _refPrice;
+      if (_maximise) {
+        return (
+          (_refPrice *
+            (this.BASIS_POINTS_DIVISOR + this.spreadBasisPointsIfInactive)) /
+          this.BASIS_POINTS_DIVISOR
+        );
+      }
+
+      return (
+        (_refPrice *
+          (this.BASIS_POINTS_DIVISOR - this.spreadBasisPointsIfInactive)) /
+        this.BASIS_POINTS_DIVISOR
+      );
     }
 
     const fastPrice = state.prices[_token];
-    if (fastPrice == 0n) {
-      return _refPrice;
-    }
+    if (fastPrice === 0n) return _refPrice;
 
-    const maxPrice =
-      (_refPrice * (this.BASIS_POINTS_DIVISOR + this.maxDeviationBasisPoints)) /
-      this.BASIS_POINTS_DIVISOR;
-    const minPrice =
-      (_refPrice * (this.BASIS_POINTS_DIVISOR - this.maxDeviationBasisPoints)) /
-      this.BASIS_POINTS_DIVISOR;
+    let diffBasisPoints =
+      _refPrice > fastPrice ? _refPrice - fastPrice : fastPrice - _refPrice;
+    diffBasisPoints = (diffBasisPoints * this.BASIS_POINTS_DIVISOR) / _refPrice;
 
-    if (this.favorFastPrice) {
-      if (fastPrice >= minPrice && fastPrice <= maxPrice) {
-        if (_maximise) {
-          if (_refPrice > fastPrice) {
-            const volPrice =
-              (fastPrice * (this.BASIS_POINTS_DIVISOR + this.volBasisPoints)) /
-              this.BASIS_POINTS_DIVISOR;
-            // the volPrice should not be more than _refPrice
-            return volPrice > _refPrice ? _refPrice : volPrice;
-          }
-          return fastPrice;
-        }
+    // create a spread between the _refPrice and the fastPrice if the maxDeviationBasisPoints is exceeded
+    // or if watchers have flagged an issue with the fast price
+    const hasSpread =
+      !this.favorFastPrice[_token] ||
+      diffBasisPoints > this.maxDeviationBasisPoints;
 
-        if (_refPrice < fastPrice) {
-          const volPrice =
-            (fastPrice * (this.BASIS_POINTS_DIVISOR - this.volBasisPoints)) /
-            this.BASIS_POINTS_DIVISOR;
-          // the volPrice should not be less than _refPrice
-          return volPrice < _refPrice ? _refPrice : volPrice;
-        }
-
-        return fastPrice;
+    if (hasSpread) {
+      // return the higher of the two prices
+      if (_maximise) {
+        return _refPrice > fastPrice ? _refPrice : fastPrice;
       }
+
+      // return the lower of the two prices
+      return _refPrice < fastPrice ? _refPrice : fastPrice;
     }
 
-    if (_maximise) {
-      if (_refPrice > fastPrice) {
-        return _refPrice;
-      }
-      return fastPrice > maxPrice ? maxPrice : fastPrice;
-    }
-
-    if (_refPrice < fastPrice) {
-      return _refPrice;
-    }
-    return fastPrice < minPrice ? minPrice : fastPrice;
+    return fastPrice;
   }
 
   static getConfigMulticallInputs(
     fastPriceFeedAddress: Address,
+    tokenAddresses: Address[],
   ): MultiCallInput[] {
     return [
       {
@@ -151,16 +160,35 @@ export class FastPriceFeed<State> extends PartialEventSubscriber<
       },
       {
         target: fastPriceFeedAddress,
-        callData: FastPriceFeed.interface.encodeFunctionData('favorFastPrice'),
+        callData: FastPriceFeed.interface.encodeFunctionData(
+          'spreadBasisPointsIfInactive',
+        ),
       },
       {
         target: fastPriceFeedAddress,
-        callData: FastPriceFeed.interface.encodeFunctionData('volBasisPoints'),
+        callData: FastPriceFeed.interface.encodeFunctionData(
+          'spreadBasisPointsIfChainError',
+        ),
       },
+      {
+        target: fastPriceFeedAddress,
+        callData: FastPriceFeed.interface.encodeFunctionData(
+          'maxPriceUpdateDelay',
+        ),
+      },
+      ...tokenAddresses.map(t => ({
+        target: fastPriceFeedAddress,
+        callData: FastPriceFeed.interface.encodeFunctionData('favorFastPrice', [
+          t,
+        ]),
+      })),
     ];
   }
 
-  static getConfig(multicallOutputs: MultiCallOutput[]): FastPriceFeedConfig {
+  static getConfig(
+    multicallOutputs: MultiCallOutput[],
+    tokenAddresses: Address[],
+  ): FastPriceFeedConfig {
     return {
       priceDuration: parseInt(
         FastPriceFeed.interface
@@ -175,16 +203,36 @@ export class FastPriceFeed<State> extends PartialEventSubscriber<
           )[0]
           .toString(),
       ),
-      favorFastPrice: Boolean(
+      spreadBasisPointsIfInactive: BigInt(
         FastPriceFeed.interface
-          .decodeFunctionResult('favorFastPrice', multicallOutputs[2])[0]
+          .decodeFunctionResult(
+            'spreadBasisPointsIfInactive',
+            multicallOutputs[2],
+          )[0]
           .toString(),
       ),
-      volBasisPoints: BigInt(
+      spreadBasisPointsIfChainError: BigInt(
         FastPriceFeed.interface
-          .decodeFunctionResult('volBasisPoints', multicallOutputs[2])[0]
+          .decodeFunctionResult(
+            'spreadBasisPointsIfChainError',
+            multicallOutputs[3],
+          )[0]
           .toString(),
       ),
+      maxPriceUpdateDelay: parseInt(
+        FastPriceFeed.interface
+          .decodeFunctionResult('maxPriceUpdateDelay', multicallOutputs[4])[0]
+          .toString(),
+      ),
+      favorFastPrice: multicallOutputs
+        .slice(5)
+        .reduce<Record<string, boolean>>((acc, curr, i) => {
+          acc[tokenAddresses[i]] = FastPriceFeed.interface.decodeFunctionResult(
+            'favorFastPrice',
+            curr,
+          )[0];
+          return acc;
+        }, {}),
     };
   }
 

--- a/src/dex/metavault-trade/metavault-trade-e2e.test.ts
+++ b/src/dex/metavault-trade/metavault-trade-e2e.test.ts
@@ -1,0 +1,130 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import {
+  Tokens,
+  Holders,
+  NativeTokenSymbols,
+} from '../../../tests/constants-e2e';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+
+/*
+  README
+  ======
+
+  This test script should add e2e tests for MetavaultTrade. The tests
+  should cover as many cases as possible. Most of the DEXes follow
+  the following test structure:
+    - DexName
+      - ForkName + Network
+        - ContractMethod
+          - ETH -> Token swap
+          - Token -> ETH swap
+          - Token -> Token swap
+
+  The template already enumerates the basic structure which involves
+  testing simpleSwap, multiSwap, megaSwap contract methods for
+  ETH <> TOKEN and TOKEN <> TOKEN swaps. You should replace tokenA and
+  tokenB with any two highly liquid tokens on MetavaultTrade for the tests
+  to work. If the tokens that you would like to use are not defined in
+  Tokens or Holders map, you can update the './tests/constants-e2e'
+
+  Other than the standard cases that are already added by the template
+  it is highly recommended to add test cases which could be specific
+  to testing MetavaultTrade (Eg. Tests based on poolType, special tokens,
+  etc).
+
+  You can run this individual test script by running:
+  `npx jest src/dex/<dex-name>/<dex-name>-e2e.test.ts`
+
+  e2e tests use the Tenderly fork api. Please add the following to your
+  .env file:
+  TENDERLY_TOKEN=Find this under Account>Settings>Authorization.
+  TENDERLY_ACCOUNT_ID=Your Tenderly account name.
+  TENDERLY_PROJECT=Name of a Tenderly project you have created in your
+  dashboard.
+
+  (This comment should be removed from the final implementation)
+*/
+
+describe('MetavaultTrade E2E', () => {
+  const dexKey = 'MetavaultTrade';
+
+  describe('MetavaultTrade Polygon', () => {
+    const network = Network.POLYGON;
+    const tokens = Tokens[network];
+    const holders = Holders[network];
+    const provider = new StaticJsonRpcProvider(
+      generateConfig(network).privateHttpProvider,
+      network,
+    );
+
+    const tokenASymbol: string = 'USDT';
+    const tokenBSymbol: string = 'WETH';
+    const nativeTokenSymbol = NativeTokenSymbols[network];
+
+    const tokenAAmount: string = '2000000000';
+    const tokenBAmount: string = '1000000000000000000';
+    const nativeTokenAmount = '1000000000000000000';
+
+    const sideToContractMethods = new Map([
+      [
+        SwapSide.SELL,
+        [
+          ContractMethod.simpleSwap,
+          ContractMethod.multiSwap,
+          ContractMethod.megaSwap,
+        ],
+      ],
+    ]);
+
+    sideToContractMethods.forEach((contractMethods, side) =>
+      contractMethods.forEach((contractMethod: ContractMethod) => {
+        describe(`${contractMethod}`, () => {
+          it(nativeTokenSymbol + ' -> TOKEN', async () => {
+            await testE2E(
+              tokens[nativeTokenSymbol],
+              tokens[tokenASymbol],
+              holders[nativeTokenSymbol],
+              side === SwapSide.SELL ? nativeTokenAmount : tokenAAmount,
+              side,
+              dexKey,
+              contractMethod,
+              network,
+              provider,
+            );
+          });
+          it('TOKEN -> ' + nativeTokenSymbol, async () => {
+            await testE2E(
+              tokens[tokenASymbol],
+              tokens[nativeTokenSymbol],
+              holders[tokenASymbol],
+              side === SwapSide.SELL ? tokenAAmount : nativeTokenAmount,
+              side,
+              dexKey,
+              contractMethod,
+              network,
+              provider,
+            );
+          });
+          it('TOKEN -> TOKEN', async () => {
+            await testE2E(
+              tokens[tokenASymbol],
+              tokens[tokenBSymbol],
+              holders[tokenASymbol],
+              side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
+              side,
+              dexKey,
+              contractMethod,
+              network,
+              provider,
+            );
+          });
+        });
+      }),
+    );
+  });
+});

--- a/src/dex/metavault-trade/metavault-trade-e2e.test.ts
+++ b/src/dex/metavault-trade/metavault-trade-e2e.test.ts
@@ -11,49 +11,10 @@ import { Network, ContractMethod, SwapSide } from '../../constants';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { generateConfig } from '../../config';
 
-/*
-  README
-  ======
-
-  This test script should add e2e tests for MetavaultTrade. The tests
-  should cover as many cases as possible. Most of the DEXes follow
-  the following test structure:
-    - DexName
-      - ForkName + Network
-        - ContractMethod
-          - ETH -> Token swap
-          - Token -> ETH swap
-          - Token -> Token swap
-
-  The template already enumerates the basic structure which involves
-  testing simpleSwap, multiSwap, megaSwap contract methods for
-  ETH <> TOKEN and TOKEN <> TOKEN swaps. You should replace tokenA and
-  tokenB with any two highly liquid tokens on MetavaultTrade for the tests
-  to work. If the tokens that you would like to use are not defined in
-  Tokens or Holders map, you can update the './tests/constants-e2e'
-
-  Other than the standard cases that are already added by the template
-  it is highly recommended to add test cases which could be specific
-  to testing MetavaultTrade (Eg. Tests based on poolType, special tokens,
-  etc).
-
-  You can run this individual test script by running:
-  `npx jest src/dex/<dex-name>/<dex-name>-e2e.test.ts`
-
-  e2e tests use the Tenderly fork api. Please add the following to your
-  .env file:
-  TENDERLY_TOKEN=Find this under Account>Settings>Authorization.
-  TENDERLY_ACCOUNT_ID=Your Tenderly account name.
-  TENDERLY_PROJECT=Name of a Tenderly project you have created in your
-  dashboard.
-
-  (This comment should be removed from the final implementation)
-*/
-
 describe('MetavaultTrade E2E', () => {
   const dexKey = 'MetavaultTrade';
 
-  describe('MetavaultTrade Polygon', () => {
+  describe('MetavaultTrade POLYGON', () => {
     const network = Network.POLYGON;
     const tokens = Tokens[network];
     const holders = Holders[network];
@@ -62,12 +23,12 @@ describe('MetavaultTrade E2E', () => {
       network,
     );
 
-    const tokenASymbol: string = 'USDT';
-    const tokenBSymbol: string = 'WETH';
+    const tokenASymbol: string = 'USDC';
+    const tokenBSymbol: string = 'WBTC';
     const nativeTokenSymbol = NativeTokenSymbols[network];
 
-    const tokenAAmount: string = '2000000000';
-    const tokenBAmount: string = '1000000000000000000';
+    const tokenAAmount: string = '2000000';
+    const tokenBAmount: string = '2000000';
     const nativeTokenAmount = '1000000000000000000';
 
     const sideToContractMethods = new Map([

--- a/src/dex/metavault-trade/metavault-trade-events.test.ts
+++ b/src/dex/metavault-trade/metavault-trade-events.test.ts
@@ -1,46 +1,13 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-import { MetavaultTradeEventPool } from './pool';
+import { MetavaultTradeEventPool } from './metavault-trade-pool';
 import { MetavaultTradeConfig } from './config';
 import { Network } from '../../constants';
-import { Address } from '../../types';
 import { DummyDexHelper } from '../../dex-helper/index';
 import { testEventSubscriber } from '../../../tests/utils-events';
 import { PoolState } from './types';
-
-/*
-  README
-  ======
-
-  This test script adds unit tests for MetavaultTrade event based
-  system. This is done by fetching the state on-chain before the
-  event block, manually pushing the block logs to the event-subscriber,
-  comparing the local state with on-chain state.
-
-  Most of the logic for testing is abstracted by `testEventSubscriber`.
-  You need to do two things to make the tests work:
-
-  1. Fetch the block numbers where certain events were released. You
-  can modify the `./scripts/fetch-event-blocknumber.ts` to get the
-  block numbers for different events. Make sure to get sufficient
-  number of blockNumbers to cover all possible cases for the event
-  mutations.
-
-  2. Complete the implementation for fetchPoolState function. The
-  function should fetch the on-chain state of the event subscriber
-  using just the blocknumber.
-
-  The template tests only include the test for a single event
-  subscriber. There can be cases where multiple event subscribers
-  exist for a single DEX. In such cases additional tests should be
-  added.
-
-  You can run this individual test script by running:
-  `npx jest src/dex/<dex-name>/<dex-name>-events.test.ts`
-
-  (This comment should be removed from the final implementation)
-*/
+import { MetavaultTrade } from './metavault-trade';
 
 jest.setTimeout(50 * 1000);
 const dexKey = 'MetavaultTrade';
@@ -48,21 +15,16 @@ const network = Network.POLYGON;
 const params = MetavaultTradeConfig[dexKey][network];
 
 async function fetchPoolState(
-  metavaultTradePools: MetavaultTradeEventPool,
+  metavaultTradePool: MetavaultTradeEventPool,
   blockNumber: number,
 ): Promise<PoolState> {
-  return metavaultTradePools.generateState(blockNumber);
+  return metavaultTradePool.generateState(blockNumber);
 }
 
-// timestamp can't be compared exactly as the event released
-// doesn't have the timestamp. It is safe to consider the
-// timestamp as the blockTime as the max deviation is bounded
-// on the contract
 const stateWithoutTimestamp = (state: PoolState) => ({
   ...state,
   secondaryPrices: {
     prices: state.secondaryPrices.prices,
-    // timestamp (this is removed)
   },
 });
 
@@ -72,44 +34,15 @@ function compareState(state: PoolState, expectedState: PoolState) {
   );
 }
 
-describe('MetavaultTrade Event', function () {
-  const blockNumbers: { [eventName: string]: number[] } = {
+describe('MetavaultTrade', function () {
+  let blockNumbers: { [eventName: string]: number[] } = {
     IncreaseUsdmAmount: [
-      19403150, 19403175, 19403183, 19403215, 19403232, 19403246, 19403344,
-      19403484, 19403545, 19403553, 19403586, 19403662, 19403712, 19403721,
-      19403757, 19403775, 19403782, 19403800, 19403807, 19403808, 19403826,
-      19403844, 19403848, 19403852, 19403860, 19403863, 19403875, 19403877,
-      19403885, 19403900, 19403904, 19403938, 19403963, 19403970, 19403973,
-      19403978, 19403999, 19404000, 19404023, 19404026, 19404046, 19404056,
-      19404060, 19404078, 19404083, 19404097, 19404149, 19404164, 19404178,
-      19404182, 19404229, 19404243, 19404264, 19404272, 19404287, 19404347,
-      19404378, 19404379, 19404389, 19404408, 19404463, 19404491, 19404560,
-      19404625, 19404657, 19404687, 19404700, 19404714, 19404763, 19404889,
-      19404892, 19404893, 19404894, 19404897, 19404904, 19404916, 19404917,
-      19404927, 19404935, 19404946, 19404949, 19404951, 19404959, 19404973,
-      19405017, 19405027, 19405034,
+      36130344, 36130244, 36130144, 36130044, 36129844, 36129644,
     ],
     DecreaseUsdmAmount: [
-      19403150, 19403175, 19403183, 19403215, 19403232, 19403246, 19403344,
-      19403545, 19403553, 19403662, 19403712, 19403721, 19403757, 19403775,
-      19403782, 19403800, 19403807, 19403808, 19403826, 19403844, 19403848,
-      19403852, 19403860, 19403863, 19403875, 19403877, 19403885, 19403900,
-      19403904, 19403938, 19403963, 19403970, 19403973, 19403978, 19403999,
-      19404000, 19404023, 19404026, 19404046, 19404056, 19404060, 19404078,
-      19404083, 19404097, 19404149, 19404164, 19404178, 19404182, 19404229,
-      19404243, 19404264, 19404272, 19404287, 19404347, 19404378, 19404379,
-      19404389, 19404408, 19404463, 19404491, 19404560, 19404625, 19404657,
-      19404687, 19404700, 19404714, 19404763, 19404889, 19404892, 19404893,
-      19404894, 19404897, 19404904, 19404916, 19404917, 19404927, 19404935,
-      19404946, 19404949, 19404951, 19404959, 19404973, 19405017, 19405027,
-      19405034,
+      36130344, 36130244, 36130144, 36130044, 36129844, 36129644,
     ],
-    Transfer: [19403484, 19403586, 19405046, 19405100, 19405154, 19405318],
-    PriceUpdate: [
-      19403134, 19403135, 19403140, 19403141, 19403144, 19403148, 19403151,
-      19403154, 19403163, 19403169, 19403170, 19403171, 19403178, 19403185,
-      19403186, 19403202,
-    ],
+    PriceUpdate: [36130344, 36130244, 36130144, 36130044, 36129844, 36129644],
   };
 
   describe('MetavaultTradeEventPool', function () {
@@ -117,20 +50,13 @@ describe('MetavaultTrade Event', function () {
       blockNumbers[event].forEach((blockNumber: number) => {
         it(`Should return the correct state after the ${blockNumber}:${event}`, async function () {
           const dexHelper = new DummyDexHelper(network);
-          const logger = dexHelper.getLogger(dexKey);
+          const metavaultTrade = new MetavaultTrade(network, dexKey, dexHelper);
 
-          const config = await MetavaultTradeEventPool.getConfig(
-            params,
+          const metavaultTradePool = await metavaultTrade.getEventPoolForBlock(
             blockNumber,
-            dexHelper.multiContract,
           );
-          const metavaultTradePool = new MetavaultTradeEventPool(
-            dexKey,
-            network,
-            dexHelper,
-            logger,
-            config,
-          );
+
+          console.log(`${dexKey}_${params.vault}`);
 
           await testEventSubscriber(
             metavaultTradePool,

--- a/src/dex/metavault-trade/metavault-trade-events.test.ts
+++ b/src/dex/metavault-trade/metavault-trade-events.test.ts
@@ -1,0 +1,149 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { MetavaultTradeEventPool } from './pool';
+import { MetavaultTradeConfig } from './config';
+import { Network } from '../../constants';
+import { Address } from '../../types';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { testEventSubscriber } from '../../../tests/utils-events';
+import { PoolState } from './types';
+
+/*
+  README
+  ======
+
+  This test script adds unit tests for MetavaultTrade event based
+  system. This is done by fetching the state on-chain before the
+  event block, manually pushing the block logs to the event-subscriber,
+  comparing the local state with on-chain state.
+
+  Most of the logic for testing is abstracted by `testEventSubscriber`.
+  You need to do two things to make the tests work:
+
+  1. Fetch the block numbers where certain events were released. You
+  can modify the `./scripts/fetch-event-blocknumber.ts` to get the
+  block numbers for different events. Make sure to get sufficient
+  number of blockNumbers to cover all possible cases for the event
+  mutations.
+
+  2. Complete the implementation for fetchPoolState function. The
+  function should fetch the on-chain state of the event subscriber
+  using just the blocknumber.
+
+  The template tests only include the test for a single event
+  subscriber. There can be cases where multiple event subscribers
+  exist for a single DEX. In such cases additional tests should be
+  added.
+
+  You can run this individual test script by running:
+  `npx jest src/dex/<dex-name>/<dex-name>-events.test.ts`
+
+  (This comment should be removed from the final implementation)
+*/
+
+jest.setTimeout(50 * 1000);
+const dexKey = 'MetavaultTrade';
+const network = Network.POLYGON;
+const params = MetavaultTradeConfig[dexKey][network];
+
+async function fetchPoolState(
+  metavaultTradePools: MetavaultTradeEventPool,
+  blockNumber: number,
+): Promise<PoolState> {
+  return metavaultTradePools.generateState(blockNumber);
+}
+
+// timestamp can't be compared exactly as the event released
+// doesn't have the timestamp. It is safe to consider the
+// timestamp as the blockTime as the max deviation is bounded
+// on the contract
+const stateWithoutTimestamp = (state: PoolState) => ({
+  ...state,
+  secondaryPrices: {
+    prices: state.secondaryPrices.prices,
+    // timestamp (this is removed)
+  },
+});
+
+function compareState(state: PoolState, expectedState: PoolState) {
+  expect(stateWithoutTimestamp(state)).toEqual(
+    stateWithoutTimestamp(expectedState),
+  );
+}
+
+describe('MetavaultTrade Event', function () {
+  const blockNumbers: { [eventName: string]: number[] } = {
+    IncreaseUsdmAmount: [
+      19403150, 19403175, 19403183, 19403215, 19403232, 19403246, 19403344,
+      19403484, 19403545, 19403553, 19403586, 19403662, 19403712, 19403721,
+      19403757, 19403775, 19403782, 19403800, 19403807, 19403808, 19403826,
+      19403844, 19403848, 19403852, 19403860, 19403863, 19403875, 19403877,
+      19403885, 19403900, 19403904, 19403938, 19403963, 19403970, 19403973,
+      19403978, 19403999, 19404000, 19404023, 19404026, 19404046, 19404056,
+      19404060, 19404078, 19404083, 19404097, 19404149, 19404164, 19404178,
+      19404182, 19404229, 19404243, 19404264, 19404272, 19404287, 19404347,
+      19404378, 19404379, 19404389, 19404408, 19404463, 19404491, 19404560,
+      19404625, 19404657, 19404687, 19404700, 19404714, 19404763, 19404889,
+      19404892, 19404893, 19404894, 19404897, 19404904, 19404916, 19404917,
+      19404927, 19404935, 19404946, 19404949, 19404951, 19404959, 19404973,
+      19405017, 19405027, 19405034,
+    ],
+    DecreaseUsdmAmount: [
+      19403150, 19403175, 19403183, 19403215, 19403232, 19403246, 19403344,
+      19403545, 19403553, 19403662, 19403712, 19403721, 19403757, 19403775,
+      19403782, 19403800, 19403807, 19403808, 19403826, 19403844, 19403848,
+      19403852, 19403860, 19403863, 19403875, 19403877, 19403885, 19403900,
+      19403904, 19403938, 19403963, 19403970, 19403973, 19403978, 19403999,
+      19404000, 19404023, 19404026, 19404046, 19404056, 19404060, 19404078,
+      19404083, 19404097, 19404149, 19404164, 19404178, 19404182, 19404229,
+      19404243, 19404264, 19404272, 19404287, 19404347, 19404378, 19404379,
+      19404389, 19404408, 19404463, 19404491, 19404560, 19404625, 19404657,
+      19404687, 19404700, 19404714, 19404763, 19404889, 19404892, 19404893,
+      19404894, 19404897, 19404904, 19404916, 19404917, 19404927, 19404935,
+      19404946, 19404949, 19404951, 19404959, 19404973, 19405017, 19405027,
+      19405034,
+    ],
+    Transfer: [19403484, 19403586, 19405046, 19405100, 19405154, 19405318],
+    PriceUpdate: [
+      19403134, 19403135, 19403140, 19403141, 19403144, 19403148, 19403151,
+      19403154, 19403163, 19403169, 19403170, 19403171, 19403178, 19403185,
+      19403186, 19403202,
+    ],
+  };
+
+  describe('MetavaultTradeEventPool', function () {
+    Object.keys(blockNumbers).forEach((event: string) => {
+      blockNumbers[event].forEach((blockNumber: number) => {
+        it(`Should return the correct state after the ${blockNumber}:${event}`, async function () {
+          const dexHelper = new DummyDexHelper(network);
+          const logger = dexHelper.getLogger(dexKey);
+
+          const config = await MetavaultTradeEventPool.getConfig(
+            params,
+            blockNumber,
+            dexHelper.multiContract,
+          );
+          const metavaultTradePool = new MetavaultTradeEventPool(
+            dexKey,
+            network,
+            dexHelper,
+            logger,
+            config,
+          );
+
+          await testEventSubscriber(
+            metavaultTradePool,
+            metavaultTradePool.addressesSubscribed,
+            (_blockNumber: number) =>
+              fetchPoolState(metavaultTradePool, _blockNumber),
+            blockNumber,
+            `${dexKey}_${params.vault}`,
+            dexHelper.provider,
+            compareState,
+          );
+        });
+      });
+    });
+  });
+});

--- a/src/dex/metavault-trade/metavault-trade-integration.test.ts
+++ b/src/dex/metavault-trade/metavault-trade-integration.test.ts
@@ -1,0 +1,117 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Interface, Result } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide } from '../../constants';
+import { BI_POWS } from '../../bigint-constants';
+import { MetavaultTrade } from './metavault-trade';
+import { MetavaultTradeConfig } from './config';
+import {
+  checkPoolPrices,
+  checkPoolsLiquidity,
+  checkConstantPoolPrices,
+} from '../../../tests/utils';
+import { Tokens } from '../../../tests/constants-e2e';
+import ReaderABI from '../../abi/metavault-trade/reader.json';
+
+const network = Network.POLYGON;
+const TokenASymbol = 'USDT';
+const TokenA = Tokens[network][TokenASymbol];
+
+const TokenBSymbol = 'WMATIC';
+const TokenB = Tokens[network][TokenBSymbol];
+
+const amounts = [
+  0n,
+  1000000000n,
+  2000000000n,
+  3000000000n,
+  4000000000n,
+  5000000000n,
+];
+
+const dexKey = 'MetavaultTrade';
+const params = MetavaultTradeConfig[dexKey][network];
+const readerInterface = new Interface(ReaderABI);
+const readerAddress = '0x01dd8b434a83cbddfa24f2ef1fe2d6920ca03734';
+
+describe('MetavaultTrade', function () {
+  it('getPoolIdentifiers and getPricesVolume SELL', async function () {
+    const dexHelper = new DummyDexHelper(network);
+    const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+    const metavaultTrade = new MetavaultTrade(network, dexKey, dexHelper);
+
+    await metavaultTrade.initializePricing(blocknumber);
+
+    const pools = await metavaultTrade.getPoolIdentifiers(
+      TokenA,
+      TokenB,
+      SwapSide.SELL,
+      blocknumber,
+    );
+    console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `, pools);
+
+    expect(pools.length).toBeGreaterThan(0);
+
+    const poolPrices = await metavaultTrade.getPricesVolume(
+      TokenA,
+      TokenB,
+      amounts,
+      SwapSide.SELL,
+      blocknumber,
+      pools,
+    );
+    console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `, poolPrices);
+
+    expect(poolPrices).not.toBeNull();
+    if (metavaultTrade.hasConstantPriceLargeAmounts) {
+      checkConstantPoolPrices(poolPrices!, amounts, dexKey);
+    } else {
+      checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+    }
+
+    // Do on chain pricing based on reader to compare
+    const readerCallData = amounts.map(a => ({
+      target: readerAddress,
+      callData: readerInterface.encodeFunctionData('getAmountOut', [
+        params.vault,
+        TokenA.address,
+        TokenB.address,
+        a.toString(),
+      ]),
+    }));
+
+    const readerResult = (
+      await dexHelper.multiContract.methods
+        .aggregate(readerCallData)
+        .call({}, blocknumber)
+    ).returnData;
+    const expectedPrices = readerResult.map((p: any) =>
+      BigInt(
+        readerInterface.decodeFunctionResult('getAmountOut', p)[0].toString(),
+      ),
+    );
+
+    expect(poolPrices![0].prices).toEqual(expectedPrices);
+  });
+
+  it('getTopPoolsForToken', async function () {
+    const dexHelper = new DummyDexHelper(network);
+    const metavaultTrade = new MetavaultTrade(network, dexKey, dexHelper);
+
+    await metavaultTrade.updatePoolState();
+    const poolLiquidity = await metavaultTrade.getTopPoolsForToken(
+      TokenA.address,
+      10,
+    );
+    console.log(
+      `${TokenASymbol} Top Pools:`,
+      JSON.stringify(poolLiquidity, null, 2),
+    );
+
+    if (!metavaultTrade.hasConstantPriceLargeAmounts) {
+      checkPoolsLiquidity(poolLiquidity, TokenA.address, dexKey);
+    }
+  });
+});

--- a/src/dex/metavault-trade/metavault-trade-integration.test.ts
+++ b/src/dex/metavault-trade/metavault-trade-integration.test.ts
@@ -1,3 +1,4 @@
+import { MetavaultTradeConfig } from './config';
 import dotenv from 'dotenv';
 dotenv.config();
 
@@ -6,7 +7,6 @@ import { DummyDexHelper } from '../../dex-helper/index';
 import { Network, SwapSide } from '../../constants';
 import { BI_POWS } from '../../bigint-constants';
 import { MetavaultTrade } from './metavault-trade';
-import { MetavaultTradeConfig } from './config';
 import {
   checkPoolPrices,
   checkPoolsLiquidity,
@@ -16,25 +16,30 @@ import { Tokens } from '../../../tests/constants-e2e';
 import ReaderABI from '../../abi/metavault-trade/reader.json';
 
 const network = Network.POLYGON;
-const TokenASymbol = 'USDT';
+const TokenASymbol = 'DAI';
 const TokenA = Tokens[network][TokenASymbol];
 
-const TokenBSymbol = 'WMATIC';
+const TokenBSymbol = 'WBTC';
 const TokenB = Tokens[network][TokenBSymbol];
 
 const amounts = [
   0n,
-  1000000000n,
-  2000000000n,
-  3000000000n,
-  4000000000n,
-  5000000000n,
+  1n * BI_POWS[TokenA.decimals],
+  2n * BI_POWS[TokenA.decimals],
+  3n * BI_POWS[TokenA.decimals],
+  4n * BI_POWS[TokenA.decimals],
+  5n * BI_POWS[TokenA.decimals],
+  6n * BI_POWS[TokenA.decimals],
+  7n * BI_POWS[TokenA.decimals],
+  8n * BI_POWS[TokenA.decimals],
+  9n * BI_POWS[TokenA.decimals],
+  10n * BI_POWS[TokenA.decimals],
 ];
 
 const dexKey = 'MetavaultTrade';
 const params = MetavaultTradeConfig[dexKey][network];
 const readerInterface = new Interface(ReaderABI);
-const readerAddress = '0x01dd8b434a83cbddfa24f2ef1fe2d6920ca03734';
+const readerAddress = '0x01dd8B434A83cbdDFa24f2ef1fe2D6920ca03734';
 
 describe('MetavaultTrade', function () {
   it('getPoolIdentifiers and getPricesVolume SELL', async function () {
@@ -50,6 +55,7 @@ describe('MetavaultTrade', function () {
       SwapSide.SELL,
       blocknumber,
     );
+
     console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `, pools);
 
     expect(pools.length).toBeGreaterThan(0);
@@ -82,11 +88,17 @@ describe('MetavaultTrade', function () {
       ]),
     }));
 
+    console.log('readerCallData', readerCallData);
+
     const readerResult = (
       await dexHelper.multiContract.methods
         .aggregate(readerCallData)
         .call({}, blocknumber)
     ).returnData;
+
+    console.log('readerResult');
+    console.log(readerResult);
+
     const expectedPrices = readerResult.map((p: any) =>
       BigInt(
         readerInterface.decodeFunctionResult('getAmountOut', p)[0].toString(),

--- a/src/dex/metavault-trade/metavault-trade.ts
+++ b/src/dex/metavault-trade/metavault-trade.ts
@@ -1,0 +1,318 @@
+import { AsyncOrSync } from 'ts-essentials';
+import {
+  Token,
+  Address,
+  ExchangePrices,
+  PoolPrices,
+  AdapterExchangeParam,
+  SimpleExchangeParam,
+  PoolLiquidity,
+  Logger,
+} from '../../types';
+import { SwapSide, Network } from '../../constants';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+import { getDexKeysWithNetwork, getBigIntPow } from '../../utils';
+import { IDex } from '../../dex/idex';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { MetavaultTradeData, DexParams } from './types';
+import { SimpleExchange } from '../simple-exchange';
+import { MetavaultTradeConfig, Adapters } from './config';
+import { MetavaultTradeEventPool } from './pool';
+import { Vault } from './vault';
+import ERC20ABI from '../../abi/erc20.json';
+import { Interface } from '@ethersproject/abi';
+
+const MetavaultTradeGasCost = 300 * 1000;
+
+export class MetavaultTrade
+  extends SimpleExchange
+  implements IDex<MetavaultTradeData>
+{
+  protected pool: MetavaultTradeEventPool | null = null;
+  protected supportedTokensMap: { [address: string]: boolean } = {};
+  // supportedTokens is only used by the pooltracker
+  protected supportedTokens: Token[] = [];
+
+  readonly hasConstantPriceLargeAmounts = false;
+  readonly needWrapNative = true;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(MetavaultTradeConfig);
+
+  public static erc20Interface = new Interface(ERC20ABI);
+
+  vaultUSDBalance: number = 0;
+
+  logger: Logger;
+
+  constructor(
+    readonly network: Network,
+    readonly dexKey: string,
+    readonly dexHelper: IDexHelper,
+    protected adapters = Adapters[network] || {},
+    protected params: DexParams = MetavaultTradeConfig[dexKey][network],
+  ) {
+    super(dexHelper.config.data.augustusAddress, dexHelper.web3Provider);
+    this.logger = dexHelper.getLogger(dexKey);
+  }
+
+  // Initialize pricing is called once in the start of
+  // pricing service. It is intended to setup the integration
+  // for pricing requests. It is optional for a DEX to
+  // implement this function
+  async initializePricing(blockNumber: number) {
+    const config = await MetavaultTradeEventPool.getConfig(
+      this.params,
+      blockNumber,
+      this.dexHelper.multiContract,
+    );
+    config.tokenAddresses.forEach(
+      (token: Address) => (this.supportedTokensMap[token] = true),
+    );
+    this.pool = new MetavaultTradeEventPool(
+      this.dexKey,
+      this.network,
+      this.dexHelper,
+      this.logger,
+      config,
+    );
+    this.dexHelper.blockManager.subscribeToLogs(
+      this.pool,
+      this.pool.addressesSubscribed,
+      blockNumber,
+    );
+  }
+
+  // Returns the list of contract adapters (name and index)
+  // for a buy/sell. Return null if there are no adapters.
+  getAdapters(side: SwapSide): { name: string; index: number }[] | null {
+    return this.adapters[side] ? this.adapters[side] : null;
+  }
+
+  // Returns list of pool identifiers that can be used
+  // for a given swap. poolIdentifiers must be unique
+  // across DEXes. It is recommended to use
+  // ${dexKey}_${poolAddress} as a poolIdentifier
+  async getPoolIdentifiers(
+    srcToken: Token,
+    destToken: Token,
+    side: SwapSide,
+    blockNumber: number,
+  ): Promise<string[]> {
+    if (side === SwapSide.BUY || !this.pool) return [];
+    const srcAddress = this.dexHelper.config
+      .wrapETH(srcToken)
+      .address.toLowerCase();
+    const destAddress = this.dexHelper.config
+      .wrapETH(destToken)
+      .address.toLowerCase();
+    if (
+      srcAddress !== destAddress &&
+      this.supportedTokensMap[srcAddress] &&
+      this.supportedTokensMap[destAddress]
+    ) {
+      return [`${this.dexKey}_${srcAddress}`, `${this.dexKey}_${destAddress}`];
+    }
+    return [];
+  }
+
+  // Returns pool prices for amounts.
+  // If limitPools is defined only pools in limitPools
+  // should be used. If limitPools is undefined then
+  // any pools can be used.
+  async getPricesVolume(
+    srcToken: Token,
+    destToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    limitPools?: string[],
+  ): Promise<null | ExchangePrices<MetavaultTradeData>> {
+    if (side === SwapSide.BUY || !this.pool) return null;
+    const srcAddress = this.dexHelper.config
+      .wrapETH(srcToken)
+      .address.toLowerCase();
+    const destAddress = this.dexHelper.config
+      .wrapETH(destToken)
+      .address.toLowerCase();
+    if (
+      srcAddress === destAddress ||
+      !(
+        this.supportedTokensMap[srcAddress] &&
+        this.supportedTokensMap[destAddress]
+      )
+    )
+      return null;
+    const srcPoolIdentifier = `${this.dexKey}_${srcAddress}`;
+    const destPoolIdentifier = `${this.dexKey}_${destAddress}`;
+    const pools = [srcPoolIdentifier, destPoolIdentifier];
+    if (limitPools && pools.some(p => !limitPools.includes(p))) return null;
+
+    const unitVolume = getBigIntPow(srcToken.decimals);
+    const prices = await this.pool.getAmountOut(
+      srcAddress,
+      destAddress,
+      [unitVolume, ...amounts],
+      blockNumber,
+    );
+
+    if (!prices) return null;
+
+    return [
+      {
+        prices: prices.slice(1),
+        unit: prices[0],
+        gasCost: MetavaultTradeGasCost,
+        exchange: this.dexKey,
+        data: {
+          exchange: '',
+        },
+        poolAddresses: [this.params.vault],
+      },
+    ];
+  }
+
+  // Returns estimated gas cost of calldata for this DEX in multiSwap
+  getCalldataGasCost(
+    poolPrices: PoolPrices<MetavaultTradeData>,
+  ): number | number[] {
+    return CALLDATA_GAS_COST.DEX_NO_PAYLOAD;
+  }
+
+  // Encode params required by the exchange adapter
+  // Used for multiSwap, buy & megaSwap
+  // Hint: abiCoder.encodeParameter() could be useful
+  getAdapterParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: MetavaultTradeData,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    return {
+      targetExchange: this.params.vault,
+      payload: '0x',
+      networkFee: '0',
+    };
+  }
+
+  // Encode call data used by simpleSwap like routers
+  // Used for simpleSwap & simpleBuy
+  // Hint: this.buildSimpleParamWithoutWETHConversion
+  // could be useful
+  async getSimpleParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: MetavaultTradeData,
+    side: SwapSide,
+  ): Promise<SimpleExchangeParam> {
+    return {
+      callees: [srcToken, this.params.vault],
+      calldata: [
+        MetavaultTrade.erc20Interface.encodeFunctionData('transfer', [
+          this.params.vault,
+          srcAmount,
+        ]),
+        Vault.interface.encodeFunctionData('swap', [
+          srcToken,
+          destToken,
+          this.augustusAddress,
+        ]),
+      ],
+      values: ['0', '0'],
+      networkFee: '0',
+    };
+  }
+
+  // This is called once before getTopPoolsForToken is
+  // called for multiple tokens. This can be helpful to
+  // update common state required for calculating
+  // getTopPoolsForToken. It is optional for a DEX
+  // to implement this
+  async updatePoolState(): Promise<void> {
+    if (!this.supportedTokens.length) {
+      const tokenAddresses = await MetavaultTradeEventPool.getWhitelistedTokens(
+        this.params.vault,
+        'latest',
+        this.dexHelper.multiContract,
+      );
+
+      const decimalsCallData =
+        MetavaultTrade.erc20Interface.encodeFunctionData('decimals');
+      const tokenBalanceMultiCall = tokenAddresses.map(t => ({
+        target: t,
+        callData: decimalsCallData,
+      }));
+      const res = (
+        await this.dexHelper.multiContract.methods
+          .aggregate(tokenBalanceMultiCall)
+          .call()
+      ).returnData;
+
+      const tokenDecimals = res.map((r: any) =>
+        parseInt(
+          MetavaultTrade.erc20Interface
+            .decodeFunctionResult('decimals', r)[0]
+            .toString(),
+        ),
+      );
+
+      this.supportedTokens = tokenAddresses.map((t, i) => ({
+        address: t,
+        decimals: tokenDecimals[i],
+      }));
+    }
+
+    const erc20BalanceCalldata =
+      MetavaultTrade.erc20Interface.encodeFunctionData('balanceOf', [
+        this.params.vault,
+      ]);
+    const tokenBalanceMultiCall = this.supportedTokens.map(t => ({
+      target: t.address,
+      callData: erc20BalanceCalldata,
+    }));
+    const res = (
+      await this.dexHelper.multiContract.methods
+        .aggregate(tokenBalanceMultiCall)
+        .call()
+    ).returnData;
+    const tokenBalances = res.map((r: any) =>
+      BigInt(
+        MetavaultTrade.erc20Interface
+          .decodeFunctionResult('balanceOf', r)[0]
+          .toString(),
+      ),
+    );
+    const tokenBalancesUSD = await Promise.all(
+      this.supportedTokens.map((t, i) =>
+        this.dexHelper.getTokenUSDPrice(t, tokenBalances[i]),
+      ),
+    );
+    this.vaultUSDBalance = tokenBalancesUSD.reduce(
+      (sum: number, curr: number) => sum + curr,
+    );
+  }
+
+  // Returns list of top pools based on liquidity. Max
+  // limit number pools should be returned.
+  async getTopPoolsForToken(
+    _tokenAddress: Address,
+    limit: number,
+  ): Promise<PoolLiquidity[]> {
+    const tokenAddress = _tokenAddress.toLowerCase();
+    if (!this.supportedTokens.some(t => t.address === tokenAddress)) return [];
+    return [
+      {
+        exchange: this.dexKey,
+        address: this.params.vault,
+        connectorTokens: this.supportedTokens.filter(
+          t => t.address !== tokenAddress,
+        ),
+        liquidityUSD: this.vaultUSDBalance,
+      },
+    ];
+  }
+}

--- a/src/dex/metavault-trade/pool.ts
+++ b/src/dex/metavault-trade/pool.ts
@@ -1,0 +1,357 @@
+import { DeepReadonly } from 'ts-essentials';
+import { Lens, lens } from '../../lens';
+import { Address, Log, Logger, MultiCallInput } from '../../types';
+import { ComposedEventSubscriber } from '../../composed-event-subscriber';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { PoolState, DexParams, PoolConfig } from './types';
+import { ChainLinkSubscriber } from '../../lib/chainlink';
+import { FastPriceFeed } from './fast-price-feed';
+import { VaultPriceFeed } from './vault-price-feed';
+import { Vault } from './vault';
+import { USDM } from './usdm';
+import { Contract } from 'web3-eth-contract';
+import ReaderABI from '../../abi/metavault-trade/reader.json';
+
+const MAX_AMOUNT_IN_CACHE_TTL = 5 * 60;
+
+export class MetavaultTradeEventPool extends ComposedEventSubscriber<PoolState> {
+  PRICE_PRECISION = 10n ** 30n;
+  USDM_DECIMALS = 18;
+  BASIS_POINTS_DIVISOR = 10000n;
+
+  vault: Vault<PoolState>;
+  reader: Contract;
+
+  constructor(
+    protected parentName: string,
+    protected network: number,
+    protected dexHelper: IDexHelper,
+    logger: Logger,
+    config: PoolConfig,
+  ) {
+    const chainlinkMap = Object.entries(config.chainlink).reduce(
+      (
+        acc: { [address: string]: ChainLinkSubscriber<PoolState> },
+        [key, value],
+      ) => {
+        acc[key] = new ChainLinkSubscriber<PoolState>(
+          value.proxy,
+          value.aggregator,
+          lens<DeepReadonly<PoolState>>().primaryPrices[key],
+          dexHelper.getLogger(`${key} ChainLink for ${parentName}-${network}`),
+        );
+        return acc;
+      },
+      {},
+    );
+    const fastPriceFeed = new FastPriceFeed(
+      config.fastPriceFeed,
+      config.fastPriceEvents,
+      config.tokenAddresses,
+      config.fastPriceFeedConfig,
+      lens<DeepReadonly<PoolState>>().secondaryPrices,
+      dexHelper.getLogger(`${parentName}-${network} fastPriceFeed`),
+    );
+    const vaultPriceFeed = new VaultPriceFeed(
+      config.vaultPriceFeedConfig,
+      chainlinkMap,
+      fastPriceFeed,
+    );
+    const usdm = new USDM(
+      config.usdmAddress,
+      lens<DeepReadonly<PoolState>>().usdm,
+      dexHelper.getLogger(`${parentName}-${network} USDG`),
+    );
+    const vault = new Vault(
+      config.vaultAddress,
+      config.tokenAddresses,
+      config.vaultConfig,
+      vaultPriceFeed,
+      usdm,
+      lens<DeepReadonly<PoolState>>().vault,
+      dexHelper.getLogger(`${parentName}-${network} vault`),
+    );
+    super(
+      parentName,
+      dexHelper.getLogger(`${parentName}-${network}`),
+      dexHelper,
+      [...Object.values(chainlinkMap), fastPriceFeed, usdm, vault],
+      {
+        primaryPrices: {},
+        secondaryPrices: {
+          lastUpdatedAt: 0,
+          prices: {},
+        },
+        vault: {
+          usdmAmounts: {},
+        },
+        usdm: {
+          totalSupply: 0n,
+        },
+      },
+    );
+    this.vault = vault;
+    this.reader = new this.dexHelper.web3Provider.eth.Contract(
+      ReaderABI as any,
+      config.readerAddress,
+    );
+  }
+
+  async getStateOrGenerate(blockNumber: number): Promise<Readonly<PoolState>> {
+    const evenState = this.getState(blockNumber);
+    if (evenState) return evenState;
+    const onChainState = await this.generateState(blockNumber);
+    this.setState(onChainState, blockNumber);
+    return onChainState;
+  }
+
+  async getMaxAmountIn(_tokenIn: Address, _tokenOut: Address): Promise<bigint> {
+    const cacheKey = `maxAmountIn_${_tokenIn}_${_tokenOut}`;
+    const maxAmountCached = await this.dexHelper.cache.get(
+      this.parentName,
+      this.network,
+      cacheKey,
+    );
+    if (maxAmountCached) return BigInt(maxAmountCached);
+    const maxAmount: string = await this.reader.methods
+      .getMaxAmountIn(this.vault.vaultAddress, _tokenIn, _tokenOut)
+      .call();
+    this.dexHelper.cache.setex(
+      this.parentName,
+      this.network,
+      cacheKey,
+      MAX_AMOUNT_IN_CACHE_TTL,
+      maxAmount,
+    );
+    return BigInt(maxAmount);
+  }
+
+  // Reference to the original implementation
+  // https://github.com/gmx-io/gmx-contracts/blob/master/contracts/peripherals/Reader.sol#L71
+  async getAmountOut(
+    _tokenIn: Address,
+    _tokenOut: Address,
+    _amountsIn: bigint[],
+    blockNumber: number,
+  ): Promise<bigint[] | null> {
+    const maxAmountIn = await this.getMaxAmountIn(_tokenIn, _tokenOut);
+    const state = await this.getStateOrGenerate(blockNumber);
+    const priceIn = this.vault.getMinPrice(state, _tokenIn);
+    const priceOut = this.vault.getMaxPrice(state, _tokenOut);
+
+    const tokenInDecimals = this.vault.tokenDecimals[_tokenIn];
+    const tokenOutDecimals = this.vault.tokenDecimals[_tokenOut];
+
+    const isStableSwap =
+      this.vault.stableTokens[_tokenIn] && this.vault.stableTokens[_tokenOut];
+    const baseBps = isStableSwap
+      ? this.vault.stableSwapFeeBasisPoints
+      : this.vault.swapFeeBasisPoints;
+    const taxBps = isStableSwap
+      ? this.vault.stableTaxBasisPoints
+      : this.vault.taxBasisPoints;
+    const USDMUnit = BigInt(10 ** this.USDM_DECIMALS);
+    const tokenInUnit = BigInt(10 ** tokenInDecimals);
+    const tokenOutUnit = BigInt(10 ** tokenOutDecimals);
+
+    return _amountsIn.map(_amountIn => {
+      if (_amountIn > maxAmountIn) return 0n;
+      let feeBasisPoints;
+      {
+        let usdmAmount = (_amountIn * priceIn) / this.PRICE_PRECISION;
+        usdmAmount = (usdmAmount * USDMUnit) / tokenInUnit;
+
+        const feesBasisPoints0 = this.vault.getFeeBasisPoints(
+          state,
+          _tokenIn,
+          usdmAmount,
+          baseBps,
+          taxBps,
+          true,
+        );
+        const feesBasisPoints1 = this.vault.getFeeBasisPoints(
+          state,
+          _tokenOut,
+          usdmAmount,
+          baseBps,
+          taxBps,
+          false,
+        );
+        // use the higher of the two fee basis points
+        feeBasisPoints =
+          feesBasisPoints0 > feesBasisPoints1
+            ? feesBasisPoints0
+            : feesBasisPoints1;
+      }
+
+      let amountOut = (_amountIn * priceIn) / priceOut;
+      amountOut = (amountOut * tokenOutUnit) / tokenInUnit;
+
+      const amountOutAfterFees =
+        (amountOut * (this.BASIS_POINTS_DIVISOR - feeBasisPoints)) /
+        this.BASIS_POINTS_DIVISOR;
+      return amountOutAfterFees;
+    });
+  }
+
+  static async getWhitelistedTokens(
+    vaultAddress: Address,
+    blockNumber: number | 'latest',
+    multiContract: Contract,
+  ) {
+    // get tokens count
+    const tokenCountResult = (
+      await multiContract.methods
+        .aggregate([
+          {
+            callData: Vault.interface.encodeFunctionData(
+              'allWhitelistedTokensLength',
+            ),
+            target: vaultAddress,
+          },
+        ])
+        .call({}, blockNumber)
+    ).returnData;
+    const tokensCount = parseInt(
+      Vault.interface
+        .decodeFunctionResult('allWhitelistedTokensLength', tokenCountResult[0])
+        .toString(),
+    );
+
+    // get tokens
+    const getTokensCalldata = new Array(tokensCount).fill(0).map((_, i) => {
+      return {
+        callData: Vault.interface.encodeFunctionData('allWhitelistedTokens', [
+          i,
+        ]),
+        target: vaultAddress,
+      };
+    });
+    const tokensResult = (
+      await multiContract.methods
+        .aggregate(getTokensCalldata)
+        .call({}, blockNumber)
+    ).returnData;
+    const tokens: Address[] = tokensResult.map((t: any) =>
+      Vault.interface
+        .decodeFunctionResult('allWhitelistedTokens', t)[0]
+        .toLowerCase(),
+    );
+    return tokens;
+  }
+
+  static async getConfig(
+    dexParams: DexParams,
+    blockNumber: number | 'latest',
+    multiContract: Contract,
+  ): Promise<PoolConfig> {
+    const tokens = await this.getWhitelistedTokens(
+      dexParams.vault,
+      blockNumber,
+      multiContract,
+    );
+
+    // get price chainlink price feed
+    const getPriceFeedCalldata = tokens.map(t => {
+      return {
+        callData: VaultPriceFeed.interface.encodeFunctionData('priceFeeds', [
+          t,
+        ]),
+        target: dexParams.priceFeed,
+      };
+    });
+    const priceFeedResult = (
+      await multiContract.methods
+        .aggregate(getPriceFeedCalldata)
+        .call({}, blockNumber)
+    ).returnData;
+    const priceFeeds = priceFeedResult.map((p: any) =>
+      VaultPriceFeed.interface
+        .decodeFunctionResult('priceFeeds', p)[0]
+        .toString()
+        .toLowerCase(),
+    );
+
+    // get config for all event listeners
+    let multicallSlices: [number, number][] = [];
+    let multiCallData: MultiCallInput[] = [];
+    let i = 0;
+    for (let priceFeed of priceFeeds) {
+      const chainlinkConfigCallData =
+        ChainLinkSubscriber.getReadAggregatorMultiCallInput(priceFeed);
+      multiCallData.push(chainlinkConfigCallData);
+      multicallSlices.push([i, i + 1]);
+      i += 1;
+    }
+
+    const fastPriceFeedConfigCallData = FastPriceFeed.getConfigMulticallInputs(
+      dexParams.fastPriceFeed,
+    );
+    multiCallData.push(...fastPriceFeedConfigCallData);
+    multicallSlices.push([i, i + fastPriceFeedConfigCallData.length]);
+    i += fastPriceFeedConfigCallData.length;
+
+    const vaultPriceFeedConfigCallData =
+      VaultPriceFeed.getConfigMulticallInputs(dexParams.priceFeed, tokens);
+    multiCallData.push(...vaultPriceFeedConfigCallData);
+    multicallSlices.push([i, i + vaultPriceFeedConfigCallData.length]);
+    i += vaultPriceFeedConfigCallData.length;
+
+    const vaultConfigCallData = Vault.getConfigMulticallInputs(
+      dexParams.vault,
+      tokens,
+    );
+    multiCallData.push(...vaultConfigCallData);
+    multicallSlices.push([i, i + vaultConfigCallData.length]);
+    i += vaultConfigCallData.length;
+
+    const configResults = (
+      await multiContract.methods.aggregate(multiCallData).call({}, blockNumber)
+    ).returnData;
+
+    const chainlink: {
+      [address: string]: { proxy: Address; aggregator: Address };
+    } = {};
+    for (let token of tokens) {
+      const aggregator = ChainLinkSubscriber.readAggregator(
+        configResults.slice(...multicallSlices.shift()!)[0],
+      );
+      chainlink[token] = {
+        proxy: priceFeeds.shift(),
+        aggregator,
+      };
+    }
+
+    const fastPriceFeedConfigResults = configResults.slice(
+      ...multicallSlices.shift()!,
+    );
+    const fastPriceFeedConfig = FastPriceFeed.getConfig(
+      fastPriceFeedConfigResults,
+    );
+
+    const vaultPriceFeedConfigResults = configResults.slice(
+      ...multicallSlices.shift()!,
+    );
+    const vaultPriceFeedConfig = VaultPriceFeed.getConfig(
+      vaultPriceFeedConfigResults,
+      tokens,
+    );
+
+    const vaultConfigResults = configResults.slice(...multicallSlices.shift()!);
+    const vaultConfig = Vault.getConfig(vaultConfigResults, tokens);
+
+    return {
+      vaultAddress: dexParams.vault,
+      readerAddress: dexParams.reader,
+      priceFeed: dexParams.priceFeed,
+      fastPriceFeed: dexParams.fastPriceFeed,
+      fastPriceEvents: dexParams.fastPriceEvents,
+      usdmAddress: dexParams.usdm,
+      tokenAddresses: tokens,
+      vaultConfig,
+      vaultPriceFeedConfig,
+      fastPriceFeedConfig,
+      chainlink,
+    };
+  }
+}

--- a/src/dex/metavault-trade/types.ts
+++ b/src/dex/metavault-trade/types.ts
@@ -1,0 +1,89 @@
+import { ChainLinkState } from '../../lib/chainlink';
+import { Address } from '../../types';
+
+export type PoolState = {
+  primaryPrices: { [poolAddress: string]: ChainLinkState };
+  secondaryPrices: FastPriceFeedState;
+  vault: VaultState;
+  usdm: USDMState;
+};
+
+export type FastPriceFeedState = {
+  lastUpdatedAt: number;
+  prices: { [tokenAddress: string]: bigint };
+};
+
+export type VaultState = {
+  usdmAmounts: { [tokenAddress: string]: bigint };
+};
+
+export type USDMState = {
+  totalSupply: bigint;
+};
+
+export type MetavaultTradeData = {
+  exchange: string;
+};
+
+export type DexParams = {
+  vault: Address;
+  reader: Address;
+  priceFeed: Address;
+  fastPriceFeed: Address;
+  fastPriceEvents: Address;
+  // Last three param can be fetched on chain by calling
+  // vaultAddress.priceFeed() => priceFeed
+  // priceFeed.secondaryPriceFeed() => fastPriceFeed
+  // fastPriceFeed.fastPriceEvents() => fastPriceEvents
+  // It is added as constants to avoid unnecessary
+  // sequential onchain calls
+  usdm: Address;
+};
+
+export type FastPriceFeedConfig = {
+  priceDuration: number;
+  maxDeviationBasisPoints: bigint;
+  favorFastPrice: boolean;
+  volBasisPoints: bigint;
+};
+
+export type VaultPriceFeedConfig = {
+  isAmmEnabled: boolean;
+  isSecondaryPriceEnabled: boolean;
+  strictStableTokens: { [address: string]: boolean };
+  spreadBasisPoints: { [address: string]: bigint };
+  adjustmentBasisPoints: { [address: string]: bigint };
+  isAdjustmentAdditive: { [address: string]: boolean };
+  priceDecimals: { [address: string]: number };
+  maxStrictPriceDeviation: bigint;
+  useV2Pricing: boolean;
+  priceSampleSpace: number;
+};
+
+export type VaultConfig = {
+  tokenDecimals: { [address: string]: number };
+  stableTokens: { [address: string]: boolean };
+  tokenWeights: { [address: string]: bigint };
+  stableSwapFeeBasisPoints: bigint;
+  swapFeeBasisPoints: bigint;
+  stableTaxBasisPoints: bigint;
+  taxBasisPoints: bigint;
+  hasDynamicFees: bigint;
+  includeAmmPrice: boolean;
+  useSwapPricing: boolean;
+  totalTokenWeights: bigint;
+};
+
+export type PoolConfig = {
+  vaultAddress: Address;
+  readerAddress: Address;
+  priceFeed: Address;
+  fastPriceFeed: Address;
+  fastPriceEvents: Address;
+  usdmAddress: Address;
+  tokenAddresses: Address[];
+  vaultConfig: VaultConfig;
+  vaultPriceFeedConfig: VaultPriceFeedConfig;
+  fastPriceFeedConfig: FastPriceFeedConfig;
+  chainlink: { [address: string]: { proxy: Address; aggregator: Address } };
+};

--- a/src/dex/metavault-trade/types.ts
+++ b/src/dex/metavault-trade/types.ts
@@ -1,5 +1,5 @@
-import { ChainLinkState } from '../../lib/chainlink';
 import { Address } from '../../types';
+import { ChainLinkState } from '../../lib/chainlink';
 
 export type PoolState = {
   primaryPrices: { [poolAddress: string]: ChainLinkState };
@@ -21,8 +21,16 @@ export type USDMState = {
   totalSupply: bigint;
 };
 
+export type VaultPriceFeedState = {
+  lastUpdatedAt: number;
+};
+
 export type MetavaultTradeData = {
-  exchange: string;
+  // TODO: MetavaultTradeData is the dex data that is
+  // returned by the API that can be used for
+  // tx building. The data structure should be minimal.
+  // Complete me!
+  // exchange: Address;
 };
 
 export type DexParams = {
@@ -43,12 +51,13 @@ export type DexParams = {
 export type FastPriceFeedConfig = {
   priceDuration: number;
   maxDeviationBasisPoints: bigint;
-  favorFastPrice: boolean;
-  volBasisPoints: bigint;
+  favorFastPrice: Record<string, boolean>;
+  spreadBasisPointsIfInactive: bigint;
+  spreadBasisPointsIfChainError: bigint;
+  maxPriceUpdateDelay: number;
 };
 
 export type VaultPriceFeedConfig = {
-  isAmmEnabled: boolean;
   isSecondaryPriceEnabled: boolean;
   strictStableTokens: { [address: string]: boolean };
   spreadBasisPoints: { [address: string]: bigint };
@@ -56,7 +65,6 @@ export type VaultPriceFeedConfig = {
   isAdjustmentAdditive: { [address: string]: boolean };
   priceDecimals: { [address: string]: number };
   maxStrictPriceDeviation: bigint;
-  useV2Pricing: boolean;
   priceSampleSpace: number;
 };
 

--- a/src/dex/metavault-trade/usdm.ts
+++ b/src/dex/metavault-trade/usdm.ts
@@ -1,0 +1,83 @@
+import _ from 'lodash';
+import { Interface } from '@ethersproject/abi';
+import { DeepReadonly } from 'ts-essentials';
+import { PartialEventSubscriber } from '../../composed-event-subscriber';
+import {
+  Address,
+  MultiCallInput,
+  MultiCallOutput,
+  Logger,
+  Log,
+  BlockHeader,
+} from '../../types';
+import { USDMState } from './types';
+import ERC20ABI from '../../abi/erc20.json';
+import { Lens } from '../../lens';
+import { NULL_ADDRESS } from '../../constants';
+
+export class USDM<State> extends PartialEventSubscriber<State, USDMState> {
+  static readonly interface = new Interface(ERC20ABI);
+
+  constructor(
+    private usdgAddress: Address,
+    lens: Lens<DeepReadonly<State>, DeepReadonly<USDMState>>,
+    logger: Logger,
+  ) {
+    super([usdgAddress], lens, logger);
+  }
+
+  getTotalSupply(state: DeepReadonly<State>) {
+    return this.lens.get()(state).totalSupply;
+  }
+
+  public processLog(
+    state: DeepReadonly<USDMState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): DeepReadonly<USDMState> | null {
+    try {
+      const parsed = USDM.interface.parseLog(log);
+      const _state: USDMState = _.cloneDeep(state);
+      switch (parsed.name) {
+        case 'Transfer': {
+          const fromAddress = parsed.args.src;
+          const toAddress = parsed.args.dst;
+          if (fromAddress === NULL_ADDRESS) {
+            _state.totalSupply += BigInt(parsed.args.wad.toString());
+          } else if (toAddress === NULL_ADDRESS) {
+            _state.totalSupply -= BigInt(parsed.args.wad.toString());
+          }
+          return _state;
+        }
+        default:
+          return null;
+      }
+    } catch (e) {
+      this.logger.error('Failed to parse log', e);
+      return null;
+    }
+  }
+
+  public getGenerateStateMultiCallInputs(): MultiCallInput[] {
+    return [
+      {
+        target: this.usdgAddress,
+        callData: USDM.interface.encodeFunctionData('totalSupply'),
+      },
+    ];
+  }
+
+  public generateState(
+    multicallOutputs: MultiCallOutput[],
+    blockNumber?: number | 'latest',
+  ): DeepReadonly<USDMState> {
+    return {
+      totalSupply: BigInt(
+        USDM.interface.decodeFunctionResult(
+          'totalSupply',
+          multicallOutputs[0],
+        )[0],
+      ),
+    };
+  }
+}

--- a/src/dex/metavault-trade/vault-price-feed.ts
+++ b/src/dex/metavault-trade/vault-price-feed.ts
@@ -1,0 +1,384 @@
+import { Interface } from '@ethersproject/abi';
+import { Address, MultiCallInput, MultiCallOutput } from '../../types';
+import { PoolState, VaultPriceFeedConfig } from './types';
+import { FastPriceFeed } from './fast-price-feed';
+import VaultPriceFeedAbi from '../../abi/metavault-trade/vault-price-feed.json';
+import { ChainLinkSubscriber } from '../../lib/chainlink';
+import { DeepReadonly } from 'ts-essentials';
+
+export class VaultPriceFeed<State> {
+  BASIS_POINTS_DIVISOR = 10000n;
+  PRICE_PRECISION = 10n ** 30n;
+  ONE_USD = this.PRICE_PRECISION;
+
+  static interface = new Interface(VaultPriceFeedAbi);
+
+  protected isAmmEnabled: boolean;
+  protected isSecondaryPriceEnabled: boolean;
+  protected strictStableTokens: { [address: string]: boolean };
+  protected spreadBasisPoints: { [address: string]: bigint };
+  protected adjustmentBasisPoints: { [address: string]: bigint };
+  protected isAdjustmentAdditive: { [address: string]: boolean };
+  protected priceDecimals: { [address: string]: number };
+  protected maxStrictPriceDeviation: bigint;
+  protected useV2Pricing: boolean;
+  protected priceSampleSpace: number;
+
+  constructor(
+    config: VaultPriceFeedConfig,
+    protected primaryPrices: { [token: string]: ChainLinkSubscriber<State> },
+    protected secondaryPrice: FastPriceFeed<State>,
+  ) {
+    this.isAmmEnabled = config.isAmmEnabled;
+    this.isSecondaryPriceEnabled = config.isSecondaryPriceEnabled;
+    this.strictStableTokens = config.strictStableTokens;
+    this.spreadBasisPoints = config.spreadBasisPoints;
+    this.adjustmentBasisPoints = config.adjustmentBasisPoints;
+    this.isAdjustmentAdditive = config.isAdjustmentAdditive;
+    this.priceDecimals = config.priceDecimals;
+    this.maxStrictPriceDeviation = config.maxStrictPriceDeviation;
+    this.useV2Pricing = config.useV2Pricing;
+    this.priceSampleSpace = config.priceSampleSpace;
+  }
+
+  getPrice(
+    state: DeepReadonly<State>,
+    _token: Address,
+    _maximise: boolean,
+    _includeAmmPrice: boolean,
+    _useSwapPricing: boolean,
+  ): bigint {
+    let price = this.useV2Pricing
+      ? this.getPriceV2(state, _token, _maximise, _includeAmmPrice)
+      : this.getPriceV1(state, _token, _maximise, _includeAmmPrice);
+
+    const adjustmentBps = this.adjustmentBasisPoints[_token];
+    if (adjustmentBps > 0n) {
+      const isAdditive = this.isAdjustmentAdditive[_token];
+      if (isAdditive) {
+        price =
+          (price * (this.BASIS_POINTS_DIVISOR + adjustmentBps)) /
+          this.BASIS_POINTS_DIVISOR;
+      } else {
+        price =
+          (price * (this.BASIS_POINTS_DIVISOR - adjustmentBps)) /
+          this.BASIS_POINTS_DIVISOR;
+      }
+    }
+
+    return price;
+  }
+
+  getPriceV2(
+    state: DeepReadonly<State>,
+    _token: Address,
+    _maximise: boolean,
+    _includeAmmPrice: boolean,
+  ): bigint {
+    throw new Error(
+      'getPriceV2 implementation is not complete, devs should disable the dex or complete the implementation',
+    );
+  }
+
+  getPriceV1(
+    state: DeepReadonly<State>,
+    _token: Address,
+    _maximise: boolean,
+    _includeAmmPrice: boolean,
+  ): bigint {
+    let price = this.getPrimaryPrice(state, _token, _maximise);
+
+    if (_includeAmmPrice && this.isAmmEnabled) {
+      const ammPrice = this.getAmmPrice(state, _token);
+      if (ammPrice > 0n) {
+        if (_maximise && ammPrice > price) {
+          price = ammPrice;
+        }
+        if (!_maximise && ammPrice < price) {
+          price = ammPrice;
+        }
+      }
+    }
+
+    if (this.isSecondaryPriceEnabled) {
+      price = this.getSecondaryPrice(state, _token, price, _maximise);
+    }
+
+    if (this.strictStableTokens[_token]) {
+      const delta =
+        price > this.ONE_USD ? price - this.ONE_USD : this.ONE_USD - price;
+      if (delta <= this.maxStrictPriceDeviation) {
+        return this.ONE_USD;
+      }
+
+      // if _maximise and price is e.g. 1.02, return 1.02
+      if (_maximise && price > this.ONE_USD) {
+        return price;
+      }
+
+      // if !_maximise and price is e.g. 0.98, return 0.98
+      if (!_maximise && price < this.ONE_USD) {
+        return price;
+      }
+
+      return this.ONE_USD;
+    }
+
+    const _spreadBasisPoints = this.spreadBasisPoints[_token];
+
+    if (_maximise) {
+      return (
+        (price * (this.BASIS_POINTS_DIVISOR + _spreadBasisPoints)) /
+        this.BASIS_POINTS_DIVISOR
+      );
+    }
+
+    return (
+      (price * (this.BASIS_POINTS_DIVISOR - _spreadBasisPoints)) /
+      this.BASIS_POINTS_DIVISOR
+    );
+  }
+
+  getAmmPrice(state: DeepReadonly<State>, token: Address): bigint {
+    throw new Error(
+      'getAmmPrice implementation is not complete, devs should disable the dex or complete the implementation',
+    );
+  }
+
+  getPrimaryPrice(
+    state: DeepReadonly<State>,
+    _token: Address,
+    _maximise: boolean,
+  ): bigint {
+    // const priceFeedAddress = this.priceFeeds[_token];
+    // require(priceFeedAddress != address(0), "VaultPriceFeed: invalid price feed");
+
+    // if (chainlinkFlags != address(0)) {
+    //   bool isRaised = IChainlinkFlags(chainlinkFlags).getFlag(FLAG_ARBITRUM_SEQ_OFFLINE);
+    //   if (isRaised) {
+    //           // If flag is raised we shouldn't perform any critical operations
+    //       revert("Chainlink feeds are not being updated");
+    //   }
+    // }
+
+    // IPriceFeed priceFeed = IPriceFeed(priceFeedAddress);
+    let price = 0n;
+    // const roundId = priceFeed.latestRound;
+
+    // for (let i = 0; i < this.priceSampleSpace; i++) {
+    //   if (roundId <= i) {
+    //     break;
+    //   }
+
+    //   if (i == 0) {
+    //       const _p = priceFeed.latestAnswer();
+    //       require(_p > 0, "VaultPriceFeed: invalid price");
+    //       p = uint256(_p);
+    //   } else {
+    //       (, int256 _p, , ,) = priceFeed.getRoundData(roundId - i);
+    //       require(_p > 0, "VaultPriceFeed: invalid price");
+    //       p = uint256(_p);
+    //   }
+
+    //   if (price == 0n) {
+    //     price = p;
+    //     continue;
+    //   }
+
+    //   if (_maximise && p > price) {
+    //     price = p;
+    //     continue;
+    //   }
+
+    //   if (!_maximise && p < price) {
+    //     price = p;
+    //   }
+    // }
+    if (this.priceSampleSpace > 1) {
+      throw new Error(
+        'Chainlink price feed is not implemented for historical prices',
+      );
+    }
+    price = this.primaryPrices[_token].getLatestRoundData(state);
+
+    // require(price > 0n, "VaultPriceFeed: could not fetch price");
+    if (price <= 0n) throw new Error('VaultPriceFeed: could not fetch price');
+    // normalise price precision
+    const _priceDecimals = this.priceDecimals[_token];
+    return (price * this.PRICE_PRECISION) / BigInt(10 ** _priceDecimals);
+  }
+
+  getSecondaryPrice(
+    state: DeepReadonly<State>,
+    _token: Address,
+    _referencePrice: bigint,
+    _maximise: boolean,
+  ): bigint {
+    return this.secondaryPrice.getPrice(
+      state,
+      _token,
+      _referencePrice,
+      _maximise,
+    );
+  }
+
+  static getConfigMulticallInputs(
+    vaultPriceFeedAddress: Address,
+    tokenAddresses: Address[],
+  ): MultiCallInput[] {
+    return [
+      {
+        target: vaultPriceFeedAddress,
+        callData: VaultPriceFeed.interface.encodeFunctionData('isAmmEnabled'),
+      },
+      {
+        target: vaultPriceFeedAddress,
+        callData: VaultPriceFeed.interface.encodeFunctionData(
+          'isSecondaryPriceEnabled',
+        ),
+      },
+      ...tokenAddresses.map(t => ({
+        target: vaultPriceFeedAddress,
+        callData: VaultPriceFeed.interface.encodeFunctionData(
+          'strictStableTokens',
+          [t],
+        ),
+      })),
+      ...tokenAddresses.map(t => ({
+        target: vaultPriceFeedAddress,
+        callData: VaultPriceFeed.interface.encodeFunctionData(
+          'spreadBasisPoints',
+          [t],
+        ),
+      })),
+      ...tokenAddresses.map(t => ({
+        target: vaultPriceFeedAddress,
+        callData: VaultPriceFeed.interface.encodeFunctionData(
+          'isAdjustmentAdditive',
+          [t],
+        ),
+      })),
+      ...tokenAddresses.map(t => ({
+        target: vaultPriceFeedAddress,
+        callData: VaultPriceFeed.interface.encodeFunctionData(
+          'adjustmentBasisPoints',
+          [t],
+        ),
+      })),
+      ...tokenAddresses.map(t => ({
+        target: vaultPriceFeedAddress,
+        callData: VaultPriceFeed.interface.encodeFunctionData('priceDecimals', [
+          t,
+        ]),
+      })),
+      {
+        target: vaultPriceFeedAddress,
+        callData: VaultPriceFeed.interface.encodeFunctionData(
+          'maxStrictPriceDeviation',
+        ),
+      },
+      {
+        target: vaultPriceFeedAddress,
+        callData: VaultPriceFeed.interface.encodeFunctionData('useV2Pricing'),
+      },
+      {
+        target: vaultPriceFeedAddress,
+        callData:
+          VaultPriceFeed.interface.encodeFunctionData('priceSampleSpace'),
+      },
+    ];
+  }
+
+  static getConfig(
+    multicallOutputs: MultiCallOutput[],
+    tokenAddress: Address[],
+  ): VaultPriceFeedConfig {
+    let i = 0;
+    return {
+      isAmmEnabled: VaultPriceFeed.interface.decodeFunctionResult(
+        'isAmmEnabled',
+        multicallOutputs[i++],
+      )[0],
+      isSecondaryPriceEnabled: VaultPriceFeed.interface.decodeFunctionResult(
+        'isSecondaryPriceEnabled',
+        multicallOutputs[i++],
+      )[0],
+      strictStableTokens: tokenAddress.reduce(
+        (acc: { [address: string]: boolean }, t: Address) => {
+          acc[t] = VaultPriceFeed.interface.decodeFunctionResult(
+            'strictStableTokens',
+            multicallOutputs[i++],
+          )[0];
+          return acc;
+        },
+        {},
+      ),
+      spreadBasisPoints: tokenAddress.reduce(
+        (acc: { [address: string]: bigint }, t: Address) => {
+          acc[t] = BigInt(
+            VaultPriceFeed.interface
+              .decodeFunctionResult(
+                'spreadBasisPoints',
+                multicallOutputs[i++],
+              )[0]
+              .toString(),
+          );
+          return acc;
+        },
+        {},
+      ),
+      isAdjustmentAdditive: tokenAddress.reduce(
+        (acc: { [address: string]: boolean }, t: Address) => {
+          acc[t] = VaultPriceFeed.interface.decodeFunctionResult(
+            'isAdjustmentAdditive',
+            multicallOutputs[i++],
+          )[0];
+          return acc;
+        },
+        {},
+      ),
+      adjustmentBasisPoints: tokenAddress.reduce(
+        (acc: { [address: string]: bigint }, t: Address) => {
+          acc[t] = BigInt(
+            VaultPriceFeed.interface
+              .decodeFunctionResult(
+                'adjustmentBasisPoints',
+                multicallOutputs[i++],
+              )[0]
+              .toString(),
+          );
+          return acc;
+        },
+        {},
+      ),
+      priceDecimals: tokenAddress.reduce(
+        (acc: { [address: string]: number }, t: Address) => {
+          acc[t] = parseInt(
+            VaultPriceFeed.interface
+              .decodeFunctionResult('priceDecimals', multicallOutputs[i++])[0]
+              .toString(),
+          );
+          return acc;
+        },
+        {},
+      ),
+      maxStrictPriceDeviation: BigInt(
+        VaultPriceFeed.interface
+          .decodeFunctionResult(
+            'maxStrictPriceDeviation',
+            multicallOutputs[i++],
+          )[0]
+          .toString(),
+      ),
+      useV2Pricing: VaultPriceFeed.interface.decodeFunctionResult(
+        'useV2Pricing',
+        multicallOutputs[i++],
+      )[0],
+      priceSampleSpace: parseInt(
+        VaultPriceFeed.interface
+          .decodeFunctionResult('priceSampleSpace', multicallOutputs[i++])[0]
+          .toString(),
+      ),
+    };
+  }
+}

--- a/src/dex/metavault-trade/vault-utils.ts
+++ b/src/dex/metavault-trade/vault-utils.ts
@@ -8,7 +8,7 @@ export class VaultUtils<State> {
   getFeeBasisPoints(
     state: DeepReadonly<State>,
     _token: Address,
-    _usdgDelta: bigint,
+    _usdmDelta: bigint,
     _feeBasisPoints: bigint,
     _taxBasisPoints: bigint,
     _increment: boolean,
@@ -17,10 +17,10 @@ export class VaultUtils<State> {
       return _feeBasisPoints;
     }
 
-    const initialAmount = this.vault.getUSDGAmount(state, _token);
-    let nextAmount = initialAmount + _usdgDelta;
+    const initialAmount = this.vault.getUSDMAmount(state, _token);
+    let nextAmount = initialAmount + _usdmDelta;
     if (!_increment) {
-      nextAmount = _usdgDelta > initialAmount ? 0n : initialAmount - _usdgDelta;
+      nextAmount = _usdmDelta > initialAmount ? 0n : initialAmount - _usdmDelta;
     }
 
     const targetAmount = this.vault.getTargetUsdmAmount(state, _token);

--- a/src/dex/metavault-trade/vault-utils.ts
+++ b/src/dex/metavault-trade/vault-utils.ts
@@ -1,0 +1,53 @@
+import { Vault } from './vault';
+import { Address } from '../../types';
+import { DeepReadonly } from 'ts-essentials';
+
+export class VaultUtils<State> {
+  constructor(protected vault: Vault<State>) {}
+
+  getFeeBasisPoints(
+    state: DeepReadonly<State>,
+    _token: Address,
+    _usdgDelta: bigint,
+    _feeBasisPoints: bigint,
+    _taxBasisPoints: bigint,
+    _increment: boolean,
+  ) {
+    if (!this.vault.hasDynamicFees) {
+      return _feeBasisPoints;
+    }
+
+    const initialAmount = this.vault.getUSDGAmount(state, _token);
+    let nextAmount = initialAmount + _usdgDelta;
+    if (!_increment) {
+      nextAmount = _usdgDelta > initialAmount ? 0n : initialAmount - _usdgDelta;
+    }
+
+    const targetAmount = this.vault.getTargetUsdmAmount(state, _token);
+    if (targetAmount == 0n) {
+      return _feeBasisPoints;
+    }
+
+    const initialDiff =
+      initialAmount > targetAmount
+        ? initialAmount - targetAmount
+        : targetAmount - initialAmount;
+    const nextDiff =
+      nextAmount > targetAmount
+        ? nextAmount - targetAmount
+        : targetAmount - nextAmount;
+
+    // action improves relative asset balance
+    if (nextDiff < initialDiff) {
+      const rebateBps = (_taxBasisPoints * initialDiff) / targetAmount;
+      return rebateBps > _feeBasisPoints ? 0n : _feeBasisPoints - rebateBps;
+    }
+
+    let averageDiff = (initialDiff + nextDiff) / 2n;
+    if (averageDiff > targetAmount) {
+      averageDiff = targetAmount;
+    }
+    const taxBps = (_taxBasisPoints * averageDiff) / targetAmount;
+    return _feeBasisPoints + taxBps;
+  }
+}

--- a/src/dex/metavault-trade/vault.ts
+++ b/src/dex/metavault-trade/vault.ts
@@ -1,26 +1,21 @@
-import _ from 'lodash';
 import { Interface } from '@ethersproject/abi';
+import _ from 'lodash';
 import { AsyncOrSync, DeepReadonly } from 'ts-essentials';
+import { BlockHeader } from 'web3-eth';
+import VaultABI from '../../abi/metavault-trade/vault.json';
 import { PartialEventSubscriber } from '../../composed-event-subscriber';
 import { Lens } from '../../lens';
-import VaultABI from '../../abi/metavault-trade/vault.json';
-import { VaultUtils } from './vault-utils';
 import {
-  VaultConfig,
-  VaultState,
-  FastPriceFeedConfig,
-  PoolState,
-} from './types';
-import { VaultPriceFeed } from './vault-price-feed';
-import { USDM } from './usdm';
-import {
+  Address,
+  Log,
+  Logger,
   MultiCallInput,
   MultiCallOutput,
-  Address,
-  Logger,
-  Log,
 } from '../../types';
-import { BlockHeader } from 'web3-eth';
+import { VaultConfig, VaultState } from './types';
+import { USDM } from './usdm';
+import { VaultPriceFeed } from './vault-price-feed';
+import { VaultUtils } from './vault-utils';
 
 export class Vault<State> extends PartialEventSubscriber<State, VaultState> {
   static readonly interface: Interface = new Interface(VaultABI);
@@ -252,7 +247,7 @@ export class Vault<State> extends PartialEventSubscriber<State, VaultState> {
     return vaultState;
   }
 
-  public getUSDGAmount(state: DeepReadonly<State>, token: Address): bigint {
+  public getUSDMAmount(state: DeepReadonly<State>, token: Address): bigint {
     return this.lens.get()(state).usdmAmounts[token];
   }
 

--- a/src/dex/metavault-trade/vault.ts
+++ b/src/dex/metavault-trade/vault.ts
@@ -1,0 +1,290 @@
+import _ from 'lodash';
+import { Interface } from '@ethersproject/abi';
+import { AsyncOrSync, DeepReadonly } from 'ts-essentials';
+import { PartialEventSubscriber } from '../../composed-event-subscriber';
+import { Lens } from '../../lens';
+import VaultABI from '../../abi/metavault-trade/vault.json';
+import { VaultUtils } from './vault-utils';
+import {
+  VaultConfig,
+  VaultState,
+  FastPriceFeedConfig,
+  PoolState,
+} from './types';
+import { VaultPriceFeed } from './vault-price-feed';
+import { USDM } from './usdm';
+import {
+  MultiCallInput,
+  MultiCallOutput,
+  Address,
+  Logger,
+  Log,
+} from '../../types';
+import { BlockHeader } from 'web3-eth';
+
+export class Vault<State> extends PartialEventSubscriber<State, VaultState> {
+  static readonly interface: Interface = new Interface(VaultABI);
+
+  protected vaultUtils: VaultUtils<State>;
+
+  public tokenDecimals: { [address: string]: number };
+  public stableTokens: { [address: string]: boolean };
+  protected tokenWeights: { [address: string]: bigint };
+  public stableSwapFeeBasisPoints: bigint;
+  public swapFeeBasisPoints: bigint;
+  public stableTaxBasisPoints: bigint;
+  public taxBasisPoints: bigint;
+  public hasDynamicFees: bigint;
+  protected includeAmmPrice: boolean;
+  protected useSwapPricing: boolean;
+  protected totalTokenWeights: bigint;
+
+  constructor(
+    public readonly vaultAddress: Address,
+    protected tokenAddresses: Address[],
+    config: VaultConfig,
+    protected vaultPriceFeed: VaultPriceFeed<State>,
+    protected usdm: USDM<State>,
+    lens: Lens<DeepReadonly<State>, DeepReadonly<VaultState>>,
+    logger: Logger,
+  ) {
+    super([vaultAddress], lens, logger);
+    this.vaultUtils = new VaultUtils(this);
+    this.tokenDecimals = config.tokenDecimals;
+    this.stableTokens = config.stableTokens;
+    this.tokenWeights = config.tokenWeights;
+    this.stableSwapFeeBasisPoints = config.stableSwapFeeBasisPoints;
+    this.swapFeeBasisPoints = config.swapFeeBasisPoints;
+    this.stableTaxBasisPoints = config.stableTaxBasisPoints;
+    this.taxBasisPoints = config.taxBasisPoints;
+    this.hasDynamicFees = config.hasDynamicFees;
+    this.includeAmmPrice = config.includeAmmPrice;
+    this.useSwapPricing = config.useSwapPricing;
+    this.totalTokenWeights = config.totalTokenWeights;
+  }
+
+  getMinPrice(state: DeepReadonly<State>, _token: Address): bigint {
+    return this.vaultPriceFeed.getPrice(
+      state,
+      _token,
+      false,
+      this.includeAmmPrice,
+      this.useSwapPricing,
+    );
+  }
+
+  getMaxPrice(state: DeepReadonly<State>, _token: Address): bigint {
+    return this.vaultPriceFeed.getPrice(
+      state,
+      _token,
+      true,
+      this.includeAmmPrice,
+      this.useSwapPricing,
+    );
+  }
+
+  getFeeBasisPoints(
+    state: DeepReadonly<State>,
+    _token: Address,
+    _usdgDelta: bigint,
+    _feeBasisPoints: bigint,
+    _taxBasisPoints: bigint,
+    _increment: boolean,
+  ): bigint {
+    return this.vaultUtils.getFeeBasisPoints(
+      state,
+      _token,
+      _usdgDelta,
+      _feeBasisPoints,
+      _taxBasisPoints,
+      _increment,
+    );
+  }
+
+  getTargetUsdmAmount(state: DeepReadonly<State>, _token: Address): bigint {
+    const supply = this.usdm.getTotalSupply(state);
+    if (supply == 0n) {
+      return 0n;
+    }
+    const weight = this.tokenWeights[_token];
+    return (weight * supply) / this.totalTokenWeights;
+  }
+
+  static getConfigMulticallInputs(
+    vaultAddress: Address,
+    tokenAddresses: Address[],
+  ): MultiCallInput[] {
+    return [
+      ...tokenAddresses.map(t => ({
+        target: vaultAddress,
+        callData: Vault.interface.encodeFunctionData('tokenDecimals', [t]),
+      })),
+      ...tokenAddresses.map(t => ({
+        target: vaultAddress,
+        callData: Vault.interface.encodeFunctionData('stableTokens', [t]),
+      })),
+      ...tokenAddresses.map(t => ({
+        target: vaultAddress,
+        callData: Vault.interface.encodeFunctionData('tokenWeights', [t]),
+      })),
+      ...[
+        'stableSwapFeeBasisPoints',
+        'swapFeeBasisPoints',
+        'stableTaxBasisPoints',
+        'taxBasisPoints',
+        'hasDynamicFees',
+        'includeAmmPrice',
+        'useSwapPricing',
+        'totalTokenWeights',
+      ].map(fn => ({
+        target: vaultAddress,
+        callData: Vault.interface.encodeFunctionData(fn),
+      })),
+    ];
+  }
+
+  static getConfig(
+    multicallOutputs: MultiCallOutput[],
+    tokenAddresses: Address[],
+  ): VaultConfig {
+    let i = 0;
+    return {
+      tokenDecimals: tokenAddresses.reduce(
+        (acc: { [address: string]: number }, t: Address) => {
+          acc[t] = parseInt(
+            Vault.interface
+              .decodeFunctionResult('tokenDecimals', multicallOutputs[i++])[0]
+              .toString(),
+          );
+          return acc;
+        },
+        {},
+      ),
+      stableTokens: tokenAddresses.reduce(
+        (acc: { [address: string]: boolean }, t: Address) => {
+          acc[t] = Vault.interface.decodeFunctionResult(
+            'stableTokens',
+            multicallOutputs[i++],
+          )[0];
+          return acc;
+        },
+        {},
+      ),
+      tokenWeights: tokenAddresses.reduce(
+        (acc: { [address: string]: bigint }, t: Address) => {
+          acc[t] = BigInt(
+            Vault.interface
+              .decodeFunctionResult('tokenWeights', multicallOutputs[i++])[0]
+              .toString(),
+          );
+          return acc;
+        },
+        {},
+      ),
+      stableSwapFeeBasisPoints: BigInt(
+        Vault.interface
+          .decodeFunctionResult(
+            'stableSwapFeeBasisPoints',
+            multicallOutputs[i++],
+          )[0]
+          .toString(),
+      ),
+      swapFeeBasisPoints: BigInt(
+        Vault.interface
+          .decodeFunctionResult('swapFeeBasisPoints', multicallOutputs[i++])[0]
+          .toString(),
+      ),
+      stableTaxBasisPoints: BigInt(
+        Vault.interface
+          .decodeFunctionResult(
+            'stableTaxBasisPoints',
+            multicallOutputs[i++],
+          )[0]
+          .toString(),
+      ),
+      taxBasisPoints: BigInt(
+        Vault.interface
+          .decodeFunctionResult('taxBasisPoints', multicallOutputs[i++])[0]
+          .toString(),
+      ),
+      hasDynamicFees: Vault.interface.decodeFunctionResult(
+        'hasDynamicFees',
+        multicallOutputs[i++],
+      )[0],
+      includeAmmPrice: Vault.interface.decodeFunctionResult(
+        'includeAmmPrice',
+        multicallOutputs[i++],
+      )[0],
+      useSwapPricing: Vault.interface.decodeFunctionResult(
+        'useSwapPricing',
+        multicallOutputs[i++],
+      )[0],
+      totalTokenWeights: BigInt(
+        Vault.interface
+          .decodeFunctionResult('totalTokenWeights', multicallOutputs[i++])[0]
+          .toString(),
+      ),
+    };
+  }
+
+  public getGenerateStateMultiCallInputs(): MultiCallInput[] {
+    return this.tokenAddresses.map((t: Address) => ({
+      target: this.vaultAddress,
+      callData: Vault.interface.encodeFunctionData('usdmAmounts', [t]),
+    }));
+  }
+
+  public generateState(
+    multicallOutputs: MultiCallOutput[],
+    blockNumber?: number | 'latest',
+  ): DeepReadonly<VaultState> {
+    let vaultState: VaultState = {
+      usdmAmounts: {},
+    };
+    this.tokenAddresses.forEach(
+      (t: Address, i: number) =>
+        (vaultState.usdmAmounts[t] = BigInt(
+          Vault.interface
+            .decodeFunctionResult('usdmAmounts', multicallOutputs[i])[0]
+            .toString(),
+        )),
+    );
+    return vaultState;
+  }
+
+  public getUSDGAmount(state: DeepReadonly<State>, token: Address): bigint {
+    return this.lens.get()(state).usdmAmounts[token];
+  }
+
+  public processLog(
+    state: DeepReadonly<VaultState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): AsyncOrSync<VaultState | null> {
+    try {
+      const parsed = Vault.interface.parseLog(log);
+      const _state: VaultState = _.cloneDeep(state);
+      switch (parsed.name) {
+        case 'IncreaseUsdgAmount': {
+          const tokenAddress = parsed.args.token.toLowerCase();
+          const amount = BigInt(parsed.args.amount.toString());
+          if (tokenAddress in state.usdmAmounts)
+            _state.usdmAmounts[tokenAddress] += amount;
+          return _state;
+        }
+        case 'DecreaseUsdgAmount': {
+          const tokenAddress = parsed.args.token.toLowerCase();
+          const amount = BigInt(parsed.args.amount.toString());
+          if (tokenAddress in state.usdmAmounts)
+            _state.usdmAmounts[tokenAddress] -= amount;
+          return _state;
+        }
+        default:
+          return null;
+      }
+    } catch (e) {
+      this.logger.error('Failed to parse log', e);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Metavault.Trade aims to become the go-to solution for traders who want to stay in control of their funds at all times without sharing their personal data. Its innovative design gives it many advantages over other existing DEXes:

- Very low transaction fees.

- No price impact, even for large order sizes. 

- Protection against liquidation events: the sudden changes in price that can often occur in one exchange (“scam wicks”) are smoothed out by the pricing mechanism design relying on Chainlink price-feeds. 

Metavault.Trade is a friendly fork of GMX on Polygon Mainnet, so you can reference the existing GMX integration for testing and the other parts. 

Note: New adapter deployment required for Metavault.Trade on Polygon Mainnet. 
