### PR TITLE
Add SwapFish to uniswap-v2

### DIFF
--- a/src/dex/uniswap-v2/config.ts
+++ b/src/dex/uniswap-v2/config.ts
@@ -539,6 +539,15 @@ export const UniswapV2Config: DexConfigMap<DexParams> = {
       feeCode: 30,
     },
   },
+  SwapFish: {
+    [Network.ARBITRUM]: {
+      subgraphURL: 'https://api.thegraph.com/subgraphs/name/swapfish/swapfish',
+      factoryAddress: '0x71539D09D3890195dDa87A6198B98B75211b72F3',
+      initCode:
+        '0xfa92cf9f91596341d1d4b5e0903226886fea1aebab892d11d3c2c1d14ae97534',
+      feeCode: 30,
+    },
+  },
   ZeroSwap: {
     [Network.AVALANCHE]: {
       subgraphURL:

--- a/src/dex/uniswap-v2/uniswap-v2-e2e-arbitrum.test.ts
+++ b/src/dex/uniswap-v2/uniswap-v2-e2e-arbitrum.test.ts
@@ -187,4 +187,40 @@ describe('UniswapV2 E2E Arbitrum', () => {
       });
     });
   });
+
+  describe('SwapFish', () => {
+    const dexKey = 'SwapFish';
+
+    describe('Simpleswap', () => {
+      it('SwapFish TOKEN -> TOKEN', async () => {
+        await testE2E(
+          tokens.WETH,
+          tokens.USDC,
+          holders.WETH,
+          '7000000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+    });
+
+    describe('Multiswap', () => {
+      it('SwapFish TOKEN -> TOKEN', async () => {
+        await testE2E(
+          tokens.WETH,
+          tokens.USDC,
+          holders.WETH,
+          '70000000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.multiSwap,
+          network,
+          provider,
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
Add SwapFish to uniswap-v2.

Website: https://swapfish.fi/
Docs: https://docs.swapfish.fi/swapfish-protocol/protocol-overview
Contract addresses: https://docs.swapfish.fi/security/contracts
Contract code: https://github.com/swapfish/contracts