### PR TITLE
Add Morphex (GMX fork on Fantom)

### DIFF
--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -62,6 +62,7 @@ import { MaverickV1 } from './maverick-v1/maverick-v1';
 import { QuickSwapV3 } from './quickswap/quickswap-v3';
 import { ZyberSwapV3 } from './quickswap/zyberswap-v3';
 import { TraderJoeV2 } from './trader-joe-v2';
+import { Morphex } from './morphex/morphex';
 
 const LegacyDexes = [
   CurveV2,
@@ -106,6 +107,7 @@ const Dexes = [
   Nerve,
   Platypus,
   GMX,
+  Morphex,
   JarvisV6,
   WooFiV2,
   ParaSwapLimitOrders,

--- a/src/dex/morphex/config.ts
+++ b/src/dex/morphex/config.ts
@@ -1,0 +1,31 @@
+import { DexParams } from '../gmx/types';
+import { DexConfigMap } from '../../types';
+import { Network, SwapSide } from '../../constants';
+
+export const MorphexConfig: DexConfigMap<DexParams> = {
+  Morphex: {
+    [Network.FANTOM]: {
+      vault: '0x3CB54f0eB62C371065D739A34a775CC16f46563e',
+      reader: '0x8BC6D6d2cdD68E51a8046F2C570824027842eD8D',
+      priceFeed: '0x1e4eed8fd57DFBaaE060F894582eC0183c5D6e38',
+      fastPriceFeed: '0x89BE4cF89c425F74b2d0691A268A9a421e9dce7b',
+      fastPriceEvents: '0xD09eF52d1BB74D67B0c508b932E90f8a6B7F1884',
+      usdg: '0xB7209EbCBF71c0ffA1585B4468A11CFfdcDBB9a9',
+    },
+  },
+};
+
+export const Adapters: {
+  [chainId: number]: {
+    [side: string]: { name: string; index: number }[] | null;
+  };
+} = {
+  [Network.FANTOM]: {
+    [SwapSide.SELL]: [
+      {
+        name: 'FantomAdapter01',
+        index: 6, // TODO: it's for aavev3, but there is no Morphex adapter
+      },
+    ],
+  },
+};

--- a/src/dex/morphex/morphex-e2e.test.ts
+++ b/src/dex/morphex/morphex-e2e.test.ts
@@ -1,0 +1,91 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import {
+  Tokens,
+  Holders,
+  NativeTokenSymbols,
+} from '../../../tests/constants-e2e';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+
+describe('Morphex E2E', () => {
+  const dexKey = 'Morphex';
+
+  describe('Morphex Fantom', () => {
+    const network = Network.FANTOM;
+    const tokens = Tokens[network];
+    const holders = Holders[network];
+    const provider = new StaticJsonRpcProvider(
+      generateConfig(network).privateHttpProvider,
+      network,
+    );
+
+    const tokenASymbol: string = 'USDC';
+    const tokenBSymbol: string = 'WETH';
+    const nativeTokenSymbol = NativeTokenSymbols[network];
+
+    const tokenBAmount: string = '1000000000000000000';
+    const tokenAAmount: string = '2000000000';
+    const nativeTokenAmount = '100000000000000000000';
+
+    const sideToContractMethods = new Map([
+      [
+        SwapSide.SELL,
+        [
+          ContractMethod.simpleSwap,
+          ContractMethod.multiSwap,
+          ContractMethod.megaSwap,
+        ],
+      ],
+    ]);
+
+    sideToContractMethods.forEach((contractMethods, side) =>
+      contractMethods.forEach((contractMethod: ContractMethod) => {
+        describe(`${contractMethod}`, () => {
+          it(nativeTokenSymbol + ' -> TOKEN', async () => {
+            await testE2E(
+              tokens[nativeTokenSymbol],
+              tokens[tokenASymbol],
+              holders[nativeTokenSymbol],
+              side === SwapSide.SELL ? nativeTokenAmount : tokenAAmount,
+              side,
+              dexKey,
+              contractMethod,
+              network,
+              provider,
+            );
+          });
+          it('TOKEN -> ' + nativeTokenSymbol, async () => {
+            await testE2E(
+              tokens[tokenASymbol],
+              tokens[nativeTokenSymbol],
+              holders[tokenASymbol],
+              side === SwapSide.SELL ? tokenAAmount : nativeTokenAmount,
+              side,
+              dexKey,
+              contractMethod,
+              network,
+              provider,
+            );
+          });
+          it('TOKEN -> TOKEN', async () => {
+            await testE2E(
+              tokens[tokenASymbol],
+              tokens[tokenBSymbol],
+              holders[tokenASymbol],
+              side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
+              side,
+              dexKey,
+              contractMethod,
+              network,
+              provider,
+            );
+          });
+        });
+      }),
+    );
+  });
+});

--- a/src/dex/morphex/morphex-events.test.ts
+++ b/src/dex/morphex/morphex-events.test.ts
@@ -1,0 +1,97 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { GMXEventPool } from '../gmx/pool';
+import { MorphexConfig } from './config';
+import { Network } from '../../constants';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { testEventSubscriber } from '../../../tests/utils-events';
+import { PoolState } from '../gmx/types';
+
+jest.setTimeout(50 * 1000);
+const dexKey = 'Morphex';
+const network = Network.FANTOM;
+const params = MorphexConfig[dexKey][network];
+
+async function fetchPoolState(
+  gmxPool: GMXEventPool,
+  blockNumber: number,
+): Promise<PoolState> {
+  return gmxPool.generateState(blockNumber);
+}
+
+// timestamp can't be compared exactly as the event released
+// doesn't have the timestamp. It is safe to consider the
+// timestamp as the blockTime as the max deviation is bounded
+// on the contract
+const stateWithoutTimestamp = (state: PoolState) => ({
+  ...state,
+  secondaryPrices: {
+    prices: state.secondaryPrices.prices,
+    // timestamp (this is removed)
+  },
+});
+
+function compareState(state: PoolState, expectedState: PoolState) {
+  expect(stateWithoutTimestamp(state)).toEqual(
+    stateWithoutTimestamp(expectedState),
+  );
+}
+
+describe('Morphex Event', function () {
+  const blockNumbers: { [eventName: string]: number[] } = {
+    IncreaseUsdgAmount: [
+      59651732, 59651743, 59651861, 59651866, 59651867, 59651930, 59651936,
+      59651997, 59651998, 59652002, 59652008, 59652009, 59652031, 59652043,
+      59652050, 59652106, 59652124, 59652298, 59652408, 59652433, 59652513,
+      59652560,
+    ],
+    DecreaseUsdgAmount: [
+      59651732, 59651743, 59651861, 59651866, 59651867, 59651930, 59651936,
+      59651997, 59651998, 59652002, 59652008, 59652009, 59652031, 59652043,
+      59652050, 59652106, 59652124, 59652298, 59652408, 59652433, 59652513,
+      59652560, 59653097,
+    ],
+    Transfer: [
+      59629746, 59630399, 59636919, 59642168, 59645873, 59647620, 59647620,
+    ],
+    PriceUpdate: [
+      59654160, 59654320, 59654371, 59654438, 59654587, 59654606, 59654632,
+      59654783, 59654800,
+    ],
+  };
+
+  describe('MorphexEventPool', function () {
+    Object.keys(blockNumbers).forEach((event: string) => {
+      blockNumbers[event].forEach((blockNumber: number) => {
+        it(`Should return the correct state after the ${blockNumber}:${event}`, async function () {
+          const dexHelper = new DummyDexHelper(network);
+          const logger = dexHelper.getLogger(dexKey);
+
+          const config = await GMXEventPool.getConfig(
+            params,
+            blockNumber,
+            dexHelper.multiContract,
+          );
+          const gmxPool = new GMXEventPool(
+            dexKey,
+            network,
+            dexHelper,
+            logger,
+            config,
+          );
+
+          await testEventSubscriber(
+            gmxPool,
+            gmxPool.addressesSubscribed,
+            (_blockNumber: number) => fetchPoolState(gmxPool, _blockNumber),
+            blockNumber,
+            `${dexKey}_${params.vault}`,
+            dexHelper.provider,
+            compareState,
+          );
+        });
+      });
+    });
+  });
+});

--- a/src/dex/morphex/morphex-integration.test.ts
+++ b/src/dex/morphex/morphex-integration.test.ts
@@ -1,0 +1,113 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Interface } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide } from '../../constants';
+import { Morphex } from './morphex';
+import { MorphexConfig } from './config';
+import {
+  checkPoolPrices,
+  checkPoolsLiquidity,
+  checkConstantPoolPrices,
+} from '../../../tests/utils';
+import { Tokens } from '../../../tests/constants-e2e';
+import ReaderABI from '../../abi/gmx/reader.json';
+
+const network = Network.FANTOM;
+const TokenASymbol = 'USDC';
+const TokenA = Tokens[network][TokenASymbol];
+
+const TokenBSymbol = 'WFTM';
+const TokenB = Tokens[network][TokenBSymbol];
+
+const amounts = [
+  0n,
+  1000000000n,
+  2000000000n,
+  3000000000n,
+  4000000000n,
+  5000000000n,
+];
+
+const dexKey = 'Morphex';
+const params = MorphexConfig[dexKey][network];
+const readerInterface = new Interface(ReaderABI);
+const readerAddress = '0x8BC6D6d2cdD68E51a8046F2C570824027842eD8D';
+
+describe('Morphex', function () {
+  it('getPoolIdentifiers and getPricesVolume SELL', async function () {
+    const dexHelper = new DummyDexHelper(network);
+    const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+    const gmx = new Morphex(network, dexKey, dexHelper);
+
+    await gmx.initializePricing(blocknumber);
+
+    const pools = await gmx.getPoolIdentifiers(
+      TokenA,
+      TokenB,
+      SwapSide.SELL,
+      blocknumber,
+    );
+    console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `, pools);
+
+    expect(pools.length).toBeGreaterThan(0);
+
+    const poolPrices = await gmx.getPricesVolume(
+      TokenA,
+      TokenB,
+      amounts,
+      SwapSide.SELL,
+      blocknumber,
+      pools,
+    );
+    console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `, poolPrices);
+
+    expect(poolPrices).not.toBeNull();
+    if (gmx.hasConstantPriceLargeAmounts) {
+      checkConstantPoolPrices(poolPrices!, amounts, dexKey);
+    } else {
+      checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+    }
+
+    // Do on chain pricing based on reader to compare
+    const readerCallData = amounts.map(a => ({
+      target: readerAddress,
+      callData: readerInterface.encodeFunctionData('getAmountOut', [
+        params.vault,
+        TokenA.address,
+        TokenB.address,
+        a.toString(),
+      ]),
+    }));
+
+    const readerResult = (
+      await dexHelper.multiContract.methods
+        .aggregate(readerCallData)
+        .call({}, blocknumber)
+    ).returnData;
+    const expectedPrices = readerResult.map((p: any) =>
+      BigInt(
+        readerInterface.decodeFunctionResult('getAmountOut', p)[0].toString(),
+      ),
+    );
+
+    expect(poolPrices![0].prices).toEqual(expectedPrices);
+  });
+
+  it('getTopPoolsForToken', async function () {
+    const dexHelper = new DummyDexHelper(network);
+    const gmx = new Morphex(network, dexKey, dexHelper);
+
+    await gmx.updatePoolState();
+    const poolLiquidity = await gmx.getTopPoolsForToken(TokenA.address, 10);
+    console.log(
+      `${TokenASymbol} Top Pools:`,
+      JSON.stringify(poolLiquidity, null, 2),
+    );
+
+    if (!gmx.hasConstantPriceLargeAmounts) {
+      checkPoolsLiquidity(poolLiquidity, TokenA.address, dexKey);
+    }
+  });
+});

