### PR TITLE
Camelot intergration

### DIFF
--- a/src/abi/camelot/CamelotFactory.json
+++ b/src/abi/camelot/CamelotFactory.json
@@ -1,0 +1,494 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "feeTo_",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "prevOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "FeePercentOwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "prevFeeTo",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newFeeTo",
+        "type": "address"
+      }
+    ],
+    "name": "FeeToTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "prevOwnerFeeShare",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ownerFeeShare",
+        "type": "uint256"
+      }
+    ],
+    "name": "OwnerFeeShareUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "prevOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "pair",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      }
+    ],
+    "name": "PairCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "referrer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "prevReferrerFeeShare",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "referrerFeeShare",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReferrerFeeShareUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "prevOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "SetStableOwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "OWNER_FEE_SHARE_MAX",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "REFERER_FEE_SHARE_MAX",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "allPairs",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "feePercentOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "feeTo",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "getPair",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "ownerFeeShare",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "referrersFeeShare",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "setStableOwner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "allPairsLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenA",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenB",
+        "type": "address"
+      }
+    ],
+    "name": "createPair",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "pair",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "setOwner",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_feePercentOwner",
+        "type": "address"
+      }
+    ],
+    "name": "setFeePercentOwner",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_setStableOwner",
+        "type": "address"
+      }
+    ],
+    "name": "setSetStableOwner",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_feeTo",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeTo",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newOwnerFeeShare",
+        "type": "uint256"
+      }
+    ],
+    "name": "setOwnerFeeShare",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "referrer",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "referrerFeeShare",
+        "type": "uint256"
+      }
+    ],
+    "name": "setReferrerFeeShare",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "feeInfo",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_ownerFeeShare",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_feeTo",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abi/camelot/CamelotPair.json
+++ b/src/abi/camelot/CamelotPair.json
@@ -1,0 +1,1027 @@
+[
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Burn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "DrainWrongToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "token0FeePercent",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "token1FeePercent",
+        "type": "uint16"
+      }
+    ],
+    "name": "FeePercentUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "SetPairTypeImmutable",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "prevStableSwap",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "stableSwap",
+        "type": "bool"
+      }
+    ],
+    "name": "SetStableSwap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "Skim",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1In",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve0",
+        "type": "uint112"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "reserve1",
+        "type": "uint112"
+      }
+    ],
+    "name": "Sync",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "FEE_DENOMINATOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "MAX_FEE_PERCENT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "MINIMUM_LIQUIDITY",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "PERMIT_TYPEHASH",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "initialized",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "kLast",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pairTypeImmutable",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "v",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "r",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "precisionMultiplier0",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "precisionMultiplier1",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "stableSwap",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token0FeePercent",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "token1FeePercent",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getReserves",
+    "outputs": [
+      {
+        "internalType": "uint112",
+        "name": "_reserve0",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint112",
+        "name": "_reserve1",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_token0FeePercent",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_token1FeePercent",
+        "type": "uint16"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_token1",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "newToken0FeePercent",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "newToken1FeePercent",
+        "type": "uint16"
+      }
+    ],
+    "name": "setFeePercent",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "stable",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint112",
+        "name": "expectedReserve0",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint112",
+        "name": "expectedReserve1",
+        "type": "uint112"
+      }
+    ],
+    "name": "setStableSwap",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "setPairTypeImmutable",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "swap",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1Out",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      },
+      {
+        "internalType": "address",
+        "name": "referrer",
+        "type": "address"
+      }
+    ],
+    "name": "swap",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      }
+    ],
+    "name": "getAmountOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "skim",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "sync",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "drainWrongToken",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/dex/camelot/camelot-e2e.test.ts
+++ b/src/dex/camelot/camelot-e2e.test.ts
@@ -1,0 +1,225 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import { Tokens, Holders } from '../../../tests/constants-e2e';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+
+describe('Camelot E2E', () => {
+  describe('Arbitrum', () => {
+    const network = Network.ARBITRUM;
+    const tokens = Tokens[network];
+    const holders = Holders[network];
+    const provider = new StaticJsonRpcProvider(
+      generateConfig(network).privateHttpProvider,
+      network,
+    );
+
+    describe(`Camelot`, () => {
+      const dexKey = 'Camelot';
+
+      describe(`simpleSwap`, () => {
+        describe(`Volatile`, () => {
+          describe(`SELL`, () => {
+            it('ETH -> USDC', async () => {
+              await testE2E(
+                tokens.ETH,
+                tokens.USDC,
+                holders.ETH,
+                '1000000000000000000',
+                SwapSide.SELL,
+                dexKey,
+                ContractMethod.simpleSwap,
+                network,
+                provider,
+              );
+            });
+            it('ETH -> USDC', async () => {
+              await testE2E(
+                tokens.ETH,
+                tokens.USDC,
+                holders.ETH,
+                '1100000000000000000',
+                SwapSide.SELL,
+                dexKey,
+                ContractMethod.simpleSwap,
+                network,
+                provider,
+              );
+            });
+            it('USDC -> ETH', async () => {
+              await testE2E(
+                tokens.USDC,
+                tokens.ETH,
+                holders.USDC,
+                '100000',
+                SwapSide.SELL,
+                dexKey,
+                ContractMethod.simpleSwap,
+                network,
+                provider,
+              );
+            });
+            it('USDC -> WETH', async () => {
+              await testE2E(
+                tokens.USDC,
+                tokens.WETH,
+                holders.USDC,
+                '10000',
+                SwapSide.SELL,
+                dexKey,
+                ContractMethod.simpleSwap,
+                network,
+                provider,
+              );
+            });
+          });
+          describe(`BUY`, () => {
+            it('ETH -> USDC', async () => {
+              await testE2E(
+                tokens.ETH,
+                tokens.USDC,
+                holders.ETH,
+                '10000',
+                SwapSide.BUY,
+                dexKey,
+                ContractMethod.simpleBuy,
+                network,
+                provider,
+              );
+            });
+            it('ETH -> USDC', async () => {
+              await testE2E(
+                tokens.ETH,
+                tokens.USDC,
+                holders.ETH,
+                '11000',
+                SwapSide.BUY,
+                dexKey,
+                ContractMethod.simpleBuy,
+                network,
+                provider,
+              );
+            });
+            it('USDC -> ETH', async () => {
+              await testE2E(
+                tokens.USDC,
+                tokens.ETH,
+                holders.USDC,
+                '100000',
+                SwapSide.BUY,
+                dexKey,
+                ContractMethod.simpleBuy,
+                network,
+                provider,
+              );
+            });
+            it('USDC -> WETH', async () => {
+              await testE2E(
+                tokens.USDC,
+                tokens.WETH,
+                holders.USDC,
+                '100000',
+                SwapSide.BUY,
+                dexKey,
+                ContractMethod.simpleBuy,
+                network,
+                provider,
+              );
+            });
+          });
+        });
+        describe(`Stable`, () => {
+          describe(`SELL`, () => {
+            it('USDC -> DAI', async () => {
+              await testE2E(
+                tokens.USDC,
+                tokens.DAI,
+                holders.USDC,
+                '100000',
+                SwapSide.SELL,
+                dexKey,
+                ContractMethod.simpleSwap,
+                network,
+                provider,
+              );
+            });
+          });
+        });
+      });
+      describe(`multiSwap`, () => {
+        describe(`Volatile`, () => {
+          it('ETH -> USDC', async () => {
+            await testE2E(
+              tokens.ETH,
+              tokens.USDC,
+              holders.ETH,
+              '1000000000000000000',
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.multiSwap,
+              network,
+              provider,
+            );
+          });
+          it('ETH -> USDC', async () => {
+            await testE2E(
+              tokens.ETH,
+              tokens.USDC,
+              holders.ETH,
+              '11000000000000000000',
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.multiSwap,
+              network,
+              provider,
+            );
+          });
+          it('USDC -> ETH', async () => {
+            await testE2E(
+              tokens.USDC,
+              tokens.ETH,
+              holders.USDC,
+              '110000',
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.multiSwap,
+              network,
+              provider,
+            );
+          });
+          it('USDC -> WETH', async () => {
+            await testE2E(
+              tokens.USDC,
+              tokens.WETH,
+              holders.USDC,
+              '100000',
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.multiSwap,
+              network,
+              provider,
+            );
+          });
+        });
+        describe(`Stable`, () => {
+          it('USDC -> DAI', async () => {
+            await testE2E(
+              tokens.USDC,
+              tokens.DAI,
+              holders.USDC,
+              '100000',
+              SwapSide.SELL,
+              dexKey,
+              ContractMethod.multiSwap,
+              network,
+              provider,
+            );
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/dex/camelot/camelot-integration.test.ts
+++ b/src/dex/camelot/camelot-integration.test.ts
@@ -1,0 +1,215 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { DummyDexHelper } from '../../dex-helper';
+import { Network, SwapSide } from '../../constants';
+import { checkPoolPrices, checkPoolsLiquidity } from '../../../tests/utils';
+import { BI_POWS } from '../../bigint-constants';
+import { Tokens } from '../../../tests/constants-e2e';
+import { Interface, Result } from '@ethersproject/abi';
+import { Camelot } from './camelot';
+import camelotPairABI from '../../abi/camelot/CamelotPair.json';
+
+const amounts18 = [0n, BI_POWS[18], 2000000000000000000n];
+const amounts6 = [0n, BI_POWS[6], 2000000n];
+
+function getReaderCalldata(
+  exchangeAddress: string,
+  readerIface: Interface,
+  amounts: bigint[],
+  funcName: string,
+  tokenIn: string,
+) {
+  return amounts.map(amount => ({
+    target: exchangeAddress,
+    callData: readerIface.encodeFunctionData(funcName, [amount, tokenIn]),
+  }));
+}
+
+function decodeReaderResult(
+  results: Result,
+  readerIface: Interface,
+  funcName: string,
+) {
+  return results.map(result => {
+    const parsed = readerIface.decodeFunctionResult(funcName, result);
+    return BigInt(parsed[0]._hex);
+  });
+}
+
+const constructCheckOnChainPricing =
+  (dexHelper: DummyDexHelper) =>
+  async (
+    camelot: Camelot,
+    funcName: string,
+    blockNumber: number,
+    prices: bigint[],
+    exchangeAddress: string,
+    tokenIn: string,
+    amounts: bigint[],
+  ) => {
+    const readerIface = new Interface(camelotPairABI as any);
+
+    const readerCallData = getReaderCalldata(
+      exchangeAddress,
+      readerIface,
+      amounts.slice(1),
+      funcName,
+      tokenIn,
+    );
+    console.log('readerCallData', readerCallData);
+    const readerResult = (
+      await dexHelper.multiContract.methods
+        .aggregate(readerCallData)
+        .call({}, blockNumber)
+    ).returnData;
+    const expectedPrices = [0n].concat(
+      decodeReaderResult(readerResult, readerIface, funcName),
+    );
+
+    expect(prices.map(p => p.toString())).toEqual(
+      expectedPrices.map(p => p.toString()),
+    );
+  };
+
+describe('Camelot integration tests', () => {
+  describe('Arbitrum', () => {
+    const network = Network.ARBITRUM;
+    const dexHelper = new DummyDexHelper(network);
+    const checkOnChainPricing = constructCheckOnChainPricing(dexHelper);
+
+    describe('Camelot', function () {
+      const dexKey = 'Camelot';
+      const camelot = new Camelot(network, dexKey, dexHelper);
+
+      describe('UniswapV2 like pool', function () {
+        const TokenASymbol = 'WETH';
+        const tokenA = Tokens[network][TokenASymbol];
+        const TokenBSymbol = 'DAI';
+        const tokenB = Tokens[network][TokenBSymbol];
+
+        const amounts = amounts18;
+
+        it('getPoolIdentifiers and getPricesVolume', async function () {
+          const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+          const pools = await camelot.getPoolIdentifiers(
+            tokenA,
+            tokenB,
+            SwapSide.SELL,
+            blocknumber,
+          );
+          console.log(
+            `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+            pools,
+          );
+
+          expect(pools.length).toBeGreaterThan(0);
+
+          const poolPrices = await camelot.getPricesVolume(
+            tokenA,
+            tokenB,
+            amounts,
+            SwapSide.SELL,
+            blocknumber,
+            pools,
+          );
+          console.log(
+            `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+            poolPrices,
+          );
+
+          expect(poolPrices).not.toBeNull();
+          checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+          // Check if onchain pricing equals to calculated ones
+
+          for (const i in poolPrices || []) {
+            await checkOnChainPricing(
+              camelot,
+              'getAmountOut',
+              blocknumber,
+              poolPrices![i].prices,
+              poolPrices![i].poolAddresses![0],
+              tokenA.address,
+              amounts,
+            );
+          }
+        });
+
+        it('getTopPoolsForToken', async function () {
+          const poolLiquidity = await camelot.getTopPoolsForToken(
+            tokenA.address,
+            10,
+          );
+          console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
+
+          checkPoolsLiquidity(poolLiquidity, tokenA.address, dexKey);
+        });
+      });
+
+      describe('Curve like stable pool', function () {
+        const TokenASymbol = 'DAI';
+        const tokenA = Tokens[network][TokenASymbol];
+        const TokenBSymbol = 'USDC';
+        const tokenB = Tokens[network][TokenBSymbol];
+
+        const amounts = amounts18; // amounts6;
+
+        it('getPoolIdentifiers and getPricesVolume', async function () {
+          const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+          const pools = await camelot.getPoolIdentifiers(
+            tokenA,
+            tokenB,
+            SwapSide.SELL,
+            blocknumber,
+          );
+          console.log(
+            `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+            pools,
+          );
+
+          expect(pools.length).toBeGreaterThan(0);
+
+          const poolPrices = await camelot.getPricesVolume(
+            tokenA,
+            tokenB,
+            amounts,
+            SwapSide.SELL,
+            blocknumber,
+            pools,
+          );
+          console.log(
+            `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+            poolPrices,
+          );
+
+          expect(poolPrices).not.toBeNull();
+          checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+          // Check if onchain pricing equals to calculated ones
+          for (const i in poolPrices || []) {
+            await checkOnChainPricing(
+              camelot,
+              'getAmountOut',
+              blocknumber,
+              poolPrices![i].prices,
+              poolPrices![i].poolAddresses![0],
+              tokenA.address,
+              amounts,
+            );
+          }
+        });
+
+        it('getTopPoolsForToken', async function () {
+          const poolLiquidity = await camelot.getTopPoolsForToken(
+            tokenA.address,
+            10,
+          );
+          console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
+
+          checkPoolsLiquidity(poolLiquidity, tokenA.address, dexKey);
+        });
+      });
+    });
+  });
+});

--- a/src/dex/camelot/camelot.ts
+++ b/src/dex/camelot/camelot.ts
@@ -1,0 +1,774 @@
+import {
+  DEST_TOKEN_PARASWAP_TRANSFERS,
+  ETHER_ADDRESS,
+  Network,
+  NULL_ADDRESS,
+  SRC_TOKEN_PARASWAP_TRANSFERS,
+  SUBGRAPH_TIMEOUT,
+} from '../../constants';
+import {
+  AdapterExchangeParam,
+  Address,
+  ExchangePrices,
+  Log,
+  Logger,
+  PoolLiquidity,
+  PoolPrices,
+  SimpleExchangeParam,
+  Token,
+  TransferFeeParams,
+  TxInfo,
+} from '../../types';
+import { IDexHelper } from '../../dex-helper';
+import erc20ABI from '../../abi/erc20.json';
+import {
+  UniswapData,
+  UniswapParam,
+  UniswapV2Functions,
+  UniswapDataLegacy,
+  UniswapV2Data,
+  UniswapPool,
+} from '../uniswap-v2/types';
+import {
+  getBigIntPow,
+  getDexKeysWithNetwork,
+  isETHAddress,
+  prependWithOx,
+} from '../../utils';
+import camelotFactoryABI from '../../abi/camelot/CamelotFactory.json';
+import camelotPairABI from '../../abi/camelot/CamelotPair.json';
+import _ from 'lodash';
+import { AsyncOrSync, DeepReadonly } from 'ts-essentials';
+import { NumberAsString, SwapSide } from 'paraswap-core';
+import { Interface, AbiCoder } from '@ethersproject/abi';
+import { SolidlyStablePool } from '../solidly/solidly-stable-pool';
+import { Uniswapv2ConstantProductPool } from '../uniswap-v2/uniswap-v2-constant-product-pool';
+import {
+  CamelotPoolState,
+  CamelotPoolOrderedParams,
+  CamelotData,
+} from './types';
+import { CamelotConfig, Adapters } from './config';
+import { Contract } from 'web3-eth-contract';
+import { IDex } from '../idex';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
+import ParaSwapABI from '../../abi/IParaswap.json';
+import UniswapV2ExchangeRouterABI from '../../abi/UniswapV2ExchangeRouter.json';
+import { SimpleExchange } from '../simple-exchange';
+import { applyTransferFee } from '../../lib/token-transfer-fee';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+
+const DefaultCamelotPoolGasCost = 90 * 1000;
+
+const camelotPairIface = new Interface(camelotPairABI);
+const coder = new AbiCoder();
+
+const LogCallTopics = [
+  '0x1c411e9a96e071241c2f21f7726b17ae89e3cab4c78be50e062b03a9fffbbad1', // event Sync(uint112 reserve0, uint112 reserve1) // uni-V2 and most forks
+  'a4877b8ecb5a00ba277e4bceeeb187a669e7113649774dfbea05c259ce27f17b', // event FeePercentUpdated(uint16 token0FeePercent, uint16 token1FeePercent)
+  'b6a86710bde53aa7fb1b3856279e2af5b476d53e2dd0902cf17a0911b5a43a8b', // event SetStableSwap(bool prevStableSwap, bool stableSwap)
+];
+
+function encodePools(
+  pools: UniswapPool[],
+  feeFactor: number,
+): NumberAsString[] {
+  return pools.map(({ fee, direction, address }) => {
+    return (
+      (BigInt(Math.ceil((feeFactor - fee) / 10)) << 161n) +
+      ((direction ? 0n : 1n) << 160n) +
+      BigInt(address)
+    ).toString();
+  });
+}
+
+export interface CamelotPair {
+  token0: Token;
+  token1: Token;
+  exchange?: Address;
+  pool?: CamelotEventPool;
+}
+
+export class CamelotEventPool extends StatefulEventSubscriber<CamelotPoolState> {
+  decoder = (log: Log) => this.iface.parseLog(log);
+
+  constructor(
+    parentName: string,
+    protected dexHelper: IDexHelper,
+    private poolAddress: Address,
+    private token0: Token,
+    private token1: Token,
+    logger: Logger,
+    private iface: Interface = camelotPairIface,
+    private callEntries: any[],
+    private callDecoder: (data: any[]) => {
+      reserve0: string;
+      reserve1: string;
+      token0FeeCode: number;
+      token1FeeCode: number;
+      stable: boolean;
+    },
+  ) {
+    super(
+      parentName,
+      (token0.symbol || token0.address) +
+        '-' +
+        (token1.symbol || token1.address) +
+        ' pool',
+      dexHelper,
+      logger,
+    );
+  }
+
+  protected processLog(
+    state: DeepReadonly<CamelotPoolState>,
+    log: Readonly<Log>,
+  ): AsyncOrSync<DeepReadonly<CamelotPoolState> | null> {
+    if (!LogCallTopics.includes(log.topics[0])) return null;
+
+    const event = this.decoder(log);
+    switch (event.name) {
+      case 'SetStableSwap':
+        return {
+          reserve0: state.reserve0,
+          reserve1: state.reserve1,
+          token0FeeCode: state.token0FeeCode,
+          token1FeeCode: state.token1FeeCode,
+          stable: event.args.stableSwap,
+        };
+      case 'FeePercentUpdated':
+        return {
+          reserve0: state.reserve0,
+          reserve1: state.reserve1,
+          token0FeeCode: parseInt(event.args.token0FeePercent.toString()),
+          token1FeeCode: parseInt(event.args.token1FeePercent.toString()),
+          stable: state.stable,
+        };
+      case 'Sync':
+        return {
+          reserve0: event.args.reserve0.toString(),
+          reserve1: event.args.reserve1.toString(),
+          token0FeeCode: state.token0FeeCode,
+          token1FeeCode: state.token1FeeCode,
+          stable: state.stable,
+        };
+    }
+    return null;
+  }
+
+  async generateState(
+    blockNumber: number | 'latest' = 'latest',
+  ): Promise<DeepReadonly<CamelotPoolState>> {
+    const data: { returnData: any[] } =
+      await this.dexHelper.multiContract.methods
+        .aggregate(this.callEntries)
+        .call({}, blockNumber);
+
+    return this.callDecoder(data.returnData);
+  }
+}
+
+export class Camelot
+  extends SimpleExchange
+  implements IDex<CamelotData, UniswapParam>
+{
+  pairs: { [key: string]: CamelotPair } = {};
+  feeFactor = 100000;
+  factory: Contract;
+
+  routerInterface: Interface;
+  exchangeRouterInterface: Interface;
+
+  readonly hasConstantPriceLargeAmounts: boolean = false;
+  readonly isFeeOnTransferSupported: boolean = true;
+  readonly DEST_TOKEN_DEX_TRANSFERS = 1;
+  logger: Logger;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(CamelotConfig);
+
+  constructor(
+    protected network: Network,
+    dexKey: string,
+    protected dexHelper: IDexHelper,
+    protected factoryAddress: Address = CamelotConfig[dexKey][network]
+      .factoryAddress,
+    protected subgraphURL: string | undefined = CamelotConfig[dexKey] &&
+      CamelotConfig[dexKey][network].subgraphURL,
+    protected initCode: string = CamelotConfig[dexKey][network].initCode,
+    protected poolGasCost: number = (CamelotConfig[dexKey] &&
+      CamelotConfig[dexKey][network].poolGasCost) ??
+      DefaultCamelotPoolGasCost,
+    protected decoderIface: Interface = camelotPairIface,
+    protected adapters = (CamelotConfig[dexKey] &&
+      CamelotConfig[dexKey][network].adapters) ??
+      Adapters[network],
+    protected routerAddress = (CamelotConfig[dexKey] &&
+      CamelotConfig[dexKey][network].router) ??
+      dexHelper.config.data.uniswapV2ExchangeRouterAddress,
+  ) {
+    super(dexHelper, dexKey);
+    this.logger = dexHelper.getLogger(dexKey);
+
+    this.factory = new dexHelper.web3Provider.eth.Contract(
+      camelotFactoryABI as any,
+      factoryAddress,
+    );
+    this.routerAddress = routerAddress;
+
+    this.routerInterface = new Interface(ParaSwapABI);
+    this.exchangeRouterInterface = new Interface(UniswapV2ExchangeRouterABI);
+  }
+
+  getPoolStatesMultiCallData(pair: CamelotPair): {
+    callEntries: any[];
+    callDecoder: (data: any[]) => {
+      reserve0: string;
+      reserve1: string;
+      token0FeeCode: number;
+      token1FeeCode: number;
+      stable: boolean;
+    };
+  } {
+    const callEntries = [
+      {
+        target: pair.exchange,
+        callData: camelotPairIface.encodeFunctionData('getReserves', []),
+      },
+      {
+        target: pair.exchange,
+        callData: camelotPairIface.encodeFunctionData('stableSwap', []),
+      },
+    ];
+
+    const callDecoder = (data: any[]) => {
+      const info = coder.decode(
+        ['uint112', 'uint112', 'uint16', 'uint16'],
+        data[0],
+      );
+      const reserve0: string = info[0].toString();
+      const reserve1: string = info[1].toString();
+      const token0FeeCode: number = parseInt(info[2].toString());
+      const token1FeeCode: number = parseInt(info[3].toString());
+      const stable: boolean = coder.decode(['bool'], data[1])[0];
+
+      return { reserve0, reserve1, token0FeeCode, token1FeeCode, stable };
+    };
+    return { callEntries, callDecoder };
+  }
+
+  protected async addPool(
+    pair: CamelotPair,
+    reserve0: string,
+    reserve1: string,
+    token0FeeCode: number,
+    token1FeeCode: number,
+    stable: boolean,
+    blockNumber: number,
+  ) {
+    const { callEntries, callDecoder } =
+      this.getPoolStatesMultiCallData(pair) || {};
+    pair.pool = new CamelotEventPool(
+      this.dexKey,
+      this.dexHelper,
+      pair.exchange!,
+      pair.token0,
+      pair.token1,
+      this.logger,
+      this.decoderIface,
+      callEntries,
+      callDecoder,
+    );
+    pair.pool.addressesSubscribed.push(pair.exchange!);
+
+    await pair.pool.initialize(blockNumber, {
+      state: { reserve0, reserve1, token0FeeCode, token1FeeCode, stable },
+    });
+  }
+
+  async getBuyPrice(
+    priceParams: CamelotPoolOrderedParams,
+    srcAmount: bigint,
+  ): Promise<bigint> {
+    if (priceParams.stable) throw new Error(`Buy not supported`);
+    return Uniswapv2ConstantProductPool.getBuyPrice(
+      priceParams,
+      srcAmount,
+      this.feeFactor,
+    );
+  }
+
+  async getSellPrice(
+    priceParams: CamelotPoolOrderedParams,
+    srcAmount: bigint,
+  ): Promise<bigint> {
+    return priceParams.stable
+      ? SolidlyStablePool.getSellPrice(priceParams, srcAmount, this.feeFactor)
+      : Uniswapv2ConstantProductPool.getSellPrice(
+          priceParams,
+          srcAmount,
+          this.feeFactor,
+        );
+  }
+
+  async getBuyPricePath(
+    amount: bigint,
+    params: CamelotPoolOrderedParams[],
+  ): Promise<bigint> {
+    let price = amount;
+    for (const param of params.reverse()) {
+      price = await this.getBuyPrice(param, price);
+    }
+    return price;
+  }
+
+  async getSellPricePath(
+    amount: bigint,
+    params: CamelotPoolOrderedParams[],
+  ): Promise<bigint> {
+    let price = amount;
+    for (const param of params) {
+      price = await this.getSellPrice(param, price);
+    }
+    return price;
+  }
+
+  async findPair(from: Token, to: Token) {
+    if (from.address.toLowerCase() === to.address.toLowerCase()) return null;
+    const [token0, token1] =
+      from.address.toLowerCase() < to.address.toLowerCase()
+        ? [from, to]
+        : [to, from];
+
+    const key = `${token0.address.toLowerCase()}-${token1.address.toLowerCase()}`;
+    let pair = this.pairs[key];
+    if (pair) return pair;
+    const exchange = await this.factory.methods
+      .getPair(token0.address, token1.address)
+      .call();
+    if (exchange === NULL_ADDRESS) {
+      pair = { token0, token1 };
+    } else {
+      pair = { token0, token1, exchange };
+    }
+    this.pairs[key] = pair;
+    return pair;
+  }
+
+  async getManyPoolStates(
+    pairs: CamelotPair[],
+    blockNumber: number,
+  ): Promise<CamelotPoolState[]> {
+    try {
+      const callData = pairs
+        .map((pair, i) => {
+          return this.getPoolStatesMultiCallData(pair).callEntries;
+        })
+        .flat();
+
+      const data: { returnData: any[] } =
+        await this.dexHelper.multiContract.methods
+          .aggregate(callData)
+          .call({}, blockNumber);
+
+      const returnData = _.chunk(data.returnData, 2);
+
+      return pairs.map((pair, i) => {
+        return this.getPoolStatesMultiCallData(pair).callDecoder(returnData[i]);
+      });
+    } catch (e) {
+      this.logger.error(
+        `Error_getManyPoolReserves could not get reserves with error:`,
+        e,
+      );
+      return [];
+    }
+  }
+
+  async batchCatchUpPairs(pairs: [Token, Token][], blockNumber: number) {
+    if (!blockNumber) return;
+    const pairsToFetch: CamelotPair[] = [];
+    for (const _pair of pairs) {
+      const pair = await this.findPair(_pair[0], _pair[1]);
+      if (!(pair && pair.exchange)) continue;
+      if (!pair.pool) {
+        pairsToFetch.push(pair);
+      } else if (!pair.pool.getState(blockNumber)) {
+        pairsToFetch.push(pair);
+      }
+    }
+
+    if (!pairsToFetch.length) return;
+
+    const pairsStates = await this.getManyPoolStates(pairsToFetch, blockNumber);
+
+    if (pairsStates.length !== pairsToFetch.length) {
+      this.logger.error(
+        `Error_getManyPoolReserves didn't get any pool reserves`,
+      );
+    }
+
+    for (let i = 0; i < pairsToFetch.length; i++) {
+      const pairState = pairsStates[i];
+      const pair = pairsToFetch[i];
+      if (!pair.pool) {
+        await this.addPool(
+          pair,
+          pairState.reserve0,
+          pairState.reserve1,
+          pairState.token0FeeCode,
+          pairState.token1FeeCode,
+          pairState.stable,
+          blockNumber,
+        );
+      } else pair.pool.setState(pairState, blockNumber);
+    }
+  }
+
+  async getPairOrderedParams(
+    from: Token,
+    to: Token,
+    blockNumber: number,
+    tokenDexTransferFee: number,
+  ): Promise<CamelotPoolOrderedParams | null> {
+    const pair = await this.findPair(from, to);
+    if (!(pair && pair.pool && pair.exchange)) return null;
+    const pairState = pair.pool.getState(blockNumber);
+    if (!pairState) {
+      this.logger.error(
+        `Error_orderPairParams expected reserves, got none (maybe the pool doesn't exist) ${
+          from.symbol || from.address
+        } ${to.symbol || to.address}`,
+      );
+      return null;
+    }
+
+    const pairReversed =
+      pair.token1.address.toLowerCase() === from.address.toLowerCase();
+    if (pairReversed) {
+      return {
+        tokenIn: from.address,
+        tokenOut: to.address,
+        reservesIn: pairState.reserve1,
+        reservesOut: pairState.reserve0,
+        decimalsIn: from.decimals,
+        decimalsOut: to.decimals,
+        fee: (pairState.token1FeeCode + tokenDexTransferFee).toString(),
+        direction: false,
+        exchange: pair.exchange,
+        stable: pairState.stable,
+      };
+    }
+    return {
+      tokenIn: from.address,
+      tokenOut: to.address,
+      decimalsIn: from.decimals,
+      decimalsOut: to.decimals,
+      reservesIn: pairState.reserve0,
+      reservesOut: pairState.reserve1,
+      fee: (pairState.token0FeeCode + tokenDexTransferFee).toString(),
+      direction: true,
+      exchange: pair.exchange,
+      stable: pairState.stable,
+    };
+  }
+
+  async getPoolIdentifiers(
+    _from: Token,
+    _to: Token,
+    side: SwapSide,
+    blockNumber: number,
+  ): Promise<string[]> {
+    const from = this.dexHelper.config.wrapETH(_from);
+    const to = this.dexHelper.config.wrapETH(_to);
+
+    if (from.address.toLowerCase() === to.address.toLowerCase()) {
+      return [];
+    }
+
+    const tokenAddress = [from.address.toLowerCase(), to.address.toLowerCase()]
+      .sort((a, b) => (a > b ? 1 : -1))
+      .join('_');
+
+    const poolIdentifier = `${this.dexKey}_${tokenAddress}`;
+    return [poolIdentifier];
+  }
+
+  async getPricesVolume(
+    _from: Token,
+    _to: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    // list of pool identifiers to use for pricing, if undefined use all pools
+    limitPools?: string[],
+    transferFees: TransferFeeParams = {
+      srcFee: 0,
+      destFee: 0,
+      srcDexFee: 0,
+      destDexFee: 0,
+    },
+  ): Promise<ExchangePrices<CamelotData> | null> {
+    try {
+      const from = this.dexHelper.config.wrapETH(_from);
+      const to = this.dexHelper.config.wrapETH(_to);
+
+      if (from.address.toLowerCase() === to.address.toLowerCase()) {
+        return null;
+      }
+
+      const tokenAddress = [
+        from.address.toLowerCase(),
+        to.address.toLowerCase(),
+      ]
+        .sort((a, b) => (a > b ? 1 : -1))
+        .join('_');
+
+      const poolIdentifier = `${this.dexKey}_${tokenAddress}`;
+
+      if (limitPools && limitPools.every(p => p !== poolIdentifier))
+        return null;
+
+      await this.batchCatchUpPairs([[from, to]], blockNumber);
+      const isSell = side === SwapSide.SELL;
+      const pairParam = await this.getPairOrderedParams(
+        from,
+        to,
+        blockNumber,
+        transferFees.srcDexFee,
+      );
+
+      if (!pairParam || (side === SwapSide.BUY && pairParam.stable))
+        return null;
+
+      const unitAmount = getBigIntPow(isSell ? from.decimals : to.decimals);
+
+      const [unitVolumeWithFee, ...amountsWithFee] = applyTransferFee(
+        [unitAmount, ...amounts],
+        side,
+        isSell ? transferFees.srcFee : transferFees.destFee,
+        isSell ? SRC_TOKEN_PARASWAP_TRANSFERS : DEST_TOKEN_PARASWAP_TRANSFERS,
+      );
+
+      const unit = isSell
+        ? await this.getSellPricePath(unitVolumeWithFee, [pairParam])
+        : await this.getBuyPricePath(unitVolumeWithFee, [pairParam]);
+
+      const prices = isSell
+        ? await Promise.all(
+            amountsWithFee.map(amount =>
+              this.getSellPricePath(amount, [pairParam]),
+            ),
+          )
+        : await Promise.all(
+            amountsWithFee.map(amount =>
+              this.getBuyPricePath(amount, [pairParam]),
+            ),
+          );
+
+      const [unitOutWithFee, ...outputsWithFee] = applyTransferFee(
+        [unit, ...prices],
+        side,
+        // This part is confusing, because we treat differently SELL and BUY fees
+        // If Buy, we should apply transfer fee on srcToken on top of dexFee applied earlier
+        // But for Sell we should apply only one dexFee
+        isSell ? transferFees.destDexFee : transferFees.srcFee,
+        isSell ? this.DEST_TOKEN_DEX_TRANSFERS : SRC_TOKEN_PARASWAP_TRANSFERS,
+      );
+
+      // As camelot just has one pool per token pair
+      return [
+        {
+          prices: outputsWithFee,
+          unit: unitOutWithFee,
+          data: {
+            router:
+              side === SwapSide.SELL
+                ? this.routerAddress
+                : this.dexHelper.config.data.uniswapV2ExchangeRouterAddress,
+            path: [from.address.toLowerCase(), to.address.toLowerCase()],
+            factory: this.factoryAddress,
+            initCode: this.initCode,
+            feeFactor: this.feeFactor,
+            pools: [
+              {
+                address: pairParam.exchange,
+                fee: parseInt(pairParam.fee),
+                direction: pairParam.direction,
+              },
+            ],
+          },
+          exchange: this.dexKey,
+          poolIdentifier,
+          gasCost: this.poolGasCost,
+          poolAddresses: [pairParam.exchange],
+        },
+      ];
+    } catch (e) {
+      if (blockNumber === 0)
+        this.logger.error(
+          `Error_getPricesVolume: Aurelius block manager not yet instantiated`,
+        );
+      this.logger.error(`Error_getPrices:`, e);
+      return null;
+    }
+  }
+
+  // Returns estimated gas cost of calldata for this DEX in multiSwap
+  getCalldataGasCost(poolPrices: PoolPrices<UniswapV2Data>): number | number[] {
+    return (
+      CALLDATA_GAS_COST.DEX_OVERHEAD +
+      CALLDATA_GAS_COST.LENGTH_SMALL +
+      // ParentStruct header
+      CALLDATA_GAS_COST.OFFSET_SMALL +
+      // ParentStruct -> weth
+      CALLDATA_GAS_COST.ADDRESS +
+      // ParentStruct -> pools[] header
+      CALLDATA_GAS_COST.OFFSET_SMALL +
+      // ParentStruct -> pools[]
+      CALLDATA_GAS_COST.LENGTH_SMALL +
+      // ParentStruct -> pools[0]
+      CALLDATA_GAS_COST.wordNonZeroBytes(22)
+    );
+  }
+
+  getAdapters(side: SwapSide): { name: string; index: number }[] | null {
+    return this.adapters[side];
+  }
+
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    count: number,
+  ): Promise<PoolLiquidity[]> {
+    if (!this.subgraphURL) return [];
+
+    const query = `query ($token: Bytes!, $count: Int) {
+      pools0: pairs(first: $count, orderBy: reserveUSD, orderDirection: desc, where: {token0: $token, reserve0_gt: 1, reserve1_gt: 1}) {
+        id
+        isStable
+        token0 {
+          id
+          decimals
+        }
+        token1 {
+          id
+          decimals
+        }
+        reserveUSD
+      }
+      pools1: pairs(first: $count, orderBy: reserveUSD, orderDirection: desc, where: {token1: $token, reserve0_gt: 1, reserve1_gt: 1}) {
+        id
+        isStable
+        token0 {
+          id
+          decimals
+        }
+        token1 {
+          id
+          decimals
+        }
+        reserveUSD
+      }
+    }`;
+
+    const { data } = await this.dexHelper.httpRequest.post(
+      this.subgraphURL,
+      {
+        query,
+        variables: { token: tokenAddress.toLowerCase(), count },
+      },
+      SUBGRAPH_TIMEOUT,
+    );
+
+    if (!(data && data.pools0 && data.pools1))
+      throw new Error("Couldn't fetch the pools from the subgraph");
+    const pools0 = _.map(data.pools0, pool => ({
+      exchange: this.dexKey,
+      stable: pool.isStable,
+      address: pool.id.toLowerCase(),
+      connectorTokens: [
+        {
+          address: pool.token1.id.toLowerCase(),
+          decimals: parseInt(pool.token1.decimals),
+        },
+      ],
+      liquidityUSD: parseFloat(pool.reserveUSD),
+    }));
+
+    const pools1 = _.map(data.pools1, pool => ({
+      exchange: this.dexKey,
+      stable: pool.isStable,
+      address: pool.id.toLowerCase(),
+      connectorTokens: [
+        {
+          address: pool.token0.id.toLowerCase(),
+          decimals: parseInt(pool.token0.decimals),
+        },
+      ],
+      liquidityUSD: parseFloat(pool.reserveUSD),
+    }));
+
+    return _.slice(
+      _.sortBy(_.concat(pools0, pools1), [pool => -1 * pool.liquidityUSD]),
+      0,
+      count,
+    );
+  }
+
+  getWETHAddress(srcToken: Address, destToken: Address, weth?: Address) {
+    if (!isETHAddress(srcToken) && !isETHAddress(destToken))
+      return NULL_ADDRESS;
+    return weth || this.dexHelper.config.data.wrappedNativeTokenAddress;
+  }
+
+  getAdapterParam(
+    srcToken: Address,
+    destToken: Address,
+    srcAmount: NumberAsString,
+    toAmount: NumberAsString, // required for buy case
+    data: UniswapData,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    const pools = encodePools(data.pools, this.feeFactor);
+    const weth = this.getWETHAddress(srcToken, destToken, data.weth);
+    const payload = this.abiCoder.encodeParameter(
+      {
+        ParentStruct: {
+          weth: 'address',
+          pools: 'uint256[]',
+        },
+      },
+      { pools, weth },
+    );
+    return {
+      targetExchange: data.router,
+      payload,
+      networkFee: '0',
+    };
+  }
+
+  async getSimpleParam(
+    src: Address,
+    dest: Address,
+    srcAmount: NumberAsString,
+    destAmount: NumberAsString,
+    data: CamelotData,
+    side: SwapSide,
+  ): Promise<SimpleExchangeParam> {
+    const pools = encodePools(data.pools, this.feeFactor);
+    const weth = this.getWETHAddress(src, dest, data.wethAddress);
+    const swapData = this.exchangeRouterInterface.encodeFunctionData(
+      side === SwapSide.SELL ? UniswapV2Functions.swap : UniswapV2Functions.buy,
+      [src, srcAmount, destAmount, weth, pools],
+    );
+
+    return this.buildSimpleParamWithoutWETHConversion(
+      src,
+      srcAmount,
+      dest,
+      destAmount,
+      swapData,
+      data.router,
+    );
+  }
+}

--- a/src/dex/camelot/config.ts
+++ b/src/dex/camelot/config.ts
@@ -1,0 +1,25 @@
+import { DexParams } from './types';
+import { DexConfigMap, AdapterMappings } from '../../types';
+import { Network, SwapSide } from '../../constants';
+
+export const CamelotConfig: DexConfigMap<DexParams> = {
+  Camelot: {
+    [Network.ARBITRUM]: {
+      subgraphURL:
+        'https://api.thegraph.com/subgraphs/name/camelotlabs/camelot-amm-2',
+      factoryAddress: '0x6EcCab422D763aC031210895C81787E87B43A652',
+      router: '0xd8f185769b6E2918B759e83F7EC268C882800EC7',
+      initCode:
+        '0xa856464ae65f7619087bc369daaf7e387dae1e5af69cfa7935850ebf754b04c1',
+      feeCode: 0, // this is ignored as Camelot uses dynamic fees
+      poolGasCost: 180 * 1000,
+    },
+  },
+};
+
+export const Adapters: Record<number, AdapterMappings> = {
+  [Network.ARBITRUM]: {
+    [SwapSide.SELL]: [{ name: 'ArbitrumAdapter01', index: 2 }], // camelot // TODO: Update index
+    [SwapSide.BUY]: [{ name: 'ArbitrumBuyAdapter', index: 1 }], // camelot // TODO: Update index
+  },
+};

--- a/src/dex/camelot/config.ts
+++ b/src/dex/camelot/config.ts
@@ -8,7 +8,7 @@ export const CamelotConfig: DexConfigMap<DexParams> = {
       subgraphURL:
         'https://api.thegraph.com/subgraphs/name/camelotlabs/camelot-amm-2',
       factoryAddress: '0x6EcCab422D763aC031210895C81787E87B43A652',
-      router: '0xd8f185769b6E2918B759e83F7EC268C882800EC7',
+      router: '0x1Be46c7A40906c19d91d07B3AE69Ef5893268F25',
       initCode:
         '0xa856464ae65f7619087bc369daaf7e387dae1e5af69cfa7935850ebf754b04c1',
       feeCode: 0, // this is ignored as Camelot uses dynamic fees

--- a/src/dex/camelot/types.ts
+++ b/src/dex/camelot/types.ts
@@ -1,0 +1,21 @@
+import {
+  UniswapV2Data,
+  UniswapV2PoolOrderedParams,
+  DexParams as UniswapV2DexParams,
+} from '../uniswap-v2/types';
+import { SolidlyPoolOrderedParams } from '../solidly/types';
+
+export type CamelotData = UniswapV2Data;
+
+export type CamelotPoolState = {
+  reserve0: string;
+  reserve1: string;
+  token0FeeCode: number;
+  token1FeeCode: number;
+  stable: boolean;
+};
+
+// to calculate prices for stable pool, we need decimals of the stable tokens
+export type CamelotPoolOrderedParams = SolidlyPoolOrderedParams;
+
+export type DexParams = UniswapV2DexParams;

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -54,6 +54,7 @@ import { CurveFork } from './curve-v1/forks/curve-forks/curve-forks';
 import { Swerve } from './curve-v1/forks/swerve/swerve';
 import { SwaapV1 } from './swaap-v1/swaap-v1';
 import { WstETH } from './wsteth/wsteth';
+import { Camelot } from './camelot/camelot';
 
 const LegacyDexes = [
   CurveV2,
@@ -106,6 +107,7 @@ const Dexes = [
   Synthetix,
   SwaapV1,
   WstETH,
+  Camelot,
 ];
 
 export type LegacyDexConstructor = new (dexHelper: IDexHelper) => IDexTxBuilder<


### PR DESCRIPTION
Camelot is a mix of UniswapV2 and Solidly AMM, with a custom fees implementation.
We're deployed on Arbitrum, here is our live factory: [CamelotFactory](https://arbiscan.io/address/0x6eccab422d763ac031210895c81787e87b43a652)

This router has been deployed especially for Paraswap integration: [CamelotRouter](https://arbiscan.io/address/0x1Be46c7A40906c19d91d07B3AE69Ef5893268F25) 
We've forked it from the router used by all Solidly fork on Optimisim: [SolidlyRouter](https://optimistic.etherscan.io/address/0xa2f581b012E0f2dcCDe86fCbfb529f4aC5dD4983)

The simple swap method seems to work well.
However, stables does not seem to work for the multiswap method, and I didn't find any Paraswap Solidly adapter for this.

