### PR TITLE
update ban logic for swaap v2

### DIFF
--- a/src/dex/swaap-v2/constants.ts
+++ b/src/dex/swaap-v2/constants.ts
@@ -26,7 +26,7 @@ export const SWAAP_403_TTL_S = 60 * 60 * 24; // 24 hours
 
 export const SWAAP_429_TTL_S = 60 * 60 * 1; // 1 hour
 
-export const SWAAP_RESTRICT_TTL_S = 60 * 30; // 30 minutes
+export const SWAAP_POOL_RESTRICT_TTL_S = 60 * 30; // 30 minutes
 
 export const SWAAP_RESTRICTED_CACHE_KEY = 'restricted';
 

--- a/src/dex/swaap-v2/constants.ts
+++ b/src/dex/swaap-v2/constants.ts
@@ -20,6 +20,8 @@ export const SWAAP_RFQ_PRICES_ENDPOINT = 'prices';
 
 export const SWAAP_RFQ_QUOTE_ENDPOINT = 'quote';
 
+export const SWAAP_NOTIFY_ENDPOINT = 'notify';
+
 export const SWAAP_RFQ_TOKENS_ENDPOINT = 'tokens';
 
 export const SWAAP_403_TTL_S = 60 * 60 * 24; // 24 hours
@@ -42,3 +44,9 @@ export const SWAAP_ORDER_TYPE_BUY = 2;
 
 export const SWAAP_MIN_SLIPPAGE_FACTOR_THRESHOLD_FOR_RESTRICTION =
   new BigNumber('0.001');
+
+export const SWAAP_NOTIFY_TIMEOUT_MS = 2000;
+
+export const SWAAP_NOTIFICATION_ORIGIN = 'paraswap';
+
+export const SWAAP_BANNED_CODE = 1;

--- a/src/dex/swaap-v2/constants.ts
+++ b/src/dex/swaap-v2/constants.ts
@@ -22,7 +22,9 @@ export const SWAAP_RFQ_QUOTE_ENDPOINT = 'quote';
 
 export const SWAAP_RFQ_TOKENS_ENDPOINT = 'tokens';
 
-export const SWAAP_BLACKLIST_TTL_S = 60 * 60 * 24; // 24 hours
+export const SWAAP_403_TTL_S = 60 * 60 * 24; // 24 hours
+
+export const SWAAP_429_TTL_S = 60 * 60 * 1; // 1 hour
 
 export const SWAAP_RESTRICT_TTL_S = 60 * 30; // 30 minutes
 

--- a/src/dex/swaap-v2/types.ts
+++ b/src/dex/swaap-v2/types.ts
@@ -93,3 +93,13 @@ export type SwaapV2APIParameters = {
 export type TokensMap = {
   [address: string]: Token;
 };
+
+export type SwaapV2NotificationRequest = {
+  origin: string;
+  code: number;
+  message: string;
+};
+
+export type SwaapV2NotificationResponse = {
+  success: boolean;
+};

--- a/src/dex/swaap-v2/utils.ts
+++ b/src/dex/swaap-v2/utils.ts
@@ -1,5 +1,5 @@
 import { Address } from '../../types';
-import { CACHE_PREFIX, ETHER_ADDRESS, NULL_ADDRESS } from '../../constants';
+import { ETHER_ADDRESS, NULL_ADDRESS } from '../../constants';
 
 export const getIdentifierPrefix = (
   dexKey: string,

--- a/src/dex/swaap-v2/utils.ts
+++ b/src/dex/swaap-v2/utils.ts
@@ -3,30 +3,23 @@ import { CACHE_PREFIX, ETHER_ADDRESS, NULL_ADDRESS } from '../../constants';
 
 export const getIdentifierPrefix = (
   dexKey: string,
-  srcAddress: Address,
-  destAddress: Address,
+  tokenA: Address,
+  tokenB: Address,
 ) => {
-  return `${dexKey}_${getPairName(srcAddress, destAddress)}`.toLowerCase();
+  return `${dexKey}_${getPairName(tokenA, tokenB)}`.toLowerCase();
 };
 
-export const getPairName = (srcAddress: Address, destAddress: Address) => {
-  const sortedAddresses =
-    srcAddress < destAddress
-      ? [srcAddress, destAddress]
-      : [destAddress, srcAddress];
+export const getPairName = (tokenA: Address, tokenB: Address) => {
+  const sortedAddresses = tokenA < tokenB ? [tokenA, tokenB] : [tokenB, tokenA];
   return `${sortedAddresses[0]}_${sortedAddresses[1]}`.toLowerCase();
 };
 
 export const getPoolIdentifier = (
   dexKey: string,
-  srcAddress: Address,
-  destAddress: Address,
+  tokenA: Address,
+  tokenB: Address,
 ) => {
-  return `${getIdentifierPrefix(
-    dexKey,
-    srcAddress,
-    destAddress,
-  )}`.toLowerCase();
+  return `${getIdentifierPrefix(dexKey, tokenA, tokenB)}`.toLowerCase();
 };
 
 export const normalizeTokenAddress = (address: string): string => {

--- a/src/dex/swaap-v2/validators.ts
+++ b/src/dex/swaap-v2/validators.ts
@@ -126,3 +126,9 @@ export const getQuoteResponseValidator = joi
     success: joi.boolean().required(),
   })
   .unknown(true);
+
+export const notifyResponseValidator = joi
+  .object({
+    success: joi.boolean().required(),
+  })
+  .unknown(true);


### PR DESCRIPTION
1. now differentiating between 403 and 429 types of restriction
2. now restricting Swaap at the pool / pair level instead of network level
(+ naming convention update in getIdentifierPrefix)