### PR TITLE
Add new Linear pool types.

### DIFF
--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -67,7 +67,7 @@ const fetchAllPools = `query ($count: Int) {
     id
     address
     poolType
-    tokens {
+    tokens (orderBy: index) {
       address
       decimals
     }

--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -62,7 +62,7 @@ const fetchAllPools = `query ($count: Int) {
     first: $count
     orderBy: totalLiquidity
     orderDirection: desc
-    where: {totalLiquidity_gt: ${MIN_USD_LIQUIDITY_TO_FETCH.toString()}, totalShares_not_in: ["0", "0.000000000001"], id_not_in: ["0xbd482ffb3e6e50dc1c437557c3bea2b68f3683ee0000000000000000000003c6"], swapEnabled: true, poolType_in: ["MetaStable", "Stable", "Weighted", "LiquidityBootstrapping", "Investment", "StablePhantom", "AaveLinear", "ERC4626Linear", "Linear", "ComposableStable"]}
+    where: {totalLiquidity_gt: ${MIN_USD_LIQUIDITY_TO_FETCH.toString()}, totalShares_not_in: ["0", "0.000000000001"], id_not_in: ["0xbd482ffb3e6e50dc1c437557c3bea2b68f3683ee0000000000000000000003c6"], swapEnabled: true, poolType_in: ["MetaStable", "Stable", "Weighted", "LiquidityBootstrapping", "Investment", "StablePhantom", "AaveLinear", "ERC4626Linear", "Linear", "ComposableStable", "EulerLinear", "BeefyLinear", "GearboxLinear", "MidasLinear", "ReaperLinear", "SiloLinear", "TetuLinear", "YearnLinear"]}
   ) {
     id
     address
@@ -175,13 +175,21 @@ export class BalancerV2EventPool extends StatefulEventSubscriber<PoolStateMap> {
     this.pools[BalancerPoolTypes.MetaStable] = stablePool;
     this.pools[BalancerPoolTypes.LiquidityBootstrapping] = weightedPool;
     this.pools[BalancerPoolTypes.Investment] = weightedPool;
-    this.pools[BalancerPoolTypes.AaveLinear] = linearPool;
-    // ERC4626Linear has the same maths and ABI as AaveLinear (has different factory)
-    this.pools[BalancerPoolTypes.ERC4626Linear] = linearPool;
-    // Beets uses "Linear" generically for all linear pool types
-    this.pools[BalancerPoolTypes.Linear] = linearPool;
     this.pools[BalancerPoolTypes.StablePhantom] = stablePhantomPool;
     this.pools[BalancerPoolTypes.ComposableStable] = composableStable;
+    // All these Linear pool have same maths and ABI as AaveLinear but have different factories
+    this.pools[BalancerPoolTypes.AaveLinear] = linearPool;
+    this.pools[BalancerPoolTypes.ERC4626Linear] = linearPool;
+    this.pools[BalancerPoolTypes.EulerLinear] = linearPool;
+    this.pools[BalancerPoolTypes.GearboxLinear] = linearPool;
+    this.pools[BalancerPoolTypes.MidasLinear] = linearPool;
+    this.pools[BalancerPoolTypes.ReaperLinear] = linearPool;
+    this.pools[BalancerPoolTypes.SiloLinear] = linearPool;
+    this.pools[BalancerPoolTypes.TetuLinear] = linearPool;
+    this.pools[BalancerPoolTypes.YearnLinear] = linearPool;
+    this.pools[BalancerPoolTypes.BeefyLinear] = linearPool;
+    // Beets uses "Linear" generically for all linear pool types
+    this.pools[BalancerPoolTypes.Linear] = linearPool;
     this.vaultDecoder = (log: Log) => this.vaultInterface.parseLog(log);
     this.addressesSubscribed = [vaultAddress];
 

--- a/src/dex/balancer-v2/types.ts
+++ b/src/dex/balancer-v2/types.ts
@@ -7,11 +7,19 @@ export enum BalancerPoolTypes {
   MetaStable = 'MetaStable',
   LiquidityBootstrapping = 'LiquidityBootstrapping',
   Investment = 'Investment',
-  AaveLinear = 'AaveLinear',
   StablePhantom = 'StablePhantom',
-  ERC4626Linear = 'ERC4626Linear',
-  Linear = 'Linear',
   ComposableStable = 'ComposableStable',
+  Linear = 'Linear',
+  AaveLinear = 'AaveLinear',
+  ERC4626Linear = 'ERC4626Linear',
+  EulerLinear = 'EulerLinear',
+  BeefyLinear = 'BeefyLinear',
+  GearboxLinear = 'GearboxLinear',
+  MidasLinear = 'MidasLinear',
+  ReaperLinear = 'ReaperLinear',
+  SiloLinear = 'SiloLinear',
+  TetuLinear = 'TetuLinear',
+  YearnLinear = 'YearnLinear',
 }
 
 export type TokenState = {

--- a/src/dex/balancer-v2/utils.ts
+++ b/src/dex/balancer-v2/utils.ts
@@ -156,7 +156,15 @@ function isLinearPool(poolType: string) {
   return (
     poolType === BalancerPoolTypes.Linear ||
     poolType === BalancerPoolTypes.AaveLinear ||
-    poolType === BalancerPoolTypes.ERC4626Linear
+    poolType === BalancerPoolTypes.ERC4626Linear ||
+    poolType === BalancerPoolTypes.EulerLinear ||
+    poolType === BalancerPoolTypes.BeefyLinear ||
+    poolType === BalancerPoolTypes.GearboxLinear ||
+    poolType === BalancerPoolTypes.MidasLinear ||
+    poolType === BalancerPoolTypes.ReaperLinear ||
+    poolType === BalancerPoolTypes.SiloLinear ||
+    poolType === BalancerPoolTypes.TetuLinear ||
+    poolType === BalancerPoolTypes.YearnLinear
   );
 }
 


### PR DESCRIPTION
We are releasing new Linear Pool types which will expand the Boosted Pools product to other protocols other than Aave. These pools perform exactly the same as the existing "AaveLinear" pools but will be named differently in the Subgraph. This PR adds the new types that will be part of the initial launch.
EulerLinear
BeefyLinear
GearboxLinear
MidasLinear
ReaperLinear
SiloLinear
TetuLinear
YearnLinear