### PR TITLE
Feat/1245 balancer v2 multihop draft

### DIFF
--- a/src/dex/balancer-v2/balancer-v2-optimizer.test.ts
+++ b/src/dex/balancer-v2/balancer-v2-optimizer.test.ts
@@ -327,7 +327,7 @@ describe('BalancerV2 optimizer', () => {
                 exchange: 'BalancerV2',
                 srcAmount: '27001080000000000000',
                 destAmount: '1663710383246524230443584',
-                percent: 100,
+                percent: 3,
                 poolAddresses: ['0xcb0e14e96f2cefa8550ad8e4aea344f211e5061d'],
                 data: {
                   poolId:
@@ -347,7 +347,7 @@ describe('BalancerV2 optimizer', () => {
                 exchange: 'BalancerV2',
                 srcAmount: '598920000000000000',
                 destAmount: '36257151080030344235259',
-                percent: 100,
+                percent: 97,
                 poolAddresses: ['0x458ae80894A0924Ac763C034977e330c565F1687'],
                 data: {
                   poolId:
@@ -507,8 +507,6 @@ describe('BalancerV2 optimizer', () => {
       },
     ];
 
-    // Test is not full
-    expect(true).toEqual(fail);
     expect(optimizedRate).toStrictEqual(expectedRate);
   });
 

--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -1054,11 +1054,11 @@ export class BalancerV2
         ETHER_ADDRESS.toLowerCase(),
       );
       const _srcToken = this.dexHelper.config.wrapETH({
-        address: srcToken,
+        address: swapData.srcToken,
         decimals: 18,
       }).address;
       const _destToken = this.dexHelper.config.wrapETH({
-        address: destToken,
+        address: swapData.destToken,
         decimals: 18,
       }).address;
 

--- a/src/dex/balancer-v2/optimizer.ts
+++ b/src/dex/balancer-v2/optimizer.ts
@@ -1,4 +1,4 @@
-import { UnoptimizedRate, OptimalSwapExchange } from '../../types';
+import { UnoptimizedRate, OptimalSwapExchange, OptimalSwap } from '../../types';
 import { BalancerSwapV2 } from './types';
 import { SwapSide } from '../../constants';
 import { BalancerConfig } from './config';
@@ -10,6 +10,7 @@ export function balancerV2Merge(or: UnoptimizedRate): UnoptimizedRate {
     rawSwap: OptimalSwapExchange<any>[],
     accumulatedBalancers: { [key: string]: OptimalSwapExchange<any> },
     side: SwapSide,
+    swap: OptimalSwap,
   ): OptimalSwapExchange<any>[] => {
     let optimizedSwap = new Array<OptimalSwapExchange<any>>();
     const newBalancers: { [key: string]: OptimalSwapExchange<any> } = {};
@@ -47,6 +48,10 @@ export function balancerV2Merge(or: UnoptimizedRate): UnoptimizedRate {
         ).toFixed(6);
 
         accumulatedBalancers[exchangeKey].data.swaps.push({
+          // it's not included in balancer-v2-optimizer.test.ts
+          srcToken: swap.srcToken,
+          destToken: swap.destToken,
+          //
           poolId: s.data.poolId,
           amount: side === SwapSide.SELL ? s.srcAmount : s.destAmount,
         });
@@ -74,6 +79,7 @@ export function balancerV2Merge(or: UnoptimizedRate): UnoptimizedRate {
             s.swapExchanges,
             accumulatedBalancers,
             or.side,
+            s,
           ),
         }))
         .filter(s => s.swapExchanges.length > 0),

--- a/src/dex/balancer-v2/types.ts
+++ b/src/dex/balancer-v2/types.ts
@@ -82,6 +82,8 @@ export interface SubgraphPoolBase {
 export type BalancerSwapV2 = {
   poolId: string;
   amount: string;
+  srcToken: string;
+  destToken: string;
 };
 
 export type OptimizedBalancerV2Data = {


### PR DESCRIPTION
- current optimizer works for balancer v2 price calculations (supports multipath Buy)
- Even though tx build works, function `getBalancerParam` in `balancer-v2.ts` is not yet adapted. `Received amount of tokens are less then expected` is the most common error
- for current implementation BalancerV2 multiSwap still works, but direct methods `directBalancerV2GivenOutSwap` methods with several optimized swaps don't work.

P.S: 
- Dex Lib doesn't support multi path price route. To make tests work, one should hardcode specific price route (for current case - multipath Buy PSP -> USDC)