--- a/src/dex/morphex/morphex.ts
+++ b/src/dex/morphex/morphex.ts
@@ -1,0 +1,22 @@
+import { Network } from '../../constants';
+import { IDexHelper } from '../../dex-helper';
+import { DexParams } from '../gmx/types';
+import { Adapters, MorphexConfig } from './config';
+import { GMX } from '../gmx/gmx';
+import { getDexKeysWithNetwork } from '../../utils';
+
+export class Morphex extends GMX {
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(MorphexConfig);
+
+  constructor(
+    protected network: Network,
+    dexKey: string,
+    protected dexHelper: IDexHelper,
+    protected adapters = Adapters[network],
+    protected params: DexParams = MorphexConfig[dexKey][network],
+  ) {
+    super(network, dexKey, dexHelper, adapters, params);
+    this.logger = dexHelper.getLogger(dexKey);
+  }
+}

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -913,7 +913,7 @@ export const Holders: {
     MIM: '0xbcab7d083cf6a01e0dda9ed7f8a02b47d125e682',
     FRAX: '0x4423ac71f53ca92e2f2be5917a9c2468e7412f4a',
     nETH: '0x16b658270ac50c0063940ed287c401b3df7ccf70',
-    WETH: '0x4ad64fd7ca6d6150614179b9bce4094bc18f29cb',
+    WETH: '0x8AeeaBD8bD2A7bcCB73D14d72b49e7341c9383B3',
     SPIRIT: '0x0d0707963952f2fba59dd06f2b425ace40b492fe',
     wBOMB: '0x28aa4f9ffe21365473b64c161b566c3cdead0108',
     TOR: '0x70de4b5ed310fd93da3c0bae824fb99cb4d44dd8',


### PR DESCRIPTION
Hi, this is initial PR for Morphex (GMX fork on Fantom). 

Morphex inherits from GMX, and all tests are based on GMX ones. 

Integration tests and events tests work properly, however in E2E tests only SimpleSwap works. 
This is because there is no proper adapter on Fantom network for Morphex.

Not sure how to go forward without the adapter, so I reached out in Discord, and created this PR.

Best regards, 
pbnather