### PR TITLE
Fix/back 1387 mitigate missed newly created pool issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.42.14-algebra-bugfix-missed-created-pools.0",
+  "version": "2.42.14-algebra-bugfix-missed-created-pools.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.42.14-algebra-bugfix-missed-created-pools.1",
+  "version": "2.42.14-algebra-bugfix-missed-created-pools.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.42.13",
+  "version": "2.42.14-algebra-bugfix-missed-created-pools.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.42.15",
+  "version": "2.42.16",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.42.14",
+  "version": "2.42.15-algebra-bugfix-missed-created-pools.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "2.42.10",
+  "version": "2.42.11-algebra-bugfix-missed-created-pools.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/algebra/algebra.ts
+++ b/src/dex/algebra/algebra.ts
@@ -267,7 +267,7 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
       );
     }
 
-    this.logger.trace(`starting to listen to new pool: ${key}`);
+    this.logger.info(`starting to listen to new pool: ${key}`);
     pool =
       pool ||
       new this.AlgebraPoolImplem(
@@ -296,10 +296,13 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
         },
       });
 
+      this.logger.info(`pool ${key} initialised`);
+
       if (this.newlyCreatedPoolKeys.has(key)) {
         this.newlyCreatedPoolKeys.delete(key);
       }
     } catch (e) {
+      this.logger.info(`pool ${key} failed to initialise`, e);
       if (e instanceof Error && e.message.endsWith('Pool does not exist')) {
         /* 
          protection against 2 race conditions

--- a/src/dex/algebra/algebra.ts
+++ b/src/dex/algebra/algebra.ts
@@ -294,6 +294,10 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
           pool!.initRetryAttemptCount = 0;
         },
       });
+
+      if (this.newlyCreatedPoolKeys.has(key)) {
+        this.newlyCreatedPoolKeys.delete(key);
+      }
     } catch (e) {
       if (e instanceof Error && e.message.endsWith('Pool does not exist')) {
         /* 
@@ -305,6 +309,7 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
           this.logger.warn(
             `[block=${blockNumber}][Pool=${key}] newly created pool failed to initialise`,
           );
+          this.newlyCreatedPoolKeys.delete(key);
         } else {
           // no need to await we want the set to have the pool key but it's not blocking
           this.dexHelper.cache.zadd(

--- a/src/dex/algebra/algebra.ts
+++ b/src/dex/algebra/algebra.ts
@@ -312,6 +312,11 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
           );
           this.newlyCreatedPoolKeys.delete(key);
         } else {
+          this.logger.info(
+            `[block=${blockNumber}][Pool=${key}] pool failed to initialize so it's marked as non existing`,
+            e,
+          );
+
           // allowing only master/leader node to alter distant cache to reduce risk of race conditions
           if (!this.dexHelper.config.isSlave) {
             // no need to await we want the set to have the pool key but it's not blocking
@@ -325,16 +330,12 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
           // Pool does not exist for this pair, so we can set it to null
           // to prevent more requests for this pool
           pool = null;
-          this.logger.info(
-            `[block=${blockNumber}][Pool=${key}] pool failed to initialize, probably not existing`,
-            e,
-          );
         }
       } else {
         // on unknown error mark as failed and increase retryCount for retry init strategy
         // note: state would be null by default which allows to fallback
         this.logger.warn(
-          `Can not generate pool state for srcAddress=${srcAddress}, destAddress=${destAddress} pool fallback to rpc and retry every ${this.config.initRetryFrequency} times, initRetryAttemptCount=${pool.initRetryAttemptCount}`,
+          `[block=${blockNumber}][Pool=${key}] Can not generate pool state for srcAddress=${srcAddress}, destAddress=${destAddress} pool fallback to rpc and retry every ${this.config.initRetryFrequency} times, initRetryAttemptCount=${pool.initRetryAttemptCount}`,
           e,
         );
         pool.initFailed = true;

--- a/src/dex/algebra/algebra.ts
+++ b/src/dex/algebra/algebra.ts
@@ -45,8 +45,8 @@ type PoolPairsInfo = {
   token1: Address;
 };
 
-const ALGEBRA_CLEAN_NOT_EXISTING_POOL_TTL_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
-const ALGEBRA_CLEAN_NOT_EXISTING_POOL_INTERVAL_MS = 24 * 60 * 60 * 1000; // Once in a day
+// const ALGEBRA_CLEAN_NOT_EXISTING_POOL_TTL_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+// const ALGEBRA_CLEAN_NOT_EXISTING_POOL_INTERVAL_MS = 24 * 60 * 60 * 1000; // Once in a day
 const ALGEBRA_EFFICIENCY_FACTOR = 3;
 const ALGEBRA_TICK_GAS_COST = 24_000; // Ceiled
 const ALGEBRA_TICK_BASE_OVERHEAD = 75_000;
@@ -141,22 +141,23 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
     // Init listening to new pools creation
     await this.factory.initialize(blockNumber);
 
-    if (!this.dexHelper.config.isSlave) {
-      const cleanExpiredNotExistingPoolsKeys = async () => {
-        const maxTimestamp =
-          Date.now() - ALGEBRA_CLEAN_NOT_EXISTING_POOL_TTL_MS;
-        await this.dexHelper.cache.zremrangebyscore(
-          this.notExistingPoolSetKey,
-          0,
-          maxTimestamp,
-        );
-      };
+    //// COMMENTING DEPRECATED LOGIC: as we now  invalidate pools on creation this is not needed anymore
+    // if (!this.dexHelper.config.isSlave) {
+    //   const cleanExpiredNotExistingPoolsKeys = async () => {
+    //     const maxTimestamp =
+    //       Date.now() - ALGEBRA_CLEAN_NOT_EXISTING_POOL_TTL_MS;
+    //     await this.dexHelper.cache.zremrangebyscore(
+    //       this.notExistingPoolSetKey,
+    //       0,
+    //       maxTimestamp,
+    //     );
+    //   };
 
-      this.intervalTask = setInterval(
-        cleanExpiredNotExistingPoolsKeys.bind(this),
-        ALGEBRA_CLEAN_NOT_EXISTING_POOL_INTERVAL_MS,
-      );
-    }
+    //   this.intervalTask = setInterval(
+    //     cleanExpiredNotExistingPoolsKeys.bind(this),
+    //     ALGEBRA_CLEAN_NOT_EXISTING_POOL_INTERVAL_MS,
+    //   );
+    // }
   }
 
   /*

--- a/src/dex/algebra/algebra.ts
+++ b/src/dex/algebra/algebra.ts
@@ -308,9 +308,8 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
         */
         if (this.newlyCreatedPoolKeys.has(key)) {
           this.logger.warn(
-            `[block=${blockNumber}][Pool=${key}] newly created pool failed to initialise`,
+            `[block=${blockNumber}][Pool=${key}] newly created pool failed to initialise, trying on next request`,
           );
-          this.newlyCreatedPoolKeys.delete(key);
         } else {
           this.logger.info(
             `[block=${blockNumber}][Pool=${key}] pool failed to initialize so it's marked as non existing`,

--- a/src/dex/algebra/algebra.ts
+++ b/src/dex/algebra/algebra.ts
@@ -317,15 +317,12 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
             e,
           );
 
-          // allowing only master/leader node to alter distant cache to reduce risk of race conditions
-          if (!this.dexHelper.config.isSlave) {
-            // no need to await we want the set to have the pool key but it's not blocking
-            this.dexHelper.cache.zadd(
-              this.notExistingPoolSetKey,
-              [Date.now(), key],
-              'NX',
-            );
-          }
+          // no need to await we want the set to have the pool key but it's not blocking
+          this.dexHelper.cache.zadd(
+            this.notExistingPoolSetKey,
+            [Date.now(), key],
+            'NX',
+          );
 
           // Pool does not exist for this pair, so we can set it to null
           // to prevent more requests for this pool

--- a/src/dex/algebra/algebra.ts
+++ b/src/dex/algebra/algebra.ts
@@ -312,12 +312,15 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
           );
           this.newlyCreatedPoolKeys.delete(key);
         } else {
-          // no need to await we want the set to have the pool key but it's not blocking
-          this.dexHelper.cache.zadd(
-            this.notExistingPoolSetKey,
-            [Date.now(), key],
-            'NX',
-          );
+          // allowing only master/leader node to alter distant cache to reduce risk of race conditions
+          if (!this.dexHelper.config.isSlave) {
+            // no need to await we want the set to have the pool key but it's not blocking
+            this.dexHelper.cache.zadd(
+              this.notExistingPoolSetKey,
+              [Date.now(), key],
+              'NX',
+            );
+          }
 
           // Pool does not exist for this pair, so we can set it to null
           // to prevent more requests for this pool

--- a/src/dex/algebra/algebra.ts
+++ b/src/dex/algebra/algebra.ts
@@ -267,7 +267,7 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
       );
     }
 
-    this.logger.info(`starting to listen to new pool: ${key}`);
+    this.logger.trace(`starting to listen to new pool: ${key}`);
     pool =
       pool ||
       new this.AlgebraPoolImplem(
@@ -296,13 +296,10 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
         },
       });
 
-      this.logger.info(`pool ${key} initialised`);
-
       if (this.newlyCreatedPoolKeys.has(key)) {
         this.newlyCreatedPoolKeys.delete(key);
       }
     } catch (e) {
-      this.logger.info(`pool ${key} failed to initialise`, e);
       if (e instanceof Error && e.message.endsWith('Pool does not exist')) {
         /* 
          protection against 2 race conditions


### PR DESCRIPTION
Introduce a local var `newlyCreatedPoolKeys` to prevent race conditions between acknowledgment of pool creation and querying pool state for first time near pool creation