### PR TITLE
Lighter v1 <> ParaSwap integration

### DIFF
--- a/scripts/fetch-event-blocknumber.ts
+++ b/scripts/fetch-event-blocknumber.ts
@@ -6,8 +6,7 @@ import { StaticJsonRpcProvider, Provider } from '@ethersproject/providers';
 import { Network } from '../src/constants';
 import { Address } from '../src/types';
 import { generateConfig } from '../src/config';
-// TODO: Import correct ABI
-import ABI from '../src/abi/erc20.json';
+import ABI from '../src/dex/lighter-v1/abi/order_book.json';
 
 // This is a helper script to fetch blockNumbers where a certain
 // event was released by a certain contract
@@ -40,12 +39,12 @@ async function getBlockNumbersForEvents(
 }
 
 // TODO: Set your values here
-const network = Network.AVALANCHE;
-const eventNames = ['Transfer'];
-const address = '0xc0253c3cc6aa5ab407b5795a04c28fb063273894';
+const network = Network.ARBITRUM;
+const eventNames = ['LimitOrderCreated', 'Swap', 'LimitOrderCanceled'];
+const address = '0xB8Df652Ccb5CB39Ac1cD98a899639F8463B103a8';
 const provider = new StaticJsonRpcProvider(
   generateConfig(network).privateHttpProvider,
   network,
 );
 
-getBlockNumbersForEvents(address, ABI, eventNames, 0, 2000, provider);
+getBlockNumbersForEvents(address, ABI, eventNames, 0, 5000, provider);

--- a/scripts/run-dex-integration-lighter-v1.ts
+++ b/scripts/run-dex-integration-lighter-v1.ts
@@ -1,0 +1,88 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Network, SwapSide } from '../src/constants';
+import { LighterV1 } from '../src/dex/lighter-v1/lighter-v1';
+import { DummyDexHelper } from '../src/dex-helper/index';
+import { BI_POWS } from '../src/bigint-constants';
+import { LighterV1EventPool } from '../src/dex/lighter-v1/lighter-v1-pool';
+
+const WETH = {
+  address: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+  decimals: 18,
+};
+
+const USDCe = {
+  address: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+  decimals: 6,
+};
+
+const USDC = {
+  address: '0xcC4a8FA63cE5C6a7f4A7A3D2EbCb738ddcD31209',
+  decimals: 6,
+};
+
+const amounts = [2000000000000000000n];
+
+async function main() {
+  const dexHelper = new DummyDexHelper(Network.ARBITRUM);
+  const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+
+  const lighterV1 = new LighterV1(Network.ARBITRUM, 'LighterV1', dexHelper);
+
+  await lighterV1.initializePricing(blocknumber);
+
+  const pool: LighterV1EventPool | undefined = lighterV1.orderBooks.get(0);
+  if (!pool) {
+    throw new Error('Pool not found');
+  }
+
+  // console.log('pool state: ', pool.getState(blocknumber));
+
+  const prices = await lighterV1.getPricesVolume(
+    WETH,
+    USDCe,
+    amounts,
+    SwapSide.SELL,
+    blocknumber,
+  );
+
+  console.log('WETH <> USDCe Pool Prices: ', prices);
+
+  const helperPrice = await lighterV1.getQuoteFromHelper(
+    blocknumber,
+    0,
+    2000000000000000000n,
+    true,
+  );
+  console.log('helper price: ', helperPrice.toString());
+
+  // await balancerV2.setupEventPools(blocknumber);
+
+  // const from = MATIC;
+  // const to = stMATIC;
+
+  // const pools = await balancerV2.getPoolIdentifiers(
+  //   from,
+  //   to,
+  //   SwapSide.SELL,
+  //   blocknumber,
+  // );
+  // console.log('WETH <> DAI Pool Identifiers: ', pools);
+
+  // const prices = await balancerV2.getPricesVolume(
+  //   from,
+  //   to,
+  //   amounts,
+  //   SwapSide.SELL,
+  //   blocknumber,
+  //   pools,
+  // );
+  // console.log('WETH <> DAI Pool Prices: ', prices);
+
+  // const poolLiquidity = await balancerV2.getTopPoolsForToken(from.address, 10);
+  // console.log('WETH Top Pools:', poolLiquidity);
+}
+
+main();

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -72,6 +72,7 @@ import { SpiritSwapV3 } from './quickswap/spiritswap-v3';
 import { TraderJoeV21 } from './trader-joe-v2.1';
 import { PancakeswapV3 } from './pancakeswap-v3/pancakeswap-v3';
 import { Algebra } from './algebra/algebra';
