### PR TITLE
BACK-928: Fix calldata gas cost.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.9.71",
+  "version": "2.9.72-fix-calldata-gascost.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/paraswap-limit-orders/paraswap-limit-orders.ts
+++ b/src/dex/paraswap-limit-orders/paraswap-limit-orders.ts
@@ -193,7 +193,7 @@ export class ParaSwapLimitOrders
   getCalldataGasCost(
     poolPrices: PoolPrices<ParaSwapLimitOrdersData>,
   ): number | number[] {
-    return (poolPrices.gasCost as number[]).map(g => {
+    const calculateCalldataGasCost = (g: number) => {
       if (!g) return 0;
       const numOrders = Number(BigInt(g) / ONE_ORDER_GASCOST);
       return (
@@ -237,7 +237,10 @@ export class ParaSwapLimitOrders
             // Struct -> orderInfos[i] -> permitMakerAsset
             CALLDATA_GAS_COST.ZERO)
       );
-    });
+    };
+    return typeof poolPrices.gasCost === 'number'
+      ? calculateCalldataGasCost(poolPrices.gasCost)
+      : poolPrices.gasCost.map(calculateCalldataGasCost);
   }
 
   async preProcessTransaction?(


### PR DESCRIPTION
Fixes errors of `TypeError: poolPrices.gasCost.map is not a function`.