### PR TITLE
fix: BalancerV2 RPC getState when none event-based

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -587,9 +587,8 @@ export class BalancerV2
       const eventPoolStatesRO = await this.eventPools.getState(blockNumber);
       if (!eventPoolStatesRO) {
         this.logger.error(`getState returned null`);
-        return null;
       }
-      const eventPoolStates = { ...eventPoolStatesRO };
+      const eventPoolStates = { ...(eventPoolStatesRO || {}) };
       for (const addr of this.eventDisabledPools) delete eventPoolStates[addr];
 
       // Fetch previously cached non-event pool states


### PR DESCRIPTION
Use the same mechanism we have for non-event-based pools to get all pools' states when event-based system returns null from getState.