### PR TITLE
BACK-930: Fix: set msg.sender to augustusRFQAddress when calling isValidSignature.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.12.5",
+  "version": "2.12.6-fix-eip-1271.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/generic-rfq/utils.ts
+++ b/src/dex/generic-rfq/utils.ts
@@ -24,7 +24,9 @@ export const checkOrder = async (
   if (verifierContract) {
     const isValid = await verifierContract.methods
       .isValidSignature(hash, order.signature)
-      .call();
+      .call({
+        from: augustusRFQAddress,
+      });
 
     if (!isValid) {
       throw new Error(`signature is invalid`);


### PR DESCRIPTION
Set the sender address to AugustusRFQ address for cases when the market maker's smart contract has a whitelist that is implemented in isValidSignature (ERC-1271).