### PR TITLE
BACK-1045: Update WooFiV2 BSC addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.15.6",
+  "version": "2.15.7-friendly-local-deadline.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.15.7-friendly-local-deadline.0",
+  "version": "2.15.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/config.ts
+++ b/src/config.ts
@@ -56,7 +56,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
       '0xF9234CB08edb93c0d4a4d4c70cC3FfD070e78e07',
     rpcPollingMaxAllowedStateDelayInBlocks: 0,
     rpcPollingBlocksBackToTriggerUpdate: 0,
-    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN,
+    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
     hashFlowDisabledMMs:
       process.env[`HASHFLOW_DISABLED_MMS_1`]?.split(',') || [],
     uniswapV3EventLoggingSampleRate: 0,
@@ -153,7 +153,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     tokenTransferProxyAddress: '0x216b4b4ba9f3e719726886d34a177484278bfcae',
     multicallV2Address: '0xC50F4c1E81c873B2204D7eFf7069Ffec6Fbe136D',
     privateHttpProvider: process.env.HTTP_PROVIDER_56,
-    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN,
+    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
     hashFlowDisabledMMs:
       process.env[`HASHFLOW_DISABLED_MMS_56`]?.split(',') || [],
     adapterAddresses: {
@@ -180,7 +180,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     tokenTransferProxyAddress: '0x216b4b4ba9f3e719726886d34a177484278bfcae',
     multicallV2Address: '0x275617327c958bD06b5D6b871E7f491D76113dd8',
     privateHttpProvider: process.env.HTTP_PROVIDER_137,
-    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN,
+    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
     hashFlowDisabledMMs:
       process.env[`HASHFLOW_DISABLED_MMS_137`]?.split(',') || [],
     adapterAddresses: {
@@ -208,7 +208,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     tokenTransferProxyAddress: '0x216b4b4ba9f3e719726886d34a177484278bfcae',
     multicallV2Address: '0xd7Fc8aD069f95B6e2835f4DEff03eF84241cF0E1',
     privateHttpProvider: process.env.HTTP_PROVIDER_43114,
-    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN,
+    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
     hashFlowDisabledMMs:
       process.env[`HASHFLOW_DISABLED_MMS_43114`]?.split(',') || [],
     adapterAddresses: {
@@ -235,7 +235,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     tokenTransferProxyAddress: '0x216b4b4ba9f3e719726886d34a177484278bfcae',
     multicallV2Address: '0xdC6E2b14260F972ad4e5a31c68294Fba7E720701',
     privateHttpProvider: process.env.HTTP_PROVIDER_250,
-    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN,
+    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
     hashFlowDisabledMMs:
       process.env[`HASHFLOW_DISABLED_MMS_250`]?.split(',') || [],
 
@@ -262,7 +262,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     tokenTransferProxyAddress: '0x216b4b4ba9f3e719726886d34a177484278bfcae',
     multicallV2Address: '0x7eCfBaa8742fDf5756DAC92fbc8b90a19b8815bF',
     privateHttpProvider: process.env.HTTP_PROVIDER_42161,
-    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN,
+    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
     hashFlowDisabledMMs:
       process.env[`HASHFLOW_DISABLED_MMS_42161`]?.split(',') || [],
     adapterAddresses: {
@@ -290,7 +290,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     tokenTransferProxyAddress: '0x216b4b4ba9f3e719726886d34a177484278bfcae',
     multicallV2Address: '0x2DC0E2aa608532Da689e89e237dF582B783E552C',
     privateHttpProvider: process.env.HTTP_PROVIDER_10,
-    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN,
+    hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
     hashFlowDisabledMMs:
       process.env[`HASHFLOW_DISABLED_MMS_10`]?.split(',') || [],
 

--- a/src/dex/curve-v1/curve-v1.ts
+++ b/src/dex/curve-v1/curve-v1.ts
@@ -331,8 +331,10 @@ export class CurveV1 extends SimpleExchange implements IDex<CurveV1Data> {
             `Error_${this.dexKey} requested unsupported event pool with address ${poolAddress}`,
           );
 
-        const addressesSubscribed = newPool.addressesSubscribed.map((address) => address.toLowerCase());
-        if(!addressesSubscribed.includes(poolAddress)) {
+        const addressesSubscribed = newPool.addressesSubscribed.map(address =>
+          address.toLowerCase(),
+        );
+        if (!addressesSubscribed.includes(poolAddress)) {
           newPool.addressesSubscribed.push(poolAddress);
         }
 

--- a/src/dex/maverick-v1/maverick-v1.ts
+++ b/src/dex/maverick-v1/maverick-v1.ts
@@ -21,7 +21,10 @@ import {
   MaverickV1Param,
   SubgraphPoolBase,
 } from './types';
-import { SimpleExchange } from '../simple-exchange';
+import {
+  getLocalDeadlineAsFriendlyPlaceholder,
+  SimpleExchange,
+} from '../simple-exchange';
 import {
   MaverickV1Config,
   Adapters,
@@ -320,7 +323,7 @@ export class MaverickV1
     data: MaverickV1Data,
     side: SwapSide,
   ): AdapterExchangeParam {
-    const { deadline, pool } = data;
+    const { pool } = data;
     const payload = this.abiCoder.encodeParameter(
       {
         ParentStruct: {
@@ -330,7 +333,7 @@ export class MaverickV1
       },
       {
         pool,
-        deadline: deadline || this.getDeadline(),
+        deadline: getLocalDeadlineAsFriendlyPlaceholder(), // FIXME: more gas efficient to pass block.timestamp in adapter
       },
     );
 
@@ -358,7 +361,7 @@ export class MaverickV1
       side === SwapSide.SELL
         ? {
             recipient: this.augustusAddress,
-            deadline: this.getDeadline(),
+            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
             amountIn: srcAmount,
             amountOutMinimum: destAmount,
             tokenIn: srcToken,
@@ -368,7 +371,7 @@ export class MaverickV1
           }
         : {
             recipient: this.augustusAddress,
-            deadline: this.getDeadline(),
+            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
             amountOut: destAmount,
             amountInMaximum: srcAmount,
             tokenIn: srcToken,

--- a/src/dex/maverick-v1/types.ts
+++ b/src/dex/maverick-v1/types.ts
@@ -45,7 +45,6 @@ export type MaverickV1Data = {
   tokenA: Address;
   tokenB: Address;
   exchange: Address;
-  deadline?: number;
 };
 
 export enum MaverickV1Functions {
@@ -58,7 +57,7 @@ export type MaverickV1SellParam = {
   tokenOut: Address;
   pool: Address;
   recipient: Address;
-  deadline: number;
+  deadline: string;
   amountIn: NumberAsString;
   amountOutMinimum: NumberAsString;
   sqrtPriceLimitD18: NumberAsString;
@@ -69,7 +68,7 @@ export type MaverickV1BuyParam = {
   tokenOut: Address;
   pool: Address;
   recipient: Address;
-  deadline: number;
+  deadline: string;
   amountOut: NumberAsString;
   amountInMaximum: NumberAsString;
   sqrtPriceLimitD18: NumberAsString;

--- a/src/dex/platypus/platypus.ts
+++ b/src/dex/platypus/platypus.ts
@@ -21,7 +21,10 @@ import {
   PlatypusData,
   PlatypusConfigInfo,
 } from './types';
-import { SimpleExchange } from '../simple-exchange';
+import {
+  getLocalDeadlineAsFriendlyPlaceholder,
+  SimpleExchange,
+} from '../simple-exchange';
 import { PlatypusConfig, Adapters } from './config';
 import { ChainLinkSubscriber } from '../../lib/chainlink';
 import { PlatypusPoolBase } from './pool-base';
@@ -461,7 +464,7 @@ export class Platypus extends SimpleExchange implements IDex<PlatypusData> {
             destToken,
             1,
             this.augustusAddress,
-            this.getDeadline(),
+            getLocalDeadlineAsFriendlyPlaceholder(),
           ])
         : isETHAddress(destToken)
         ? Platypus.avaxPoolInterface.encodeFunctionData('swapToETH', [
@@ -469,7 +472,7 @@ export class Platypus extends SimpleExchange implements IDex<PlatypusData> {
             srcAmount,
             1,
             this.augustusAddress,
-            this.getDeadline(),
+            getLocalDeadlineAsFriendlyPlaceholder(),
           ])
         : Platypus.poolInterface.encodeFunctionData('swap', [
             srcToken,
@@ -477,7 +480,7 @@ export class Platypus extends SimpleExchange implements IDex<PlatypusData> {
             srcAmount,
             1,
             this.augustusAddress,
-            this.getDeadline(),
+            getLocalDeadlineAsFriendlyPlaceholder(),
           ]),
       data.pool,
     );

--- a/src/dex/shell.ts
+++ b/src/dex/shell.ts
@@ -2,9 +2,11 @@ import { Interface, JsonFragment } from '@ethersproject/abi';
 import { SwapSide } from '../constants';
 import { AdapterExchangeParam, Address, SimpleExchangeParam } from '../types';
 import { IDexTxBuilder } from './idex';
-import { SimpleExchange } from './simple-exchange';
+import {
+  getLocalDeadlineAsFriendlyPlaceholder,
+  SimpleExchange,
+} from './simple-exchange';
 import ShellABI from '../abi/Shell.json';
-import Web3 from 'web3';
 import { IDexHelper } from '../dex-helper';
 
 export type ShellData = {
@@ -16,7 +18,7 @@ type ShellParam = [
   _target: string,
   _originAmount: string,
   _minTargetAmount: string,
-  _deadline?: number,
+  _deadline: string,
 ];
 enum ShellFunctions {
   originSwap = 'originSwap',
@@ -63,7 +65,7 @@ export class Shell
       destToken,
       srcAmount,
       destAmount,
-      data.deadline || this.getDeadline(),
+      getLocalDeadlineAsFriendlyPlaceholder(),
     ];
     const swapData = this.exchangeRouterInterface.encodeFunctionData(
       swapFunction,

--- a/src/dex/simple-exchange.ts
+++ b/src/dex/simple-exchange.ts
@@ -10,6 +10,18 @@ import { MAX_UINT } from '../constants';
 import Web3 from 'web3';
 import { IDexHelper } from '../dex-helper';
 
+/*
+ * Context: Augustus routers have all a deadline protection logic implemented globally.
+ * But some integrations (router, pools,...) require passing a deadline generally as uint256.
+ * While this problem can be solved in adapters easily by passing block.timestamp (or block.timestamp +1 for some marginal cases),
+ * In the context of direct calls like simpleSwap we have to generate this value offchain.
+ * One can naively pick type(uint).max but that would impose a higher gas cost on the calldata.
+ * Here we decide to go with a high enough default so that the local deadline rarely supersedes the global router deadline.
+ */
+export const FRIENDLY_LOCAL_DEADLINE = 7 * 24 * 60 * 60;
+export const getLocalDeadlineAsFriendlyPlaceholder = () =>
+  String(Math.floor(new Date().getTime() / 1000) + FRIENDLY_LOCAL_DEADLINE);
+
 export class SimpleExchange {
   simpleSwapHelper: Interface;
   protected abiCoder: AbiCoder;
@@ -121,9 +133,5 @@ export class SimpleExchange {
       values: [...approveParam.values, swapValue],
       networkFee,
     };
-  }
-
-  getDeadline() {
-    return Math.floor(new Date().getTime() / 1000) + 60 * 60;
   }
 }

--- a/src/dex/trader-joe-v2.ts
+++ b/src/dex/trader-joe-v2.ts
@@ -2,7 +2,10 @@ import { Network, SwapSide } from '../constants';
 import { AdapterExchangeParam, Address, SimpleExchangeParam } from '../types';
 import { IDexTxBuilder } from './idex';
 import { IDexHelper } from '../dex-helper';
-import { SimpleExchange } from './simple-exchange';
+import {
+  getLocalDeadlineAsFriendlyPlaceholder,
+  SimpleExchange,
+} from './simple-exchange';
 import { NumberAsString } from '@paraswap/core';
 import { AsyncOrSync } from 'ts-essentials';
 import { Interface, JsonFragment } from '@ethersproject/abi';
@@ -29,7 +32,7 @@ type TraderJoeV2RouterBuyParams = [
   _pairBinSteps: NumberAsString[],
   _tokenPath: Address[],
   to: Address,
-  _deadline: number,
+  _deadline: string,
 ];
 
 type TraderJoeV2RouterParam =
@@ -37,7 +40,6 @@ type TraderJoeV2RouterParam =
   | TraderJoeV2RouterBuyParams;
 
 export type TraderJoeV2Data = {
-  deadline?: number;
   tokenIn: string; // redundant
   tokenOut: string; // redundant
   binStep: string;
@@ -87,7 +89,7 @@ export class TraderJoeV2
       {
         _pairBinSteps: [data.binStep],
         _tokenPath: [data.tokenIn, data.tokenOut], // FIXME: redundant, shoot & read from contract
-        _deadline: data.deadline || this.getDeadline(),
+        _deadline: getLocalDeadlineAsFriendlyPlaceholder(), // FIXME: more gas efficient to pass block.timestamp in adapter
       },
     );
 
@@ -119,7 +121,7 @@ export class TraderJoeV2
             [data.binStep],
             [srcToken, destToken],
             this.augustusAddress,
-            data.deadline || this.getDeadline(),
+            getLocalDeadlineAsFriendlyPlaceholder(),
           ]
         : [
             destAmount,
@@ -127,7 +129,7 @@ export class TraderJoeV2
             [data.binStep],
             [srcToken, destToken],
             this.augustusAddress,
-            data.deadline || this.getDeadline(),
+            getLocalDeadlineAsFriendlyPlaceholder(),
           ];
     const swapData = this.exchangeRouterInterface.encodeFunctionData(
       swapFunction,

--- a/src/dex/uniswap-v3.ts
+++ b/src/dex/uniswap-v3.ts
@@ -3,7 +3,10 @@ import { pack } from '@ethersproject/solidity';
 import { Network, SwapSide } from '../constants';
 import { AdapterExchangeParam, Address, SimpleExchangeParam } from '../types';
 import { IDexTxBuilder } from './idex';
-import { SimpleExchange } from './simple-exchange';
+import {
+  getLocalDeadlineAsFriendlyPlaceholder,
+  SimpleExchange,
+} from './simple-exchange';
 import UniswapV3RouterABI from '../abi/UniswapV3Router.json';
 import { NumberAsString } from '@paraswap/core';
 import { IDexHelper } from '../dex-helper';
@@ -17,7 +20,6 @@ const UNISWAP_V3_ROUTER_ADDRESSES: { [network: number]: Address } = {
 
 export type UniswapV3Data = {
   // ExactInputSingleParams
-  deadline?: number;
   path: {
     tokenIn: Address;
     tokenOut: Address;
@@ -28,7 +30,7 @@ export type UniswapV3Data = {
 type UniswapV3SellParam = {
   path: string;
   recipient: Address;
-  deadline: number;
+  deadline: string;
   amountIn: NumberAsString;
   amountOutMinimum: NumberAsString;
 };
@@ -36,7 +38,7 @@ type UniswapV3SellParam = {
 type UniswapV3BuyParam = {
   path: string;
   recipient: Address;
-  deadline: number;
+  deadline: string;
   amountOut: NumberAsString;
   amountInMaximum: NumberAsString;
 };
@@ -112,7 +114,7 @@ export class UniswapV3
     data: UniswapV3Data,
     side: SwapSide,
   ): AdapterExchangeParam {
-    const { deadline, path: rawPath } = data;
+    const { path: rawPath } = data;
     const path = this.encodePath(rawPath, side);
     const payload = this.abiCoder.encodeParameter(
       {
@@ -123,14 +125,14 @@ export class UniswapV3
       },
       {
         path,
-        deadline: deadline || this.getDeadline(),
+        deadline: getLocalDeadlineAsFriendlyPlaceholder(), // FIXME: more gas efficient to pass block.timestamp in adapter
       },
     );
 
     return {
       targetExchange: this.routerAddress,
       payload,
-      networkFee: '0', // warning
+      networkFee: '0',
     };
   }
 
@@ -151,14 +153,14 @@ export class UniswapV3
       side === SwapSide.SELL
         ? {
             recipient: this.augustusAddress,
-            deadline: data.deadline || this.getDeadline(),
+            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
             amountIn: srcAmount,
             amountOutMinimum: destAmount,
             path,
           }
         : {
             recipient: this.augustusAddress,
-            deadline: data.deadline || this.getDeadline(),
+            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
             amountOut: destAmount,
             amountInMaximum: srcAmount,
             path,

--- a/src/dex/uniswap-v3/types.ts
+++ b/src/dex/uniswap-v3/types.ts
@@ -72,7 +72,7 @@ export type DexParams = {
 export type UniswapV3SellParam = {
   path: string;
   recipient: Address;
-  deadline: number;
+  deadline: string;
   amountIn: NumberAsString;
   amountOutMinimum: NumberAsString;
 };
@@ -80,7 +80,7 @@ export type UniswapV3SellParam = {
 export type UniswapV3BuyParam = {
   path: string;
   recipient: Address;
-  deadline: number;
+  deadline: string;
   amountOut: NumberAsString;
   amountInMaximum: NumberAsString;
 };

--- a/src/dex/uniswap-v3/uniswap-v3.ts
+++ b/src/dex/uniswap-v3/uniswap-v3.ts
@@ -30,7 +30,10 @@ import {
   UniswapV3Functions,
   UniswapV3Param,
 } from './types';
-import { SimpleExchange } from '../simple-exchange';
+import {
+  getLocalDeadlineAsFriendlyPlaceholder,
+  SimpleExchange,
+} from '../simple-exchange';
 import { UniswapV3Config, Adapters, PoolsToPreload } from './config';
 import { UniswapV3EventPool } from './uniswap-v3-pool';
 import UniswapV3RouterABI from '../../abi/uniswap-v3/UniswapV3Router.abi.json';
@@ -686,7 +689,7 @@ export class UniswapV3
       },
       {
         path,
-        deadline: this.getDeadline(),
+        deadline: getLocalDeadlineAsFriendlyPlaceholder(), // FIXME: more gas efficient to pass block.timestamp in adapter
       },
     );
 
@@ -740,14 +743,14 @@ export class UniswapV3
       side === SwapSide.SELL
         ? {
             recipient: this.augustusAddress,
-            deadline: this.getDeadline(),
+            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
             amountIn: srcAmount,
             amountOutMinimum: destAmount,
             path,
           }
         : {
             recipient: this.augustusAddress,
-            deadline: this.getDeadline(),
+            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
             amountOut: destAmount,
             amountInMaximum: srcAmount,
             path,

--- a/src/dex/woo-fi-v2/config.ts
+++ b/src/dex/woo-fi-v2/config.ts
@@ -15,12 +15,12 @@ export const WooFiV2Config: DexConfigMap<DexParams> = {
       },
     },
     [Network.BSC]: {
-      wooPPV2Address: '0xEc054126922a9a1918435c9072c32f1B60cB2B90',
-      wooOracleV2Address: '0x747f99D619D5612399010Ec5706F13e3345c4a9E',
-      integrationHelperAddress: '0xe12dC1F01ccB71ef00ADd1D8A5116b905261D879',
-      // BUSD
+      wooPPV2Address: '0x59dE3B49314Bf5067719364A2Cb43e8525ab93FA',
+      wooOracleV2Address: '0x4B11B9BfAafA840c436a1ddDc13D3738C8ebfD62',
+      integrationHelperAddress: '0xAA9c15cd603428cA8ddD45e933F8EfE3Afbcc173',
+      // USDT
       quoteToken: {
-        address: '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
+        address: '0x55d398326f99059fF775485246999027B3197955',
         decimals: 18,
       },
     },

--- a/src/dex/woo-fi-v2/woo-fi-v2-e2e.test.ts
+++ b/src/dex/woo-fi-v2/woo-fi-v2-e2e.test.ts
@@ -114,7 +114,7 @@ describe('WooFiV2 E2E', () => {
 
     const baseATokenSymbol = 'WBNB';
     const baseBTokenSymbol = 'bBTC';
-    const quoteTokenSymbol = 'BUSD';
+    const quoteTokenSymbol = 'USDT';
 
     const tokenBaseAAmount = '1000000000000000000';
     const tokenQuoteAmount = '1000000000000000000';

--- a/src/dex/woo-fi-v2/woo-fi-v2-integration.test.ts
+++ b/src/dex/woo-fi-v2/woo-fi-v2-integration.test.ts
@@ -360,7 +360,7 @@ describe('WooFiV2', function () {
     });
 
     const baseATokenSymbol = 'WBNB';
-    const quoteTokenSymbol = 'BUSD';
+    const quoteTokenSymbol = 'USDT';
     const baseBTokenSymbol = 'bBTC';
     const untradableSymbol = 'POPS';
 

--- a/src/transaction-builder.ts
+++ b/src/transaction-builder.ts
@@ -2,6 +2,10 @@ import { OptimalRate, Address, Adapters } from './types';
 import { ETHER_ADDRESS, SwapSide } from './constants';
 import { RouterService } from './router';
 import { DexAdapterService } from './dex';
+import {
+  FRIENDLY_LOCAL_DEADLINE,
+  getLocalDeadlineAsFriendlyPlaceholder,
+} from './dex/simple-exchange';
 
 export class TransactionBuilder {
   routerService: RouterService;
@@ -43,6 +47,14 @@ export class TransactionBuilder {
     beneficiary?: Address;
     onlyParams?: boolean;
   }) {
+    const globalDeadline = +deadline;
+    if (isNaN(globalDeadline)) throw new Error('deadline should be a number');
+    const localDeadline = +getLocalDeadlineAsFriendlyPlaceholder();
+    if (globalDeadline > localDeadline)
+      throw new Error(
+        `Deadline is too high. Maximum allowed is ${FRIENDLY_LOCAL_DEADLINE} seconds`,
+      );
+
     const _beneficiary = beneficiary || userAddress;
     const { encoder, params, networkFee } = await this.routerService
       .getRouterByContractMethod(priceRoute.contractMethod)


### PR DESCRIPTION
Changes:
* WooFiV2 changed quoteToken for their contracts from BUSD -> USDT, therefore need to update contract addresses.
* Updated tests to match new test scenarios. All are passing
* Make Hashflow token optional
* Merged to this PR dex-lib deadline check

To test you can take any pair on BSC like: WBNB -> USDT and see if it is working