+import { LighterV1 } from './lighter-v1/lighter-v1';
 
 const LegacyDexes = [
   CurveV2,
@@ -141,6 +142,7 @@ const Dexes = [
   MaverickV1,
   Camelot,
   SwaapV2,
+  LighterV1,
 ];
 
 export type LegacyDexConstructor = new (dexHelper: IDexHelper) => IDexTxBuilder<

--- a/src/dex/lighter-v1/abi/erc20.json
+++ b/src/dex/lighter-v1/abi/erc20.json
@@ -1,0 +1,222 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/src/dex/lighter-v1/abi/factory.json
+++ b/src/dex/lighter-v1/abi/factory.json
@@ -1,0 +1,291 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "orderBookAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "logSizeTick",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "logPriceTick",
+        "type": "uint8"
+      }
+    ],
+    "name": "OrderBookCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerChanged",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "internalType": "uint8",
+        "name": "logSizeTick",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "logPriceTick",
+        "type": "uint8"
+      }
+    ],
+    "name": "createOrderBook",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "orderBookAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "_orderBookId",
+        "type": "uint8"
+      }
+    ],
+    "name": "getOrderBookDetailsFromId",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "orderBookAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "sizeTick",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "priceTick",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_token1",
+        "type": "address"
+      }
+    ],
+    "name": "getOrderBookDetailsFromTokenPair",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "orderBookAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "internalType": "uint128",
+        "name": "sizeTick",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "priceTick",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      }
+    ],
+    "name": "getOrderBookFromId",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      }
+    ],
+    "name": "getOrderBookFromTokenPair",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "router",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "setOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "routerAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setRouter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/dex/lighter-v1/abi/order_book.json
+++ b/src/dex/lighter-v1/abi/order_book.json
@@ -1,0 +1,594 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "_orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "token0Address",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1Address",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_routerAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint8",
+        "name": "logSizeTick",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "logPriceTick",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "LimitOrderCanceled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "LimitOrderCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newAmount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newAmount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "LimitOrderUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "MarketOrderCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "askId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "askOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "bidId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "bidOwner",
+        "type": "address"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "balanceChangeCallback",
+    "outputs": [
+      {
+        "internalType": "contract IBalanceChangeCallback",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      }
+    ],
+    "name": "cancelLimitOrder",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "amount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "hintId",
+        "type": "uint32"
+      }
+    ],
+    "name": "createLimitOrder",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "newOrderId",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "amount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      }
+    ],
+    "name": "createMarketOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBestAsk",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "id",
+            "type": "uint32"
+          },
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount1",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LimitOrder",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBestBid",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "id",
+            "type": "uint32"
+          },
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount1",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LimitOrder",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLimitOrders",
+    "outputs": [
+      {
+        "internalType": "uint32[]",
+        "name": "",
+        "type": "uint32[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bool[]",
+        "name": "",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "getMockIndexToInsert",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      }
+    ],
+    "name": "isAskOrder",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      }
+    ],
+    "name": "isOrderActive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "orderBookId",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceMultiplier",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceTick",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "routerAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sizeTick",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "contract IERC20Metadata",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "contract IERC20Metadata",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/dex/lighter-v1/abi/order_book_helper.json
+++ b/src/dex/lighter-v1/abi/order_book_helper.json
@@ -1,0 +1,176 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_factory",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_router",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      }
+    ],
+    "name": "approveRouter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "contract IFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllOrderBooks",
+    "outputs": [
+      {
+        "internalType": "uint8[]",
+        "name": "orderBookIds",
+        "type": "uint8[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "orderBookAddresses",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "token0s",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "token1s",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "sizeTicks",
+        "type": "uint128[]"
+      },
+      {
+        "internalType": "uint128[]",
+        "name": "priceTicks",
+        "type": "uint128[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "quoteExactInput",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "router",
+    "outputs": [
+      {
+        "internalType": "contract Router",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactInput",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/dex/lighter-v1/abi/router.json
+++ b/src/dex/lighter-v1/abi/router.json
@@ -1,0 +1,488 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "factoryAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "stateMutability": "nonpayable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20Metadata",
+        "name": "tokenToTransfer",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      }
+    ],
+    "name": "addBalanceCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32",
+        "name": "orderId",
+        "type": "uint32"
+      }
+    ],
+    "name": "cancelLimitOrder",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "size",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "orderId",
+        "type": "uint32[]"
+      }
+    ],
+    "name": "cancelLimitOrderBatch",
+    "outputs": [
+      {
+        "internalType": "bool[]",
+        "name": "isCanceled",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "amount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "hintId",
+        "type": "uint32"
+      }
+    ],
+    "name": "createLimitOrder",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "orderId",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "size",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "amount0Base",
+        "type": "uint64[]"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "priceBase",
+        "type": "uint64[]"
+      },
+      {
+        "internalType": "bool[]",
+        "name": "isAsk",
+        "type": "bool[]"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "hintId",
+        "type": "uint32[]"
+      }
+    ],
+    "name": "createLimitOrderBatch",
+    "outputs": [
+      {
+        "internalType": "uint32[]",
+        "name": "orderId",
+        "type": "uint32[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "amount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "createMarketOrder",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "contract IFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      }
+    ],
+    "name": "getBestAsk",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "id",
+            "type": "uint32"
+          },
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount1",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LimitOrder",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      }
+    ],
+    "name": "getBestBid",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "id",
+            "type": "uint32"
+          },
+          {
+            "internalType": "address",
+            "name": "owner",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "amount1",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct LimitOrder",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      }
+    ],
+    "name": "getLimitOrders",
+    "outputs": [
+      {
+        "internalType": "uint32[]",
+        "name": "",
+        "type": "uint32[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bool[]",
+        "name": "",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "getMockIndexToInsert",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IERC20Metadata",
+        "name": "tokenToTransferFrom",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      }
+    ],
+    "name": "subtractBalanceCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32",
+        "name": "orderId",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "newAmount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "newPriceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint32",
+        "name": "hintId",
+        "type": "uint32"
+      }
+    ],
+    "name": "updateLimitOrder",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "newOrderId",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "size",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "orderId",
+        "type": "uint32[]"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "newAmount0Base",
+        "type": "uint64[]"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "newPriceBase",
+        "type": "uint64[]"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "hintId",
+        "type": "uint32[]"
+      }
+    ],
+    "name": "updateLimitOrderBatch",
+    "outputs": [
+      {
+        "internalType": "uint32[]",
+        "name": "newOrderId",
+        "type": "uint32[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/dex/lighter-v1/config.ts
+++ b/src/dex/lighter-v1/config.ts
@@ -1,0 +1,17 @@
+import { DexParams } from './types';
+import { DexConfigMap, AdapterMappings } from '../../types';
+import { Network, SwapSide } from '../../constants';
+
+export const LighterV1Config: DexConfigMap<DexParams> = {
+  LighterV1: {
+    [Network.ARBITRUM]: {
+      factory: '0x35642792abC96fA1E9fFe5F2f62A539bB80a8AF4',
+      router: '0x033c00fd922AF40b6683Fe5371380831a5b81D57',
+      orderBookHelper: '0xa43E0c9e8755D4C8B42E837D74E2888B8184eA93',
+    },
+  },
+};
+
+export const Adapters: Record<number, AdapterMappings> = {
+  [Network.ARBITRUM]: { [SwapSide.SELL]: [{ name: 'LighterV1', index: 0 }] },
+};

--- a/src/dex/lighter-v1/constants.ts
+++ b/src/dex/lighter-v1/constants.ts
@@ -1,0 +1,7 @@
+export const stablecoins = ['USDC', 'USDT', 'USDC.e', 'DAI'];
+
+export function replaceTokenSymbol(tokenSymbol: string) {
+  if (tokenSymbol === 'WETH') return 'ETH';
+  if (tokenSymbol === 'WBTC') return 'BTC';
+  return tokenSymbol;
+}

--- a/src/dex/lighter-v1/lighter-v1-e2e.test.ts
+++ b/src/dex/lighter-v1/lighter-v1-e2e.test.ts
@@ -12,45 +12,6 @@ import { Network, ContractMethod, SwapSide } from '../../constants';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { generateConfig } from '../../config';
 
-/*
-  README
-  ======
-
-  This test script should add e2e tests for LighterV1. The tests
-  should cover as many cases as possible. Most of the DEXes follow
-  the following test structure:
-    - DexName
-      - ForkName + Network
-        - ContractMethod
-          - ETH -> Token swap
-          - Token -> ETH swap
-          - Token -> Token swap
-
-  The template already enumerates the basic structure which involves
-  testing simpleSwap, multiSwap, megaSwap contract methods for
-  ETH <> TOKEN and TOKEN <> TOKEN swaps. You should replace tokenA and
-  tokenB with any two highly liquid tokens on LighterV1 for the tests
-  to work. If the tokens that you would like to use are not defined in
-  Tokens or Holders map, you can update the './tests/constants-e2e'
-
-  Other than the standard cases that are already added by the template
-  it is highly recommended to add test cases which could be specific
-  to testing LighterV1 (Eg. Tests based on poolType, special tokens,
-  etc).
-
-  You can run this individual test script by running:
-  `npx jest src/dex/<dex-name>/<dex-name>-e2e.test.ts`
-
-  e2e tests use the Tenderly fork api. Please add the following to your
-  .env file:
-  TENDERLY_TOKEN=Find this under Account
-  TENDERLY_ACCOUNT_ID=Your Tenderly account name.
-  TENDERLY_PROJECT=Name of a Tenderly project you have created in your
-  dashboard.
-
-  (This comment should be removed from the final implementation)
-*/
-
 function testForNetwork(
   network: Network,
   dexKey: string,
@@ -66,18 +27,10 @@ function testForNetwork(
   );
   const tokens = Tokens[network];
   const holders = Holders[network];
-  const nativeTokenSymbol = NativeTokenSymbols[network];
 
   // TODO: Add any direct swap contractMethod name if it exists
   const sideToContractMethods = new Map([
-    [
-      SwapSide.SELL,
-      [
-        ContractMethod.simpleSwap,
-        // ContractMethod.multiSwap,
-        // ContractMethod.megaSwap,
-      ],
-    ],
+    [SwapSide.SELL, [ContractMethod.simpleSwap]],
   ]);
 
   describe(`${network}`, () => {
@@ -85,32 +38,6 @@ function testForNetwork(
       describe(`${side}`, () => {
         contractMethods.forEach((contractMethod: ContractMethod) => {
           describe(`${contractMethod}`, () => {
-            // it(`${nativeTokenSymbol} -> ${tokenASymbol}`, async () => {
-            //   await testE2E(
-            //     tokens[nativeTokenSymbol],
-            //     tokens[tokenASymbol],
-            //     holders[nativeTokenSymbol],
-            //     side === SwapSide.SELL ? nativeTokenAmount : tokenAAmount,
-            //     side,
-            //     dexKey,
-            //     contractMethod,
-            //     network,
-            //     provider,
-            //   );
-            // });
-            // it(`${tokenASymbol} -> ${nativeTokenSymbol}`, async () => {
-            //   await testE2E(
-            //     tokens[tokenASymbol],
-            //     tokens[nativeTokenSymbol],
-            //     holders[tokenASymbol],
-            //     side === SwapSide.SELL ? tokenAAmount : nativeTokenAmount,
-            //     side,
-            //     dexKey,
-            //     contractMethod,
-            //     network,
-            //     provider,
-            //   );
-            // });
             it(`${tokenASymbol} -> ${tokenBSymbol}`, async () => {
               await testE2E(
                 tokens[tokenASymbol],

--- a/src/dex/lighter-v1/lighter-v1-e2e.test.ts
+++ b/src/dex/lighter-v1/lighter-v1-e2e.test.ts
@@ -1,0 +1,160 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import {
+  Tokens,
+  Holders,
+  NativeTokenSymbols,
+} from '../../../tests/constants-e2e';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+
+/*
+  README
+  ======
+
+  This test script should add e2e tests for LighterV1. The tests
+  should cover as many cases as possible. Most of the DEXes follow
+  the following test structure:
+    - DexName
+      - ForkName + Network
+        - ContractMethod
+          - ETH -> Token swap
+          - Token -> ETH swap
+          - Token -> Token swap
+
+  The template already enumerates the basic structure which involves
+  testing simpleSwap, multiSwap, megaSwap contract methods for
+  ETH <> TOKEN and TOKEN <> TOKEN swaps. You should replace tokenA and
+  tokenB with any two highly liquid tokens on LighterV1 for the tests
+  to work. If the tokens that you would like to use are not defined in
+  Tokens or Holders map, you can update the './tests/constants-e2e'
+
+  Other than the standard cases that are already added by the template
+  it is highly recommended to add test cases which could be specific
+  to testing LighterV1 (Eg. Tests based on poolType, special tokens,
+  etc).
+
+  You can run this individual test script by running:
+  `npx jest src/dex/<dex-name>/<dex-name>-e2e.test.ts`
+
+  e2e tests use the Tenderly fork api. Please add the following to your
+  .env file:
+  TENDERLY_TOKEN=Find this under Account
+  TENDERLY_ACCOUNT_ID=Your Tenderly account name.
+  TENDERLY_PROJECT=Name of a Tenderly project you have created in your
+  dashboard.
+
+  (This comment should be removed from the final implementation)
+*/
+
+function testForNetwork(
+  network: Network,
+  dexKey: string,
+  tokenASymbol: string,
+  tokenBSymbol: string,
+  tokenAAmount: string,
+  tokenBAmount: string,
+  nativeTokenAmount: string,
+) {
+  const provider = new StaticJsonRpcProvider(
+    generateConfig(network).privateHttpProvider,
+    network,
+  );
+  const tokens = Tokens[network];
+  const holders = Holders[network];
+  const nativeTokenSymbol = NativeTokenSymbols[network];
+
+  // TODO: Add any direct swap contractMethod name if it exists
+  const sideToContractMethods = new Map([
+    [
+      SwapSide.SELL,
+      [
+        ContractMethod.simpleSwap,
+        // ContractMethod.multiSwap,
+        // ContractMethod.megaSwap,
+      ],
+    ],
+  ]);
+
+  describe(`${network}`, () => {
+    sideToContractMethods.forEach((contractMethods, side) =>
+      describe(`${side}`, () => {
+        contractMethods.forEach((contractMethod: ContractMethod) => {
+          describe(`${contractMethod}`, () => {
+            // it(`${nativeTokenSymbol} -> ${tokenASymbol}`, async () => {
+            //   await testE2E(
+            //     tokens[nativeTokenSymbol],
+            //     tokens[tokenASymbol],
+            //     holders[nativeTokenSymbol],
+            //     side === SwapSide.SELL ? nativeTokenAmount : tokenAAmount,
+            //     side,
+            //     dexKey,
+            //     contractMethod,
+            //     network,
+            //     provider,
+            //   );
+            // });
+            // it(`${tokenASymbol} -> ${nativeTokenSymbol}`, async () => {
+            //   await testE2E(
+            //     tokens[tokenASymbol],
+            //     tokens[nativeTokenSymbol],
+            //     holders[tokenASymbol],
+            //     side === SwapSide.SELL ? tokenAAmount : nativeTokenAmount,
+            //     side,
+            //     dexKey,
+            //     contractMethod,
+            //     network,
+            //     provider,
+            //   );
+            // });
+            it(`${tokenASymbol} -> ${tokenBSymbol}`, async () => {
+              await testE2E(
+                tokens[tokenASymbol],
+                tokens[tokenBSymbol],
+                holders[tokenASymbol],
+                side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+          });
+        });
+      }),
+    );
+  });
+}
+
+describe('LighterV1 E2E', () => {
+  const dexKey = 'LighterV1';
+
+  describe('Arbitrum', () => {
+    const network = Network.ARBITRUM;
+
+    // TODO: Modify the tokenASymbol, tokenBSymbol, tokenAAmount;
+    const tokenASymbol: string = 'WETH';
+    const tokenBSymbol: string = 'USDC';
+
+    const tokenAAmount: string = '1000000000000000000';
+    const tokenBAmount: string = '100000000';
+    const nativeTokenAmount = '1000000000000000000';
+
+    testForNetwork(
+      network,
+      dexKey,
+      tokenASymbol,
+      tokenBSymbol,
+      tokenAAmount,
+      tokenBAmount,
+      nativeTokenAmount,
+    );
+
+    // TODO: Add any additional test cases required to test LighterV1
+  });
+});

--- a/src/dex/lighter-v1/lighter-v1-events.test.ts
+++ b/src/dex/lighter-v1/lighter-v1-events.test.ts
@@ -1,0 +1,159 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { LighterV1EventPool } from './lighter-v1-pool';
+import { Network } from '../../constants';
+import { Address, Token } from '../../types';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { testEventSubscriber } from '../../../tests/utils-events';
+import { PoolState } from './types';
+import { Tokens } from '../../../tests/constants-e2e';
+import { bigIntify } from '../../utils';
+import { DeepReadonly } from 'ts-essentials';
+
+/*
+  README
+  ======
+
+  This test script adds unit tests for LighterV1 event based
+  system. This is done by fetching the state on-chain before the
+  event block, manually pushing the block logs to the event-subscriber,
+  comparing the local state with on-chain state.
+
+  Most of the logic for testing is abstracted by `testEventSubscriber`.
+  You need to do two things to make the tests work:
+
+  1. Fetch the block numbers where certain events were released. You
+  can modify the `./scripts/fetch-event-blocknumber.ts` to get the
+  block numbers for different events. Make sure to get sufficient
+  number of blockNumbers to cover all possible cases for the event
+  mutations.
+
+  2. Complete the implementation for fetchPoolState function. The
+  function should fetch the on-chain state of the event subscriber
+  using just the blocknumber.
+
+  The template tests only include the test for a single event
+  subscriber. There can be cases where multiple event subscribers
+  exist for a single DEX. In such cases additional tests should be
+  added.
+
+  You can run this individual test script by running:
+  `npx jest src/dex/<dex-name>/<dex-name>-events.test.ts`
+
+  (This comment should be removed from the final implementation)
+*/
+
+jest.setTimeout(50 * 1000);
+
+async function fetchPoolState(
+  lighterV1Pool: LighterV1EventPool,
+  blockNumber: number,
+  poolAddress: string,
+): Promise<DeepReadonly<PoolState>> {
+  return await lighterV1Pool.generateState(blockNumber);
+}
+
+// eventName -> blockNumbers
+type EventMappings = Record<string, number[]>;
+
+const WETHUSDC: EventMappings = {
+  LimitOrderCreated: [
+    114787446, 114787446, 114787527, 114787527, 114787609, 114787768, 114787849,
+    114788013, 114788093, 114788093, 114788093, 114788093, 114788179, 114788264,
+    114788264, 114788344, 114788346, 114788427, 114788427, 114788516, 114788516,
+    114788593, 114788593, 114788652, 114788674, 114788755, 114788755, 114788755,
+    114788755, 114788838, 114788920, 114789001, 114789001, 114789157, 114789157,
+    114789319, 114789319, 114789406, 114789406, 114789406, 114789406, 114789494,
+    114789651, 114789651, 114789733, 114789733, 114789813, 114789891, 114790051,
+    114790051, 114790123, 114790202, 114790202, 114790359, 114790597, 114790678,
+    114790830, 114790917, 114790917, 114791068, 114791457, 114791614, 114791695,
+    114791863, 114792176,
+  ],
+  Swap: [
+    114787371, 114787504, 114788166, 114788536, 114788601, 114788851, 114790044,
+    114792123,
+  ],
+  LimitOrderCanceled: [
+    114787337, 114787337, 114787382, 114787475, 114787663, 114787757, 114787895,
+    114787993, 114787993, 114787993, 114787993, 114788177, 114788177, 114788227,
+    114788344, 114788371, 114788371, 114788371, 114788371, 114788465, 114788465,
+    114788465, 114788465, 114788648, 114788648, 114788652, 114788695, 114788695,
+    114788695, 114788746, 114788884, 114788884, 114789073, 114789073, 114789260,
+    114789260, 114789260, 114789355, 114789355, 114789355, 114789355, 114789355,
+    114789552, 114789552, 114789597, 114789597, 114789693, 114789834, 114789973,
+    114789973, 114789973, 114790067, 114790155, 114790155, 114790246, 114790480,
+    114790623, 114790717, 114790805, 114790853, 114790953, 114791407, 114791500,
+    114791640, 114791783, 114792245,
+  ],
+};
+
+// initialzie the events to test with above block numbers
+
+describe('LighterV1 EventPool Arbitrum', function () {
+  const dexKey = 'LighterV1';
+  const network = Network.ARBITRUM;
+  const dexHelper = new DummyDexHelper(network);
+  const logger = dexHelper.getLogger(dexKey);
+  let lighterV1Pool: LighterV1EventPool;
+
+  // poolAddress -> EventMappings
+  const eventsToTest: Record<Address, EventMappings> = {
+    '0xB8Df652Ccb5CB39Ac1cD98a899639F8463B103a8': WETHUSDC,
+  };
+
+  beforeEach(async () => {
+    const baseToken: Token = {
+      address: Tokens[network].WETH.address,
+      decimals: Tokens[network].WETH.decimals,
+      symbol: Tokens[network].WETH.symbol,
+    };
+
+    const quoteToken: Token = {
+      address: Tokens[network].USDC.address,
+      decimals: Tokens[network].USDC.decimals,
+      symbol: Tokens[network].USDC.symbol,
+    };
+    // create pool
+    lighterV1Pool = new LighterV1EventPool(
+      dexKey,
+      network,
+      dexHelper,
+      logger,
+      '0x35642792abC96fA1E9fFe5F2f62A539bB80a8AF4',
+      '0x033c00fd922AF40b6683Fe5371380831a5b81D57',
+      0,
+      '0xB8Df652Ccb5CB39Ac1cD98a899639F8463B103a8',
+      baseToken,
+      quoteToken,
+      bigIntify(14),
+    );
+  });
+
+  Object.entries(eventsToTest).forEach(
+    ([poolAddress, events]: [string, EventMappings]) => {
+      describe(`Events for ${poolAddress}`, () => {
+        Object.entries(events).forEach(
+          ([eventName, blockNumbers]: [string, number[]]) => {
+            describe(`${eventName}`, () => {
+              blockNumbers.forEach((blockNumber: number) => {
+                it(`State after ${blockNumber}`, async function () {
+                  await testEventSubscriber(
+                    lighterV1Pool,
+                    lighterV1Pool.addressesSubscribed,
+                    (_blockNumber: number) =>
+                      fetchPoolState(lighterV1Pool, _blockNumber, poolAddress),
+                    blockNumber,
+                    `${dexKey}_${poolAddress}`,
+                    dexHelper.provider,
+                  );
+                });
+              });
+            });
+          },
+        );
+      });
+    },
+  );
+});

--- a/src/dex/lighter-v1/lighter-v1-events.test.ts
+++ b/src/dex/lighter-v1/lighter-v1-events.test.ts
@@ -11,40 +11,6 @@ import { PoolState } from './types';
 import { Tokens } from '../../../tests/constants-e2e';
 import { bigIntify } from '../../utils';
 import { DeepReadonly } from 'ts-essentials';
-
-/*
-  README
-  ======
-
-  This test script adds unit tests for LighterV1 event based
-  system. This is done by fetching the state on-chain before the
-  event block, manually pushing the block logs to the event-subscriber,
-  comparing the local state with on-chain state.
-
-  Most of the logic for testing is abstracted by `testEventSubscriber`.
-  You need to do two things to make the tests work:
-
-  1. Fetch the block numbers where certain events were released. You
-  can modify the `./scripts/fetch-event-blocknumber.ts` to get the
-  block numbers for different events. Make sure to get sufficient
-  number of blockNumbers to cover all possible cases for the event
-  mutations.
-
-  2. Complete the implementation for fetchPoolState function. The
-  function should fetch the on-chain state of the event subscriber
-  using just the blocknumber.
-
-  The template tests only include the test for a single event
-  subscriber. There can be cases where multiple event subscribers
-  exist for a single DEX. In such cases additional tests should be
-  added.
-
-  You can run this individual test script by running:
-  `npx jest src/dex/<dex-name>/<dex-name>-events.test.ts`
-
-  (This comment should be removed from the final implementation)
-*/
-
 jest.setTimeout(50 * 1000);
 
 async function fetchPoolState(

--- a/src/dex/lighter-v1/lighter-v1-integration.test.ts
+++ b/src/dex/lighter-v1/lighter-v1-integration.test.ts
@@ -117,7 +117,6 @@ describe('LighterV1', function () {
   let lighterV1: LighterV1;
 
   describe('Arbitrum', () => {
-    console.log('here we are');
     const network = Network.ARBITRUM;
     const dexHelper = new DummyDexHelper(network);
 

--- a/src/dex/lighter-v1/lighter-v1-integration.test.ts
+++ b/src/dex/lighter-v1/lighter-v1-integration.test.ts
@@ -1,0 +1,186 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Interface, Result } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide } from '../../constants';
+import { BI_POWS } from '../../bigint-constants';
+import { LighterV1 } from './lighter-v1';
+import {
+  checkPoolPrices,
+  checkPoolsLiquidity,
+  checkConstantPoolPrices,
+} from '../../../tests/utils';
+import { Tokens } from '../../../tests/constants-e2e';
+import { ethers } from 'ethers';
+
+async function getQuoteFromHelper(
+  lighterV1: LighterV1,
+  blockNumber: number,
+  orderBookId: number,
+  amountIn: bigint,
+  isAsk: boolean,
+): Promise<bigint> {
+  const helper = new ethers.Contract(
+    lighterV1.config.orderBookHelper,
+    lighterV1.orderBookHelperIface,
+  );
+
+  const data = await lighterV1.dexHelper.provider.call(
+    {
+      to: helper.address,
+      data: helper.interface.encodeFunctionData('quoteExactInput', [
+        orderBookId,
+        isAsk,
+        amountIn,
+      ]),
+    },
+    blockNumber,
+  );
+
+  const [_, amountOut] = helper.interface.decodeFunctionResult(
+    'quoteExactInput',
+    data,
+  );
+
+  return amountOut;
+}
+
+async function testPricingOnNetwork(
+  lighterV1: LighterV1,
+  network: Network,
+  dexKey: string,
+  blockNumber: number,
+  srcTokenSymbol: string,
+  destTokenSymbol: string,
+  side: SwapSide,
+  amounts: bigint[],
+) {
+  const networkTokens = Tokens[network];
+
+  const pools = await lighterV1.getPoolIdentifiers(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    side,
+    blockNumber,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Identifiers: `,
+    pools,
+  );
+
+  expect(pools.length).toBeGreaterThan(0);
+
+  const poolPrices = await lighterV1.getPricesVolume(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    amounts,
+    side,
+    blockNumber,
+    pools,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Prices: `,
+    poolPrices,
+  );
+
+  const key = pools[0].split('_')[1];
+
+  const orderBookType = lighterV1.allSupportedOrderBooks.get(key);
+
+  const expectedPrices: bigint[] = [];
+
+  for (let i = 0; i < amounts.length; i++) {
+    const amount = amounts[i];
+    const price = await getQuoteFromHelper(
+      lighterV1,
+      blockNumber,
+      orderBookType!.orderBookId,
+      amount,
+      orderBookType!.isAsk,
+    );
+    expectedPrices.push(price);
+  }
+
+  expect(poolPrices).not.toBeNull();
+  if (lighterV1.hasConstantPriceLargeAmounts) {
+    checkConstantPoolPrices(poolPrices!, expectedPrices, dexKey);
+  } else {
+    checkPoolPrices(poolPrices!, expectedPrices, side, dexKey);
+  }
+}
+
+describe('LighterV1', function () {
+  const dexKey = 'LighterV1';
+  let blockNumber: number;
+  let lighterV1: LighterV1;
+
+  describe('Arbitrum', () => {
+    console.log('here we are');
+    const network = Network.ARBITRUM;
+    const dexHelper = new DummyDexHelper(network);
+
+    const tokens = Tokens[network];
+
+    const srcTokenSymbol = 'WETH';
+    const destTokenSymbol = 'USDC';
+
+    const amountsForSell = [
+      0n,
+      1n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      2n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      3n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      4n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      5n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      6n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      7n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      8n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      9n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      10n * BI_POWS[tokens[srcTokenSymbol].decimals],
+    ];
+
+    beforeAll(async () => {
+      blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      lighterV1 = new LighterV1(network, dexKey, dexHelper);
+      if (lighterV1.initializePricing) {
+        await lighterV1.initializePricing(blockNumber);
+      }
+    });
+
+    it('getPoolIdentifiers and getPricesVolume SELL', async function () {
+      await testPricingOnNetwork(
+        lighterV1,
+        network,
+        dexKey,
+        blockNumber,
+        srcTokenSymbol,
+        destTokenSymbol,
+        SwapSide.SELL,
+        amountsForSell,
+      );
+    });
+
+    it('getTopPoolsForToken', async function () {
+      // We have to check without calling initializePricing, because
+      // pool-tracker is not calling that function
+      const newLighterV1 = new LighterV1(network, dexKey, dexHelper);
+      if (newLighterV1.updatePoolState) {
+        await newLighterV1.updatePoolState();
+      }
+      const poolLiquidity = await newLighterV1.getTopPoolsForToken(
+        tokens[srcTokenSymbol].address,
+        10,
+      );
+      console.log(`${srcTokenSymbol} Top Pools:`, poolLiquidity);
+
+      if (!newLighterV1.hasConstantPriceLargeAmounts) {
+        checkPoolsLiquidity(
+          poolLiquidity,
+          Tokens[network][srcTokenSymbol].address,
+          dexKey,
+        );
+      }
+    });
+  });
+});

--- a/src/dex/lighter-v1/lighter-v1-pool.ts
+++ b/src/dex/lighter-v1/lighter-v1-pool.ts
@@ -1,0 +1,458 @@
+import { Interface } from '@ethersproject/abi';
+import { DeepReadonly } from 'ts-essentials';
+import { Address, Log, Logger, Token } from '../../types';
+import { bigIntify, catchParseLogError } from '../../utils';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { LimitOrder, OrderBook, OrderBookDetails, PoolState } from './types';
+import LighterV1OrderBookIface from './abi/order_book.json';
+import LighterV1OrderBookHelperIface from './abi/order_book_helper.json';
+import LighterV1FactoryIface from './abi/factory.json';
+import LighterV1RouterIface from './abi/router.json';
+import Erc20Iface from './abi/erc20.json';
+import { Contract, ethers } from 'ethers';
+import BigNumber from 'bignumber.js';
+import { replaceTokenSymbol, stablecoins } from './constants';
+
+export class LighterV1EventPool extends StatefulEventSubscriber<PoolState> {
+  handlers: {
+    [event: string]: (
+      event: any,
+      state: DeepReadonly<PoolState>,
+      log: Readonly<Log>,
+    ) => DeepReadonly<PoolState> | null;
+  } = {};
+
+  logDecoder: (log: Log) => any;
+
+  private baseToken: Token;
+  private quoteToken: Token;
+  private orderBookId: number;
+  private sizeTick: bigint;
+
+  public readonly orderBookAddress: Address;
+
+  public readonly orderBookIface = new Interface(LighterV1OrderBookIface);
+  public readonly orderBookHelperIface = new Interface(
+    LighterV1OrderBookHelperIface,
+  );
+  public readonly factoryIface = new Interface(LighterV1FactoryIface);
+  public readonly routerIface = new Interface(LighterV1RouterIface);
+  public readonly erc20Iface = new Interface(Erc20Iface);
+
+  addressesSubscribed: string[];
+
+  constructor(
+    readonly parentName: string,
+    protected network: number,
+    protected dexHelper: IDexHelper,
+    logger: Logger,
+    protected readonly factoryAddress: Address,
+    protected readonly routerAddress: Address,
+    orderBookId: number,
+    orderBookAddress: Address,
+    baseToken: Token,
+    quoteToken: Token,
+    sizeTick: bigint,
+  ) {
+    super(
+      parentName,
+      `${baseToken.address}_${quoteToken.address}`,
+      dexHelper,
+      logger,
+    );
+
+    this.logDecoder = (log: Log) => this.orderBookIface.parseLog(log);
+    this.addressesSubscribed = new Array<Address>(1);
+    this.addressesSubscribed[0] = orderBookAddress;
+
+    this.baseToken = baseToken;
+    this.quoteToken = quoteToken;
+    this.orderBookId = orderBookId;
+    this.sizeTick = sizeTick;
+    this.orderBookAddress = orderBookAddress;
+
+    // Add handlers
+    this.handlers['LimitOrderCreated'] =
+      this.handleLimitOrderCreatedEvent.bind(this);
+    this.handlers['LimitOrderCanceled'] =
+      this.handleLimitOrderCanceledEvent.bind(this);
+    this.handlers['Swap'] = this.handleSwapEvent.bind(this);
+  }
+
+  /**
+   * The function is called every time any of the subscribed
+   * addresses release log. The function accepts the current
+   * state, updates the state according to the log, and returns
+   * the updated state.
+   * @param state - Current state of event subscriber
+   * @param log - Log released by one of the subscribed addresses
+   * @returns Updates state of the event subscriber after the log
+   */
+  protected processLog(
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<PoolState> | null {
+    try {
+      const event = this.logDecoder(log);
+      if (event.name in this.handlers) {
+        return this.handlers[event.name](event, state, log);
+      }
+    } catch (e) {
+      catchParseLogError(e, this.logger);
+    }
+
+    return null;
+  }
+
+  // TODO: this might be called from v1
+  async getOrderBookDetailsFromTokenPair(
+    token0: Address,
+    token1: Address,
+  ): Promise<OrderBookDetails> {
+    const factory = new ethers.Contract(this.factoryAddress, this.factoryIface);
+    const result = await factory.getOrderBookDetailsFromTokenPair(
+      token0,
+      token1,
+    );
+
+    return {
+      orderBookId: result[0],
+      orderBookAddress: result[1],
+      token0Address: result[2],
+      token1Address: result[3],
+      sizeTick: result[4],
+      priceTick: result[5],
+    };
+  }
+
+  private _getPrice(
+    baseAmount: bigint,
+    quoteAmount: bigint,
+    powBase: bigint,
+    powQuote: bigint,
+  ): number {
+    // Convert BigInt to BigNumber
+    let baseAmountBN = new BigNumber(baseAmount.toString());
+    let quoteAmountBN = new BigNumber(quoteAmount.toString());
+    let powBaseBN = new BigNumber(powBase.toString());
+    let powQuoteBN = new BigNumber(powQuote.toString());
+
+    // Perform the calculation
+    let priceRat = quoteAmountBN
+      .times(powBaseBN)
+      .dividedBy(baseAmountBN)
+      .dividedBy(powQuoteBN);
+
+    // Convert the result to a number and return it
+    let price: number = priceRat.toNumber();
+
+    return price;
+  }
+
+  async getOrderBook(blockNumber: number): Promise<OrderBook> {
+    const router = new ethers.Contract(this.routerAddress, this.routerIface);
+
+    const data = await this.dexHelper.provider.call(
+      {
+        to: router.address,
+        data: router.interface.encodeFunctionData('getLimitOrders', [
+          this.orderBookId,
+        ]),
+      },
+      blockNumber,
+    );
+
+    const result = router.interface.decodeFunctionResult(
+      'getLimitOrders',
+      data,
+    );
+    const [ids, _, amounts0, amounts1, isAsks] = result;
+
+    const orders: LimitOrder[] = ids.map((id: bigint, index: number) => ({
+      id: id,
+      amount0: bigIntify(amounts0[index]),
+      amount1: bigIntify(amounts1[index]),
+      isAsk: isAsks[index],
+      price: this._getPrice(
+        bigIntify(amounts0[index]),
+        bigIntify(amounts1[index]),
+        10n ** bigIntify(this.baseToken.decimals),
+        10n ** bigIntify(this.quoteToken.decimals),
+      ),
+    }));
+
+    const asks: Record<number, LimitOrder> = {};
+    const bids: Record<number, LimitOrder> = {};
+
+    orders.forEach(order => {
+      if (order.isAsk) {
+        asks[Number(order.id)] = order;
+      } else {
+        bids[Number(order.id)] = order;
+      }
+    });
+
+    const sortedAsks = Object.values(asks).sort((a, b) => {
+      const priceDifference = Number(a.price - b.price);
+      if (priceDifference === 0) {
+        return Number(a.id - b.id); // lower id comes first
+      } else {
+        return priceDifference;
+      }
+    });
+
+    const sortedBids = Object.values(bids).sort((a, b) => {
+      const priceDifference = Number(b.price - a.price);
+      if (priceDifference === 0) {
+        return Number(a.id - b.id); // lower id comes first
+      } else {
+        return priceDifference;
+      }
+    });
+
+    const orderBook: OrderBook = {
+      sortedAsks: sortedAsks,
+      sortedBids: sortedBids,
+    };
+
+    return orderBook;
+  }
+
+  /**
+   * The function generates state using on-chain calls. This
+   * function is called to regenerate state if the event based
+   * system fails to fetch events and the local state is no
+   * more correct.
+   * @param blockNumber - Blocknumber for which the state should
+   * should be generated
+   * @returns state of the event subscriber at blocknumber
+   */
+  async generateState(blockNumber: number): Promise<DeepReadonly<PoolState>> {
+    const orderBook = await this.getOrderBook(blockNumber);
+
+    return {
+      pool: this.orderBookAddress,
+      baseToken: this.baseToken,
+      quoteToken: this.quoteToken,
+      orderBook: orderBook,
+      sizeTick: this.sizeTick,
+    };
+  }
+
+  handleLimitOrderCreatedEvent(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<PoolState> | null {
+    const order: LimitOrder = {
+      id: event.args.id,
+      amount0: bigIntify(event.args.amount0),
+      amount1: bigIntify(event.args.amount1),
+      isAsk: event.args.isAsk,
+      price: this._getPrice(
+        bigIntify(event.args.amount0),
+        bigIntify(event.args.amount1),
+        10n ** bigIntify(this.baseToken.decimals),
+        10n ** bigIntify(this.quoteToken.decimals),
+      ),
+    };
+
+    const sortedAsks = [...state.orderBook.sortedAsks];
+    const sortedBids = [...state.orderBook.sortedBids];
+
+    if (order.isAsk) {
+      sortedAsks.push(order);
+      sortedAsks.sort((a, b) => {
+        const priceDifference = Number(a.price - b.price);
+        if (priceDifference === 0) {
+          return Number(a.id - b.id); // lower id comes first
+        } else {
+          return priceDifference;
+        }
+      });
+    } else {
+      sortedBids.push(order);
+      sortedBids.sort((a, b) => {
+        const priceDifference = Number(b.price - a.price);
+        if (priceDifference === 0) {
+          return Number(a.id - b.id); // lower id comes first
+        } else {
+          return priceDifference;
+        }
+      });
+    }
+
+    const orderBook: OrderBook = {
+      sortedAsks: sortedAsks,
+      sortedBids: sortedBids,
+    };
+
+    return {
+      ...state,
+      orderBook: orderBook,
+    };
+  }
+
+  handleLimitOrderCanceledEvent(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<PoolState> | null {
+    const order: LimitOrder = {
+      id: event.args.id,
+      amount0: event.args.amount0,
+      amount1: event.args.amount1,
+      isAsk: event.args.isAsk,
+      price: this._getPrice(
+        bigIntify(event.args.amount0),
+        bigIntify(event.args.amount1),
+        10n ** bigIntify(this.baseToken.decimals),
+        10n ** bigIntify(this.quoteToken.decimals),
+      ),
+    };
+
+    const sortedAsks = [...state.orderBook.sortedAsks];
+    const sortedBids = [...state.orderBook.sortedBids];
+
+    if (order.isAsk) {
+      sortedAsks.splice(
+        sortedAsks.findIndex(o => o.id === order.id),
+        1,
+      );
+    } else {
+      sortedBids.splice(
+        sortedBids.findIndex(o => o.id === order.id),
+        1,
+      );
+    }
+
+    const orderBook: OrderBook = {
+      sortedAsks: sortedAsks,
+      sortedBids: sortedBids,
+    };
+
+    return {
+      ...state,
+      orderBook: orderBook,
+    };
+  }
+
+  handleSwapEvent(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<PoolState> | null {
+    const askOrder: LimitOrder | undefined = state.orderBook.sortedAsks.find(
+      o => o.id === Number(event.args.askId),
+    );
+
+    const bidOrder: LimitOrder | undefined = state.orderBook.sortedBids.find(
+      o => o.id === Number(event.args.bidId),
+    );
+
+    const sortedAsks = [...state.orderBook.sortedAsks];
+    const sortedBids = [...state.orderBook.sortedBids];
+
+    if (askOrder && askOrder.amount0 === event.args.amount0) {
+      sortedAsks.splice(
+        sortedAsks.findIndex(o => o.id === event.args.askId),
+        1,
+      );
+    } else if (askOrder) {
+      sortedAsks.splice(
+        sortedAsks.findIndex(o => o.id === event.args.askId),
+        1,
+        {
+          ...askOrder,
+          amount0: askOrder.amount0 - bigIntify(event.args.amount0),
+          amount1: askOrder.amount1 - bigIntify(event.args.amount1),
+        },
+      );
+    }
+
+    if (bidOrder && bidOrder.amount1 === event.args.amount1) {
+      sortedBids.splice(
+        sortedBids.findIndex(o => o.id === event.args.bidId),
+        1,
+      );
+    } else if (bidOrder) {
+      sortedBids.splice(
+        sortedBids.findIndex(o => o.id === event.args.bidId),
+        1,
+        {
+          ...bidOrder,
+          amount0: bidOrder.amount0 - bigIntify(event.args.amount0),
+          amount1: bidOrder.amount1 - bigIntify(event.args.amount1),
+        },
+      );
+    }
+
+    const orderBook: OrderBook = {
+      sortedAsks: sortedAsks,
+      sortedBids: sortedBids,
+    };
+
+    return {
+      ...state,
+      orderBook: orderBook,
+    };
+  }
+
+  async getTokenPrice(tokenSymbol?: string): Promise<number> {
+    if (!tokenSymbol) {
+      return 0;
+    }
+
+    if (stablecoins.includes(tokenSymbol)) {
+      return 1;
+    }
+
+    tokenSymbol = replaceTokenSymbol(tokenSymbol);
+
+    const url = `https://api.binance.com/api/v3/ticker/price?symbol=${tokenSymbol}USDT`;
+
+    let response: any;
+    try {
+      response = await this.dexHelper.httpRequest.get(url);
+    } catch (e) {
+      return 0;
+    }
+
+    return parseFloat(response.price);
+  }
+
+  async calculateLiquidity(): Promise<number> {
+    const token0Price = await this.getTokenPrice(this.baseToken.symbol);
+    const token1Price = await this.getTokenPrice(this.quoteToken.symbol);
+
+    let liquidity = 0;
+
+    const state = this.getState(this.stateBlockNumber);
+
+    if (!state) {
+      return 0;
+    }
+
+    for (const ask of state.orderBook.sortedAsks) {
+      let baseAmount = new BigNumber(ask.amount0.toString());
+      let powDecimals = new BigNumber(
+        (10n ** bigIntify(this.baseToken.decimals)).toString(),
+      );
+
+      const amount0 = baseAmount.dividedBy(powDecimals).toNumber();
+      liquidity += amount0 * token0Price;
+    }
+
+    for (const bid of state.orderBook.sortedBids) {
+      let quoteAmount = new BigNumber(bid.amount1.toString());
+      let powDecimals = new BigNumber(
+        (10n ** bigIntify(this.quoteToken.decimals)).toString(),
+      );
+      const amount1 = quoteAmount.dividedBy(powDecimals).toNumber();
+      liquidity += amount1 * token1Price;
+    }
+
+    return liquidity;
+  }
+}

--- a/src/dex/lighter-v1/lighter-v1-pool.ts
+++ b/src/dex/lighter-v1/lighter-v1-pool.ts
@@ -153,11 +153,17 @@ export class LighterV1EventPool extends StatefulEventSubscriber<PoolState> {
   async getOrderBook(blockNumber: number): Promise<OrderBook> {
     const router = new ethers.Contract(this.routerAddress, this.routerIface);
 
+    const currentBlockNumber = await this.dexHelper.provider.getBlockNumber();
+
+    if (currentBlockNumber < blockNumber) {
+      blockNumber = currentBlockNumber;
+    }
+
     const data = await this.dexHelper.provider.call(
       {
         to: router.address,
         data: router.interface.encodeFunctionData('getLimitOrders', [
-          this.orderBookId,
+          Number(this.orderBookId),
         ]),
       },
       blockNumber,
@@ -167,6 +173,7 @@ export class LighterV1EventPool extends StatefulEventSubscriber<PoolState> {
       'getLimitOrders',
       data,
     );
+
     const [ids, _, amounts0, amounts1, isAsks] = result;
 
     const orders: LimitOrder[] = ids.map((id: bigint, index: number) => ({

--- a/src/dex/lighter-v1/lighter-v1.ts
+++ b/src/dex/lighter-v1/lighter-v1.ts
@@ -73,10 +73,6 @@ export class LighterV1 extends SimpleExchange implements IDex<LighterV1Data> {
     this.logger = dexHelper.getLogger(dexKey);
   }
 
-  // Initialize pricing is called once in the start of
-  // pricing service. It is intended to setup the integration
-  // for pricing requests. It is optional for a DEX to
-  // implement this function
   async initializePricing(blockNumber: number) {
     await this.updatePoolState(blockNumber);
   }
@@ -87,10 +83,6 @@ export class LighterV1 extends SimpleExchange implements IDex<LighterV1Data> {
     return this.adapters[side] ? this.adapters[side] : null;
   }
 
-  // Returns list of pool identifiers that can be used
-  // for a given swap. poolIdentifiers must be unique
-  // across DEXes. It is recommended to use
-  // ${dexKey}_${poolAddress} as a poolIdentifier
   async getPoolIdentifiers(
     srcToken: Token,
     destToken: Token,
@@ -122,10 +114,6 @@ export class LighterV1 extends SimpleExchange implements IDex<LighterV1Data> {
     return [];
   }
 
-  // Returns pool prices for amounts.
-  // If limitPools is defined only pools in limitPools
-  // should be used. If limitPools is undefined then
-  // any pools can be used.
   async getPricesVolume(
     srcToken: Token,
     destToken: Token,
@@ -359,11 +347,6 @@ export class LighterV1 extends SimpleExchange implements IDex<LighterV1Data> {
     return amountOut;
   }
 
-  // This is called once before getTopPoolsForToken is
-  // called for multiple tokens. This can be helpful to
-  // update common state required for calculating
-  // getTopPoolsForToken. It is optional for a DEX
-  // to implement this
   async updatePoolState(blockNumber?: number): Promise<void> {
     const helper = new ethers.Contract(
       this.config.orderBookHelper,

--- a/src/dex/lighter-v1/lighter-v1.ts
+++ b/src/dex/lighter-v1/lighter-v1.ts
@@ -1,0 +1,514 @@
+import { AsyncOrSync } from 'ts-essentials';
+import {
+  Token,
+  Address,
+  ExchangePrices,
+  PoolPrices,
+  AdapterExchangeParam,
+  SimpleExchangeParam,
+  PoolLiquidity,
+  Logger,
+} from '../../types';
+import { SwapSide, Network } from '../../constants';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+import { bigIntify, getDexKeysWithNetwork } from '../../utils';
+import { IDex } from '../../dex/idex';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import {
+  AllOrderBooks,
+  LighterV1Data,
+  LimitOrder,
+  OrderBook,
+  OrderBookType,
+} from './types';
+import { SimpleExchange } from '../simple-exchange';
+import { LighterV1Config, Adapters } from './config';
+import { LighterV1EventPool } from './lighter-v1-pool';
+import { Interface } from 'ethers/lib/utils';
+
+import LighterV1OrderBookHelperIface from './abi/order_book_helper.json';
+import LighterV1FactoryIface from './abi/factory.json';
+import LighterV1RouterIface from './abi/router.json';
+import Erc20Iface from './abi/erc20.json';
+import { ethers } from 'ethers';
+
+export class LighterV1 extends SimpleExchange implements IDex<LighterV1Data> {
+  // protected eventPools: LighterV1EventPool;
+
+  readonly hasConstantPriceLargeAmounts = false;
+  // TODO: set true here if protocols works only with wrapped asset
+  readonly needWrapNative = true;
+
+  readonly isFeeOnTransferSupported = false;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(LighterV1Config);
+
+  public readonly factoryIface = new Interface(LighterV1FactoryIface);
+  public readonly routerIface = new Interface(LighterV1RouterIface);
+  public readonly orderBookHelperIface = new Interface(
+    LighterV1OrderBookHelperIface,
+  );
+
+  public allSupportedOrderBooks: AllOrderBooks = new Map<
+    string,
+    OrderBookType
+  >();
+
+  logger: Logger;
+
+  public orderBooks: Map<number, LighterV1EventPool> = new Map<
+    number,
+    LighterV1EventPool
+  >();
+
+  constructor(
+    readonly network: Network,
+    readonly dexKey: string,
+    readonly dexHelper: IDexHelper,
+    public config = LighterV1Config[dexKey][network],
+    protected adapters = Adapters[network] || {}, // TODO: add any additional optional params to support other fork DEXes
+  ) {
+    super(dexHelper, dexKey);
+    this.logger = dexHelper.getLogger(dexKey);
+  }
+
+  // Initialize pricing is called once in the start of
+  // pricing service. It is intended to setup the integration
+  // for pricing requests. It is optional for a DEX to
+  // implement this function
+  async initializePricing(blockNumber: number) {
+    await this.updatePoolState(blockNumber);
+  }
+
+  // Returns the list of contract adapters (name and index)
+  // for a buy/sell. Return null if there are no adapters.
+  getAdapters(side: SwapSide): { name: string; index: number }[] | null {
+    return this.adapters[side] ? this.adapters[side] : null;
+  }
+
+  // Returns list of pool identifiers that can be used
+  // for a given swap. poolIdentifiers must be unique
+  // across DEXes. It is recommended to use
+  // ${dexKey}_${poolAddress} as a poolIdentifier
+  async getPoolIdentifiers(
+    srcToken: Token,
+    destToken: Token,
+    side: SwapSide,
+    blockNumber: number,
+  ): Promise<string[]> {
+    if (side == SwapSide.BUY) {
+      return [];
+    }
+
+    const _srcToken = this.dexHelper.config.wrapETH(srcToken);
+    const _destToken = this.dexHelper.config.wrapETH(destToken);
+
+    const keyForAsk = `${_srcToken.address}-${_destToken.address}`;
+    const keyForBid = `${_destToken.address}-${_srcToken.address}`;
+
+    const orderBookForAsk = this.allSupportedOrderBooks.get(keyForAsk);
+
+    if (orderBookForAsk) {
+      return [`${this.dexKey}_${keyForAsk}`];
+    }
+
+    const orderBookForBid = this.allSupportedOrderBooks.get(keyForBid);
+
+    if (orderBookForBid) {
+      return [`${this.dexKey}_${keyForBid}}`];
+    }
+
+    return [];
+  }
+
+  // Returns pool prices for amounts.
+  // If limitPools is defined only pools in limitPools
+  // should be used. If limitPools is undefined then
+  // any pools can be used.
+  async getPricesVolume(
+    srcToken: Token,
+    destToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    limitPools?: string[],
+  ): Promise<null | ExchangePrices<LighterV1Data>> {
+    const poolIdentifier = await this.getPoolIdentifiers(
+      srcToken,
+      destToken,
+      side,
+      blockNumber,
+    );
+
+    if (poolIdentifier.length == 0) {
+      return null;
+    }
+
+    // LighterV1_0x82aF49447D8a07e3bd95BD0d56f35241523fBab1_0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8
+    // omit LighterV1 from this string, split
+    const key = poolIdentifier[0].split('_')[1];
+
+    const orderBookType = this.allSupportedOrderBooks.get(key);
+
+    if (!orderBookType) {
+      return null;
+    }
+
+    const pool = this.orderBooks.get(orderBookType.orderBookId);
+
+    if (!pool) {
+      return null;
+    }
+
+    let state = pool.getState(blockNumber);
+
+    if (!state) {
+      state = await pool.generateState(blockNumber);
+    }
+
+    const orderBookData = state.orderBook;
+    const limitOrders = orderBookType.isAsk
+      ? orderBookData.sortedBids
+      : orderBookData.sortedAsks;
+
+    const outAmounts: bigint[] = await this.getOutAmount(
+      amounts,
+      orderBookType.isAsk,
+      limitOrders,
+      state.sizeTick,
+    );
+
+    return [
+      {
+        prices: outAmounts,
+        unit: bigIntify(0),
+        data: { exchange: this.dexKey },
+        poolIdentifier: poolIdentifier[0],
+        exchange: this.dexKey,
+        gasCost: CALLDATA_GAS_COST.DEX_NO_PAYLOAD,
+        poolAddresses: [pool.orderBookAddress],
+      },
+    ];
+  }
+
+  async getOutAmount(
+    amountIns: bigint[],
+    isAsk: boolean,
+    limitOrders: Readonly<LimitOrder[]>,
+    sizeTick: Readonly<bigint>,
+  ): Promise<bigint[]> {
+    return amountIns.map(amountIn => {
+      // This is important, reviewer should check this
+      // there is a size tick in the order book and we need to round the amountIn
+      if (isAsk) {
+        amountIn -= amountIn % BigInt(sizeTick);
+      }
+
+      let remainingAmountIn = amountIn;
+      let runningAmountOut = BigInt(0);
+
+      let partialAmountOut = BigInt(0);
+      let orderAmountIn = BigInt(0);
+      let orderAmountOut = BigInt(0);
+      for (
+        let i = 0;
+        i < limitOrders.length && remainingAmountIn > BigInt(0);
+        i++
+      ) {
+        if (isAsk != limitOrders[i].isAsk) {
+          orderAmountIn = limitOrders[i].amount0;
+          orderAmountOut = limitOrders[i].amount1;
+
+          if (remainingAmountIn >= orderAmountIn) {
+            runningAmountOut += orderAmountOut;
+            remainingAmountIn -= orderAmountIn;
+          } else {
+            partialAmountOut =
+              (remainingAmountIn * orderAmountOut) / orderAmountIn;
+            if (!isAsk) {
+              partialAmountOut -= partialAmountOut % BigInt(sizeTick);
+            }
+            runningAmountOut += partialAmountOut;
+            remainingAmountIn -=
+              (partialAmountOut * orderAmountIn) / orderAmountOut;
+
+            break;
+          }
+        }
+      }
+      return runningAmountOut;
+    });
+  }
+
+  // Returns estimated gas cost of calldata for this DEX in multiSwap
+  getCalldataGasCost(poolPrices: PoolPrices<LighterV1Data>): number | number[] {
+    // TODO: update if there is any payload in getAdapterParam
+    return CALLDATA_GAS_COST.DEX_NO_PAYLOAD;
+  }
+
+  // Encode params required by the exchange adapter
+  // Used for multiSwap, buy & megaSwap
+  // Hint: abiCoder.encodeParameter() could be useful
+  getAdapterParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: LighterV1Data,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    const { exchange } = data;
+
+    // Encode here the payload for adapter
+    const payload = '';
+
+    return {
+      targetExchange: exchange,
+      payload,
+      networkFee: '0',
+    };
+  }
+
+  // Encode call data used by simpleSwap like routers
+  // Used for simpleSwap & simpleBuy
+  // Hint: this.buildSimpleParamWithoutWETHConversion
+  // could be useful
+  async getSimpleParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: LighterV1Data,
+    side: SwapSide,
+  ): Promise<SimpleExchangeParam> {
+    if (side == SwapSide.BUY) {
+      throw new Error('Buy not supported');
+    }
+
+    const poolIdentifier = await this.getPoolIdentifiers(
+      { address: srcToken, decimals: 0 },
+      { address: destToken, decimals: 0 },
+      SwapSide.SELL,
+      0,
+    );
+
+    if (poolIdentifier.length == 0) {
+      throw new Error('Pool identifier not found');
+    }
+
+    const key = poolIdentifier[0].split('_')[1];
+
+    const orderBookType = this.allSupportedOrderBooks.get(key);
+
+    if (!orderBookType) {
+      throw new Error('Order book type not found');
+    }
+
+    // Encode here the transaction arguments
+    const helper = new ethers.Contract(
+      this.config.orderBookHelper,
+      this.orderBookHelperIface,
+    );
+
+    const payload = helper.interface.encodeFunctionData('swapExactInput', [
+      orderBookType.orderBookId,
+      orderBookType.isAsk,
+      srcAmount,
+      destAmount,
+    ]);
+
+    return this.buildSimpleParamWithoutWETHConversion(
+      srcToken,
+      srcAmount,
+      destToken,
+      destAmount,
+      payload,
+      helper.address,
+    );
+  }
+
+  async getQuoteFromHelper(
+    blockNumber: number,
+    orderBookId: number,
+    amountIn: bigint,
+    isAsk: boolean,
+  ): Promise<bigint> {
+    const helper = new ethers.Contract(
+      this.config.orderBookHelper,
+      this.orderBookHelperIface,
+    );
+
+    const data = await this.dexHelper.provider.call(
+      {
+        to: helper.address,
+        data: helper.interface.encodeFunctionData('quoteExactInput', [
+          orderBookId,
+          isAsk,
+          amountIn,
+        ]),
+      },
+      blockNumber,
+    );
+
+    const [amountInResult, amountOut] = helper.interface.decodeFunctionResult(
+      'quoteExactInput',
+      data,
+    );
+
+    return amountOut;
+  }
+
+  // This is called once before getTopPoolsForToken is
+  // called for multiple tokens. This can be helpful to
+  // update common state required for calculating
+  // getTopPoolsForToken. It is optional for a DEX
+  // to implement this
+  async updatePoolState(blockNumber?: number): Promise<void> {
+    const helper = new ethers.Contract(
+      this.config.orderBookHelper,
+      this.orderBookHelperIface,
+    );
+
+    const block = blockNumber
+      ? blockNumber
+      : await this.dexHelper.provider.getBlockNumber();
+
+    const data = await this.dexHelper.provider.call(
+      {
+        to: helper.address,
+        data: helper.interface.encodeFunctionData('getAllOrderBooks', []),
+      },
+      block,
+    );
+
+    const [orderBookIds, orderBookAddresses, token0s, token1s, sizeTicks, _] =
+      helper.interface.decodeFunctionResult('getAllOrderBooks', data);
+
+    for (let i = 0; i < orderBookIds.length; i++) {
+      // Generate keys for both sides of each order book
+      const keyForAsk = `${token0s[i]}-${token1s[i]}`;
+      const keyForBid = `${token1s[i]}-${token0s[i]}`;
+
+      if (!this.allSupportedOrderBooks.has(keyForAsk)) {
+        // Construct the OrderBookType objects
+        const orderBookForAsk = { orderBookId: orderBookIds[i], isAsk: true };
+        const orderBookForBid = { orderBookId: orderBookIds[i], isAsk: false };
+
+        // Add the order books to the map
+        this.allSupportedOrderBooks.set(keyForAsk, orderBookForAsk);
+        this.allSupportedOrderBooks.set(keyForBid, orderBookForBid);
+      }
+
+      let pool: LighterV1EventPool;
+
+      if (!this.orderBooks.has(orderBookIds[i])) {
+        const token0 = new ethers.Contract(
+          token0s[i],
+          Erc20Iface,
+          this.dexHelper.provider,
+        );
+        const token1 = new ethers.Contract(
+          token1s[i],
+          Erc20Iface,
+          this.dexHelper.provider,
+        );
+        // get token symbol
+        const token0Symbol = await token0.symbol();
+        const token1Symbol = await token1.symbol();
+
+        // get token decimals
+        const token0Decimals = await token0.decimals();
+        const token1Decimals = await token1.decimals();
+
+        const baseToken: Token = {
+          address: token0s[i],
+          decimals: token0Decimals,
+          symbol: token0Symbol,
+        };
+
+        const quoteToken: Token = {
+          address: token1s[i],
+          decimals: token1Decimals,
+          symbol: token1Symbol,
+        };
+        // create pool
+        pool = new LighterV1EventPool(
+          this.dexKey,
+          this.network,
+          this.dexHelper,
+          this.logger,
+          this.config.factory,
+          this.config.router,
+          orderBookIds[i],
+          orderBookAddresses[i],
+          baseToken,
+          quoteToken,
+          sizeTicks[i],
+        );
+
+        this.orderBooks.set(orderBookIds[i], pool);
+      }
+
+      pool = this.orderBooks.get(orderBookIds[i])!;
+
+      const state = await pool.generateState(block);
+      pool.setState(state, block);
+    }
+  }
+
+  // Returns list of top pools based on liquidity. Max
+  // limit number pools should be returned.
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    limit: number,
+  ): Promise<PoolLiquidity[]> {
+    const pools: PoolLiquidity[] = [];
+
+    // find the pools that have the token in allSupportedOrderBooks keys
+    for (const [key, orderBookType] of this.allSupportedOrderBooks) {
+      if (pools.length >= limit) {
+        break;
+      }
+      const [token0, token1] = key.split('-');
+      // if one of these tokens is given token
+      if (token0 == tokenAddress) {
+        const pool = this.orderBooks.get(orderBookType.orderBookId);
+
+        if (!pool) {
+          continue;
+        }
+
+        const state = pool.getState(pool.getStateBlockNumber());
+
+        if (!state) {
+          continue;
+        }
+
+        const liq = await pool.calculateLiquidity();
+
+        // find the connector token,
+        // if token0 is the given token, then token1 is the connector token
+
+        const connectorToken =
+          tokenAddress == state.baseToken.address
+            ? state.quoteToken
+            : state.baseToken;
+
+        pools.push({
+          exchange: this.dexKey,
+          address: this.config.orderBookHelper,
+          connectorTokens: [connectorToken],
+          liquidityUSD: liq,
+        });
+      }
+    }
+    return pools;
+  }
+
+  // This is optional function in case if your implementation has acquired any resources
+  // you need to release for graceful shutdown. For example, it may be any interval timer
+  releaseResources(): AsyncOrSync<void> {
+    // TODO: complete me!
+  }
+}

--- a/src/dex/lighter-v1/types.ts
+++ b/src/dex/lighter-v1/types.ts
@@ -1,0 +1,55 @@
+import { Address, Token } from '../../types';
+
+export type PoolState = {
+  pool: Address;
+  baseToken: Token;
+  quoteToken: Token;
+  orderBook: OrderBook;
+  sizeTick: bigint;
+};
+
+export type OrderBook = {
+  sortedAsks: LimitOrder[];
+  sortedBids: LimitOrder[];
+};
+
+export type LighterV1Data = {
+  // TODO: LighterV1Data is the dex data that is
+  // returned by the API that can be used for
+  // tx building. The data structure should be minimal.
+  // Complete me!
+  exchange: Address;
+};
+
+export type DexParams = {
+  // TODO: DexParams is set of parameters the can
+  // be used to initiate a DEX fork.
+  // Complete me!
+  factory: Address;
+  router: Address;
+  orderBookHelper: Address;
+};
+
+export type OrderBookDetails = {
+  orderBookId: number;
+  orderBookAddress: string;
+  token0Address: string;
+  token1Address: string;
+  sizeTick: number;
+  priceTick: number;
+};
+
+export type LimitOrder = {
+  id: number;
+  amount0: bigint;
+  amount1: bigint;
+  isAsk: boolean;
+  price: number;
+};
+
+export type OrderBookType = {
+  orderBookId: number;
+  isAsk: boolean;
+};
+
+export type AllOrderBooks = Map<string, OrderBookType>;

--- a/tests/utils-events.ts
+++ b/tests/utils-events.ts
@@ -155,7 +155,8 @@ export function getSavedState<SubscriberState>(
   if (_state) {
     const checker = (obj: any) => _.isString(obj) && obj.includes('bi@');
     const caster = (obj: string) => bigintify(obj.slice(3));
-    return deepTypecast<string>(_.cloneDeep(_state), checker, caster);
+    const x = deepTypecast<string>(_.cloneDeep(_state), checker, caster);
+    return x;
   }
   return undefined;
 }


### PR DESCRIPTION
- All order books are got from factory contract and initiated as a different pool

- Each pool is initiated by getting all limit orders from router contract, then listens three different events from respective order book contracts;
1. LimitOrderCreated
2. LimitOrderCanceled
3. Swap

So pools keep track of asks and bids.

As of now we have 4 different Order books;
1. WETH - USDC.e
2. WBTC - USDC.e
3. USDT - USDC.e
4. USDC - USDC.e
