### PR TITLE
Lighter V2 Integration

### DIFF
--- a/src/abi/lighter-v2/Factory.json
+++ b/src/abi/lighter-v2/Factory.json
@@ -1,0 +1,442 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2CreateOrderBook_InvalidTokenPair",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2CreateOrderBook_OrderBookAlreadyExists",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2CreateOrderBook_OrderBookIdExceedsLimit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Factory_CallerNotOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Factory_OwnerCannotBeZero",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "orderBookAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "logSizeTick",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "logPriceTick",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "minToken0BaseAmount",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "minToken1BaseAmount",
+        "type": "uint128"
+      }
+    ],
+    "name": "OrderBookCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerChanged",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "ORDERBOOK_ID_THRESHOLD",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "internalType": "uint8",
+        "name": "logSizeTick",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "logPriceTick",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "minToken0BaseAmount",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "minToken1BaseAmount",
+        "type": "uint128"
+      }
+    ],
+    "name": "createOrderBook",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "orderBookAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllOrderBooksDetails",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "orderBookAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "orderBookId",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint128",
+            "name": "sizeTick",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "priceMultiplier",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "priceDivider",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint64",
+            "name": "minToken0BaseAmount",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint128",
+            "name": "minToken1BaseAmount",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct IFactory.OrderBookDetails[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      }
+    ],
+    "name": "getOrderBookDetailsFromId",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "orderBookAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "orderBookId",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint128",
+            "name": "sizeTick",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "priceMultiplier",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "priceDivider",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint64",
+            "name": "minToken0BaseAmount",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint128",
+            "name": "minToken1BaseAmount",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct IFactory.OrderBookDetails",
+        "name": "orderBookDetails",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      }
+    ],
+    "name": "getOrderBookDetailsFromTokenPair",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "orderBookAddress",
+            "type": "address"
+          },
+          {
+            "internalType": "uint8",
+            "name": "orderBookId",
+            "type": "uint8"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint128",
+            "name": "sizeTick",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "priceMultiplier",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint128",
+            "name": "priceDivider",
+            "type": "uint128"
+          },
+          {
+            "internalType": "uint64",
+            "name": "minToken0BaseAmount",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint128",
+            "name": "minToken1BaseAmount",
+            "type": "uint128"
+          }
+        ],
+        "internalType": "struct IFactory.OrderBookDetails",
+        "name": "orderBookDetails",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      }
+    ],
+    "name": "getOrderBookFromId",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      }
+    ],
+    "name": "getOrderBookFromTokenPair",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "orderBookIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "setOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/abi/lighter-v2/OrderBook.json
+++ b/src/abi/lighter-v2/OrderBook.json
@@ -1,0 +1,1184 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "_orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "_token0Address",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_token1Address",
+        "type": "address"
+      },
+      {
+        "internalType": "uint8",
+        "name": "_logSizeTick",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "_logPriceTick",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "_minToken0BaseAmount",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "_minToken1BaseAmount",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Base_ContractBalanceDoesNotMatchSentAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2CreateOrderBook_InvalidMinAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2CreateOrderBook_InvalidTickCombination",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2FlashLoan_InsufficentCallbackTransfer",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_AmountTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_CannotCancelInactiveOrders",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_CannotEraseHeadOrTailOrders",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_CreatorIdExceedsLimit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_FoKNotFilled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_InsufficentCallbackTransfer",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_InsufficientClaimableBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_InvalidHintId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_OrderDoesNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_OrderIdExceedsLimit",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_PriceTooBig",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Order_PriceTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Owner_CallerCannotCancel",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Swap_NotEnoughLiquidity",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Swap_NotEnoughOutput",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Swap_TooMuchRequested",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2TokenTransfer_Failed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Vault_InsufficentCallbackTransfer",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Vault_InvalidClaimAmount",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      }
+    ],
+    "name": "CancelLimitOrder",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isToken0",
+        "type": "bool"
+      }
+    ],
+    "name": "ClaimableBalanceDecrease",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountDelta",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isToken0",
+        "type": "bool"
+      }
+    ],
+    "name": "ClaimableBalanceIncrease",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "amount0Base",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum IOrderBook.OrderType",
+        "name": "orderType",
+        "type": "uint8"
+      }
+    ],
+    "name": "CreateOrder",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "FlashLoan",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "askId",
+        "type": "uint32"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint32",
+        "name": "bidId",
+        "type": "uint32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "askOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "bidOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isExactInput",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapAmount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "swapAmount1",
+        "type": "uint256"
+      }
+    ],
+    "name": "SwapExactAmount",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "CREATOR_ID_THRESHOLD",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LOG10_TICK_THRESHOLD",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_PRICE",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ORDER_ID_THRESHOLD",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "addressToCreatorId",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "addressToOwnerId",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "cancelLimitOrder",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountToClaim",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isToken0",
+        "type": "bool"
+      }
+    ],
+    "name": "claimToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "claimableToken0Balance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "claimableToken1Balance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "amount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "hintId",
+        "type": "uint32"
+      },
+      {
+        "internalType": "enum IOrderBook.OrderType",
+        "name": "orderType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callbackData",
+        "type": "bytes"
+      }
+    ],
+    "name": "createOrder",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "newOrderId",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "name": "creatorIdToAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountToDeposit",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isToken0",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callbackData",
+        "type": "bytes"
+      }
+    ],
+    "name": "depositToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callbackData",
+        "type": "bytes"
+      }
+    ],
+    "name": "flashLoan",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      }
+    ],
+    "name": "getLimitOrder",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint32",
+            "name": "perfMode_creatorId",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "prev",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "next",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint32",
+            "name": "ownerId",
+            "type": "uint32"
+          },
+          {
+            "internalType": "uint64",
+            "name": "amount0Base",
+            "type": "uint64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "priceBase",
+            "type": "uint64"
+          }
+        ],
+        "internalType": "struct IOrderBook.LimitOrder",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "takerOrderAmount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "takerOrderPriceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "makerOrderAmount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "makerOrderPriceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isTakerAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "getLimitOrderSwapAmounts",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "amount0BaseReturn",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amount1BaseReturn",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "startOrderId",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "limit",
+        "type": "uint32"
+      }
+    ],
+    "name": "getPaginatedOrders",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isAsk",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint32[]",
+            "name": "ids",
+            "type": "uint32[]"
+          },
+          {
+            "internalType": "address[]",
+            "name": "owners",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "amount0s",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "prices",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct IOrderBook.OrderQueryItem",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint64",
+        "name": "makerAmount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "makerPriceBase",
+        "type": "uint64"
+      }
+    ],
+    "name": "getSwapAmountsForToken0",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "swapAmount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swapAmount1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "amount0BaseDelta",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "fullTakerFill",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint64",
+        "name": "makerAmount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "makerPriceBase",
+        "type": "uint64"
+      }
+    ],
+    "name": "getSwapAmountsForToken1",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "swapAmount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swapAmount1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint64",
+        "name": "amount0BaseDelta",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "fullTakerFill",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      }
+    ],
+    "name": "isAskOrder",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "id",
+        "type": "uint32"
+      }
+    ],
+    "name": "isOrderActive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minToken0BaseAmount",
+    "outputs": [
+      {
+        "internalType": "uint64",
+        "name": "",
+        "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minToken1BaseAmount",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "orderBookId",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "orderIdCounter",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "name": "ownerIdToAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceDivider",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceMultiplier",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "priceTick",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "sizeTick",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "suggestHintId",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "bool",
+        "name": "isExactInput",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "expectedAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callbackData",
+        "type": "bytes"
+      }
+    ],
+    "name": "swapExactSingle",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "contract IERC20Minimal",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "contract IERC20Minimal",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abi/lighter-v2/Router.json
+++ b/src/abi/lighter-v2/Router.json
@@ -1,0 +1,1009 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_factoryAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_wethAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2ParseCallData_ByteSizeLimit32",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2ParseCallData_CannotReadPastEndOfCallData",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2ParseCallData_InvalidFunctionSelector",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2ParseCallData_InvalidMantissa",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2ParseCallData_InvalidPaddedNumber",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Quoter_InvalidOrderBookId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Quoter_InvalidSwapExactMultiRequestCombination",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Quoter_NotEnoughLiquidity",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Router_InsufficientWETH9",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Router_InvalidOrderBookId",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Router_NativeRefundFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Router_NotEnoughNative",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Router_ReceiveNotSupported",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Router_SwapExactOutputMultiTooMuchRequested",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "LighterV2Router_TransferCallbackCallerIsNotOrderBook",
+    "type": "error"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32",
+        "name": "orderId",
+        "type": "uint32"
+      }
+    ],
+    "name": "cancelLimitOrder",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "size",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "orderId",
+        "type": "uint32[]"
+      }
+    ],
+    "name": "cancelLimitOrderBatch",
+    "outputs": [
+      {
+        "internalType": "bool[]",
+        "name": "isCanceled",
+        "type": "bool[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "amount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "createFoKOrder",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "orderId",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "amount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "createIoCOrder",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "orderId",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "amount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "hintId",
+        "type": "uint32"
+      }
+    ],
+    "name": "createLimitOrder",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "orderId",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "size",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "amount0Base",
+        "type": "uint64[]"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "priceBase",
+        "type": "uint64[]"
+      },
+      {
+        "internalType": "bool[]",
+        "name": "isAsk",
+        "type": "bool[]"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "hintId",
+        "type": "uint32[]"
+      }
+    ],
+    "name": "createLimitOrderBatch",
+    "outputs": [
+      {
+        "internalType": "uint32[]",
+        "name": "orderId",
+        "type": "uint32[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "contract IFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32",
+        "name": "limit",
+        "type": "uint32"
+      }
+    ],
+    "name": "getLimitOrders",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isAsk",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint32[]",
+            "name": "ids",
+            "type": "uint32[]"
+          },
+          {
+            "internalType": "address[]",
+            "name": "owners",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "amount0s",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "prices",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct IOrderBook.OrderQueryItem",
+        "name": "askOrders",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isAsk",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint32[]",
+            "name": "ids",
+            "type": "uint32[]"
+          },
+          {
+            "internalType": "address[]",
+            "name": "owners",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "amount0s",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "prices",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct IOrderBook.OrderQueryItem",
+        "name": "bidOrders",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32",
+        "name": "startOrderId",
+        "type": "uint32"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint32",
+        "name": "limit",
+        "type": "uint32"
+      }
+    ],
+    "name": "getPaginatedOrders",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isAsk",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint32[]",
+            "name": "ids",
+            "type": "uint32[]"
+          },
+          {
+            "internalType": "address[]",
+            "name": "owners",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "amount0s",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "prices",
+            "type": "uint256[]"
+          }
+        ],
+        "internalType": "struct IOrderBook.OrderQueryItem",
+        "name": "orderData",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "getQuoteForExactInput",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "quotedInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "quotedOutput",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isAsk",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint8",
+            "name": "orderBookId",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ISwapMultiRequest.SwapRequest[]",
+        "name": "swapRequests",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactInput",
+        "type": "uint256"
+      }
+    ],
+    "name": "getQuoteForExactInputMulti",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "quotedInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "quotedOutput",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "getQuoteForExactOutput",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "quotedInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "quotedOutput",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isAsk",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint8",
+            "name": "orderBookId",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ISwapMultiRequest.SwapRequest[]",
+        "name": "swapRequests",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactOutput",
+        "type": "uint256"
+      }
+    ],
+    "name": "getQuoteForExactOutputMulti",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "quotedInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "quotedOutput",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "debitTokenAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract IERC20Minimal",
+        "name": "debitToken",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "lighterV2TransferCallback",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint64",
+        "name": "priceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      }
+    ],
+    "name": "suggestHintId",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "bool",
+                "name": "isAsk",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint8",
+                "name": "orderBookId",
+                "type": "uint8"
+              }
+            ],
+            "internalType": "struct ISwapMultiRequest.SwapRequest[]",
+            "name": "swapRequests",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "exactInput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "minOutput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "unwrap",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct ISwapMultiRequest.MultiPathExactInputRequest",
+        "name": "multiPathExactInputRequest",
+        "type": "tuple"
+      }
+    ],
+    "name": "swapExactInputMulti",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "swappedInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swappedOutput",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minOutput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "unwrap",
+        "type": "bool"
+      }
+    ],
+    "name": "swapExactInputSingle",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "swappedInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swappedOutput",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "bool",
+                "name": "isAsk",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint8",
+                "name": "orderBookId",
+                "type": "uint8"
+              }
+            ],
+            "internalType": "struct ISwapMultiRequest.SwapRequest[]",
+            "name": "swapRequests",
+            "type": "tuple[]"
+          },
+          {
+            "internalType": "uint256",
+            "name": "exactOutput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxInput",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "recipient",
+            "type": "address"
+          },
+          {
+            "internalType": "bool",
+            "name": "unwrap",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct ISwapMultiRequest.MultiPathExactOutputRequest",
+        "name": "multiPathExactOutputRequest",
+        "type": "tuple"
+      }
+    ],
+    "name": "swapExactOutputMulti",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "swappedInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swappedOutput",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "bool",
+        "name": "isAsk",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "exactOutput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "unwrap",
+        "type": "bool"
+      }
+    ],
+    "name": "swapExactOutputSingle",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "swappedInput",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "swappedOutput",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32",
+        "name": "orderId",
+        "type": "uint32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "newAmount0Base",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint64",
+        "name": "newPriceBase",
+        "type": "uint64"
+      },
+      {
+        "internalType": "uint32",
+        "name": "hintId",
+        "type": "uint32"
+      }
+    ],
+    "name": "updateLimitOrder",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "newOrderId",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderBookId",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint8",
+        "name": "size",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "orderId",
+        "type": "uint32[]"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "newAmount0Base",
+        "type": "uint64[]"
+      },
+      {
+        "internalType": "uint64[]",
+        "name": "newPriceBase",
+        "type": "uint64[]"
+      },
+      {
+        "internalType": "uint32[]",
+        "name": "hintId",
+        "type": "uint32[]"
+      }
+    ],
+    "name": "updateLimitOrderBatch",
+    "outputs": [
+      {
+        "internalType": "uint32[]",
+        "name": "newOrderId",
+        "type": "uint32[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "isAsk",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint8",
+            "name": "orderBookId",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct ISwapMultiRequest.SwapRequest[]",
+        "name": "swapRequests",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "validateMultiPathSwap",
+    "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "weth9",
+    "outputs": [
+      {
+        "internalType": "contract IWETH9",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -80,6 +80,7 @@ import { Algebra } from './algebra/algebra';
 import { QuickPerps } from './quick-perps/quick-perps';
 import { NomiswapV2 } from './uniswap-v2/nomiswap-v2';
 import { Dexalot } from './dexalot/dexalot';
+import { LighterV2 } from './lighter-v2/lighter-v2';
 
 const LegacyDexes = [
   CurveV2,
@@ -157,6 +158,7 @@ const Dexes = [
   SwaapV2,
   QuickPerps,
   NomiswapV2,
+  LighterV2,
 ];
 
 export type LegacyDexConstructor = new (dexHelper: IDexHelper) => IDexTxBuilder<

--- a/src/dex/lighter-v2/config.ts
+++ b/src/dex/lighter-v2/config.ts
@@ -1,0 +1,18 @@
+import { DexParams } from './types';
+import { DexConfigMap, AdapterMappings } from '../../types';
+import { Network, SwapSide } from '../../constants';
+
+export const LighterV2Config: DexConfigMap<DexParams> = {
+  LighterV2: {
+    [Network.ARBITRUM]: {
+      factory: '0xDa66c2ADFAF2c524283Ff9e72Ef7702a254C9127',
+      router: '0x86D4Ef07492605D30124E25B1E08E3C489D39807',
+    },
+  },
+};
+
+export const Adapters: Record<number, AdapterMappings> = {
+  // TODO: add adapters for each chain
+  // This is an example to copy
+  [Network.MAINNET]: { [SwapSide.SELL]: [{ name: '', index: 0 }] },
+};

--- a/src/dex/lighter-v2/fallback.ts
+++ b/src/dex/lighter-v2/fallback.ts
@@ -1,0 +1,129 @@
+import { BigNumber, BigNumberish } from 'ethers';
+
+export const fixedSize = (s: string, len: number) => {
+  if (s.length > len)
+    throw new Error(`given size (${s.length}) is too big to fit in ${len}`);
+  return s.padStart(len, '0');
+};
+
+// numberToCallData returns a hex-encoded number, without the `0x` prefix, with desired number of bytes
+function numberToCallData(amount: BigNumberish, numBytes: number): string {
+  return fixedSize(
+    BigNumber.from(amount).toHexString().replace('0x', ''),
+    numBytes * 2,
+  );
+}
+
+class MantissaFormattedNumber {
+  type: number;
+  exponent: number;
+  mantissa: BigNumber;
+
+  private constructor(exponent: number, mantissa: BigNumber, type: number) {
+    this.type = type;
+    this.exponent = exponent;
+    this.mantissa = mantissa;
+  }
+
+  static from(_value: BigNumberish, _type: number): MantissaFormattedNumber {
+    const value = BigNumber.from(_value);
+    let PRECISION = BigNumber.from('2').pow(8 * (2 * _type + 3));
+    let MAX_EXPONENT = 60;
+
+    if (value == BigNumber.from(0))
+      return new MantissaFormattedNumber(0, BigNumber.from(0), 0);
+
+    let exponent = 0;
+    let mantissa = value;
+
+    while (mantissa.gte(PRECISION)) {
+      mantissa = mantissa.div(10);
+      exponent++;
+    }
+
+    if (exponent > MAX_EXPONENT) {
+      throw 'exponent too big';
+    }
+
+    // make the mantissa smaller if the precision is the same
+    while (mantissa.mod(10).eq(0) && exponent < MAX_EXPONENT) {
+      mantissa = mantissa.div(10);
+      exponent++;
+    }
+
+    // Represent the mantissa with the smallest possible type
+    let type = _type;
+    if (type > 1 && mantissa.lt(BigNumber.from('2').pow(40))) type = 1;
+    if (type > 0 && mantissa.lt(BigNumber.from('2').pow(24))) type = 0;
+
+    return new MantissaFormattedNumber(exponent, mantissa, type);
+  }
+
+  getHexString(): string {
+    let hexString = numberToCallData(this.type * 64 + this.exponent, 1);
+    hexString += numberToCallData(this.mantissa, 2 * this.type + 3);
+    return hexString;
+  }
+}
+
+export function getSwapExactInputSingleFallbackData(
+  orderBookId: number,
+  isAsk: boolean,
+  exactInput: BigNumberish,
+  minOutput: BigNumberish,
+  unwrap: boolean,
+) {
+  const ExactInputSingleFallbackStart = 8;
+
+  let data = '0x';
+  const recipientIsMsgSender = true;
+  data += BigNumber.from(
+    ExactInputSingleFallbackStart +
+      Number(unwrap) +
+      2 * Number(recipientIsMsgSender),
+  )
+    .toHexString()
+    .replace('0x', '');
+
+  // orderBookId & isAsk
+  if (orderBookId > 127) {
+    throw `orderBookId too big for compressed form ${orderBookId}`;
+  }
+  const compressed = BigNumber.from(orderBookId).toNumber() + (isAsk ? 128 : 0);
+  data += numberToCallData(compressed, 1);
+
+  data += MantissaFormattedNumber.from(exactInput, 2).getHexString();
+  data += MantissaFormattedNumber.from(minOutput, 2).getHexString();
+  return data;
+}
+
+export function getSwapExactOutputSingleFallbackData(
+  orderBookId: number,
+  isAsk: boolean,
+  exactOutput: BigNumberish,
+  maxInput: BigNumberish,
+  unwrap: boolean,
+) {
+  const ExactOutputSingleFallbackStart = 12;
+
+  let data = '0x';
+  const recipientIsMsgSender = true;
+  data += BigNumber.from(
+    ExactOutputSingleFallbackStart +
+      Number(unwrap) +
+      2 * Number(recipientIsMsgSender),
+  )
+    .toHexString()
+    .replace('0x', '');
+
+  // orderBookId & isAsk
+  if (orderBookId > 127) {
+    throw `orderBookId too big for compressed form ${orderBookId}`;
+  }
+  const compressed = BigNumber.from(orderBookId).toNumber() + (isAsk ? 128 : 0);
+  data += numberToCallData(compressed, 1);
+
+  data += MantissaFormattedNumber.from(exactOutput, 2).getHexString();
+  data += MantissaFormattedNumber.from(maxInput, 2).getHexString();
+  return data;
+}

--- a/src/dex/lighter-v2/lighter-v2-e2e.test.ts
+++ b/src/dex/lighter-v2/lighter-v2-e2e.test.ts
@@ -1,0 +1,107 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import {
+  Tokens,
+  Holders,
+  NativeTokenSymbols,
+} from '../../../tests/constants-e2e';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+import { parseUnits } from 'ethers/lib/utils';
+
+function testForNetwork(
+  network: Network,
+  dexKey: string,
+  tokenASymbol: string,
+  tokenBSymbol: string,
+  tokenAAmount: string,
+  tokenBAmount: string,
+) {
+  const provider = new StaticJsonRpcProvider(
+    generateConfig(network).privateHttpProvider,
+    network,
+  );
+  const tokens = Tokens[network];
+  const holders = Holders[network];
+
+  // TODO: Add any direct swap contractMethod name if it exists
+  const sideToContractMethods = new Map([
+    [
+      SwapSide.SELL,
+      [
+        ContractMethod.simpleSwap,
+        // ContractMethod.multiSwap,
+        // ContractMethod.megaSwap,
+      ],
+    ],
+    [
+      SwapSide.BUY,
+      [
+        ContractMethod.simpleBuy,
+        // ContractMethod.buy
+      ],
+    ],
+  ]);
+
+  describe(`${network}`, () => {
+    sideToContractMethods.forEach((contractMethods, side) =>
+      describe(`${side}`, () => {
+        contractMethods.forEach((contractMethod: ContractMethod) => {
+          describe(`${contractMethod}`, () => {
+            it(`${tokenASymbol} -> ${tokenBSymbol}`, async () => {
+              await testE2E(
+                tokens[tokenASymbol],
+                tokens[tokenBSymbol],
+                holders[tokenASymbol],
+                side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+            it(`${tokenBSymbol} -> ${tokenASymbol}`, async () => {
+              await testE2E(
+                tokens[tokenBSymbol],
+                tokens[tokenASymbol],
+                holders[tokenBSymbol],
+                side === SwapSide.SELL ? tokenBAmount : tokenAAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+          });
+        });
+      }),
+    );
+  });
+}
+
+describe('LighterV2 E2E', () => {
+  const dexKey = 'LighterV2';
+
+  describe('Arbitrum', () => {
+    const network = Network.ARBITRUM;
+    const native: string = NativeTokenSymbols[network];
+    const weth: string = 'WETH';
+    const usdc: string = 'USDCe';
+
+    const wethAmount: string = parseUnits('1.0', 18).toString();
+    const usdcAmount: string = parseUnits('1900.0', 6).toString();
+
+    // WETH <-> USDC.e
+    testForNetwork(network, dexKey, weth, usdc, wethAmount, usdcAmount);
+
+    // ETH <-> USDC.e
+    testForNetwork(network, dexKey, native, usdc, wethAmount, usdcAmount);
+  });
+});

--- a/src/dex/lighter-v2/lighter-v2-events.test.ts
+++ b/src/dex/lighter-v2/lighter-v2-events.test.ts
@@ -1,0 +1,118 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+import { LighterV2EventPool } from './lighter-v2-pool';
+import { Network } from '../../constants';
+import { Address } from '../../types';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { testEventSubscriber } from '../../../tests/utils-events';
+import { PoolState } from './types';
+import { DeepReadonly } from 'ts-essentials';
+import { BI_POWS } from '../../bigint-constants';
+import { Tokens } from '../../../tests/constants-e2e';
+
+jest.setTimeout(50 * 1000);
+
+async function fetchPoolState(
+  lighterV2Pools: LighterV2EventPool,
+  blockNumber: number,
+  poolAddress: string,
+): Promise<DeepReadonly<PoolState>> {
+  return lighterV2Pools.generateState(blockNumber);
+}
+
+// eventName -> blockNumbers
+type EventMappings = Record<string, number[]>;
+
+const WETHUSDCe: EventMappings = {
+  CreateOrder: [
+    150021042, 150021278, 150021278, 150021516, 150021516, 150021750, 150021750,
+    150021985, 150021985, 150022217, 150022217, 150022458, 150022458, 150022692,
+    150022692, 150022926, 150022926, 150023163, 150023163, 150023383, 150023383,
+    150023611, 150023611, 150023859, 150023859, 150024099, 150024099, 150024338,
+    150024338, 150024576, 150024576, 150024811, 150024811, 150025049, 150025049,
+    150025306, 150025306, 150025549, 150025549, 150025786, 150025786, 150026020,
+    150026020, 150026258, 150026258, 150026497, 150026497, 150026748, 150026748,
+    150026989, 150026989, 150027232, 150027232, 150027468, 150027468, 150027703,
+    150027703, 150027943, 150027943, 150028182, 150028427, 150028667, 150028667,
+    150028904, 150028904, 150029141, 150029141, 150029380, 150029380, 150029619,
+    150029619, 150029869, 150029869, 150030108, 150030108, 150030347, 150030347,
+    150030588, 150030588, 150030829, 150030829,
+  ],
+  CancelLimitOrder: [
+    150021103, 150021103, 150021103, 150021175, 150021314, 150021338, 150021525,
+    150021676, 150021782, 150021997, 150022169, 150022265, 150022468, 150022738,
+    150022740, 150022918, 150023026, 150023030, 150023144, 150023208, 150023292,
+    150023409, 150023662, 150023701, 150023830, 150023830, 150023908, 150023912,
+    150024031, 150024125, 150024425, 150024601, 150024609, 150024860, 150025080,
+    150025109, 150025285, 150025332, 150025481, 150025570, 150025573, 150025573,
+    150025655, 150025834, 150026053, 150026199, 150026272, 150026411, 150026557,
+    150026631, 150026773, 150026822, 150027005, 150027108, 150027281, 150027331,
+    150027534, 150027757, 150027938, 150027968, 150028272, 150028588, 150028654,
+    150028656, 150028684, 150028891, 150028914, 150029148, 150029274, 150029411,
+    150029517, 150029523, 150029600, 150029656, 150029885, 150029913, 150029953,
+    150030137, 150030239, 150030375, 150030615, 150030669, 150030836,
+  ],
+  PartialSwap: [
+    151268471, 151269071, 151272596, 151325725, 151352760, 151406799, 151503260,
+    151602829, 151707841, 151708337, 151855350, 151856622, 151898798, 151924020,
+    151943598, 152180013, 152180466,
+  ],
+  FullSwaps: [151707487, 151143491],
+};
+
+describe('LighterV2 EventPool Arbitrum', function () {
+  const dexKey = 'LighterV2';
+  const network = Network.ARBITRUM;
+  const dexHelper = new DummyDexHelper(network);
+  const logger = dexHelper.getLogger(dexKey);
+  let lighterV2Pool: LighterV2EventPool;
+
+  // poolAddress -> EventMappings
+  const eventsToTest: Record<Address, EventMappings> = {
+    '0x33a5A405B97C6e77f3cA07a55FeF08454F5550bd': WETHUSDCe,
+  };
+
+  beforeEach(async () => {
+    lighterV2Pool = new LighterV2EventPool(
+      dexKey,
+      network,
+      dexHelper,
+      logger,
+      '0x33a5A405B97C6e77f3cA07a55FeF08454F5550bd',
+      0,
+      Tokens[Network.ARBITRUM]['WETH'],
+      Tokens[Network.ARBITRUM]['USDCe'],
+      BI_POWS[12],
+      BI_POWS[4],
+    );
+  });
+
+  Object.entries(eventsToTest).forEach(
+    ([poolAddress, events]: [string, EventMappings]) => {
+      describe(`Events for ${poolAddress}`, () => {
+        Object.entries(events).forEach(
+          ([eventName, blockNumbers]: [string, number[]]) => {
+            describe(`${eventName}`, () => {
+              blockNumbers.forEach((blockNumber: number) => {
+                it(`State after ${blockNumber}`, async function () {
+                  await testEventSubscriber(
+                    lighterV2Pool,
+                    lighterV2Pool.addressesSubscribed,
+                    (_blockNumber: number) =>
+                      fetchPoolState(lighterV2Pool, _blockNumber, poolAddress),
+                    blockNumber,
+                    `${dexKey}_${poolAddress}`,
+                    dexHelper.provider,
+                  );
+                });
+              });
+            });
+          },
+        );
+      });
+    },
+  );
+});

--- a/src/dex/lighter-v2/lighter-v2-integration.test.ts
+++ b/src/dex/lighter-v2/lighter-v2-integration.test.ts
@@ -1,0 +1,278 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+import { Interface, Result } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network } from '../../constants';
+import { BI_POWS } from '../../bigint-constants';
+import { LighterV2 } from './lighter-v2';
+import { checkPoolsLiquidity } from '../../../tests/utils';
+import { Tokens } from '../../../tests/constants-e2e';
+import { SwapSide } from '@paraswap/core';
+
+function getReaderCalldata(
+  exchangeAddress: string,
+  readerIface: Interface,
+  amounts: bigint[],
+  funcName: string,
+  orderBookId: number,
+  isAsk: boolean,
+) {
+  return amounts.map(amount => ({
+    target: exchangeAddress,
+    callData: readerIface.encodeFunctionData(funcName, [
+      orderBookId,
+      isAsk,
+      amount,
+    ]),
+  }));
+}
+
+// only returns quotedOutput
+function decodeReaderResult(
+  results: Result,
+  readerIface: Interface,
+  funcName: string,
+) {
+  return results.map(result => {
+    const parsed = readerIface.decodeFunctionResult(funcName, result);
+    if (funcName == 'getQuoteForExactInput') {
+      return BigInt(parsed[1]._hex);
+    } else {
+      return BigInt(parsed[0]._hex);
+    }
+  });
+}
+
+async function checkOnChainPricing(
+  lighterV2: LighterV2,
+  blockNumber: number,
+  prices: bigint[],
+  amounts: bigint[],
+  orderBookId: number,
+  isAsk: boolean,
+  isExactInput: boolean,
+) {
+  const exchangeAddress = lighterV2.config.router;
+  const readerIface = lighterV2.routerContract.interface;
+
+  const funcName = isExactInput
+    ? 'getQuoteForExactInput'
+    : 'getQuoteForExactOutput';
+
+  const readerCallData = getReaderCalldata(
+    exchangeAddress,
+    readerIface,
+    amounts.slice(1),
+    funcName,
+    orderBookId,
+    isAsk,
+  );
+
+  const readerResult = (
+    await lighterV2.dexHelper.multiContract.methods
+      .aggregate(readerCallData)
+      .call({}, blockNumber)
+  ).returnData;
+
+  const expectedPrices = [0n].concat(
+    decodeReaderResult(readerResult, readerIface, funcName),
+  );
+
+  expect(prices).toEqual(expectedPrices);
+}
+
+async function testPricingOnNetwork(
+  lighterV2: LighterV2,
+  network: Network,
+  dexKey: string,
+  blockNumber: number,
+  srcTokenSymbol: string,
+  destTokenSymbol: string,
+  side: SwapSide,
+  amounts: bigint[],
+) {
+  const networkTokens = Tokens[network];
+
+  const pools = await lighterV2.getPoolIdentifiers(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    side,
+    blockNumber,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Identifiers: `,
+    pools,
+  );
+
+  // there should be 1 pool only and it should be defined
+  expect(pools.length).toEqual(1);
+  const pool = lighterV2.getPoolByIdentifier(pools[0]);
+  expect(pool).not.toBeUndefined();
+
+  const poolPrices = await lighterV2.getPricesVolume(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    amounts,
+    side,
+    blockNumber,
+    pools,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Prices: `,
+    poolPrices,
+  );
+
+  expect(poolPrices).not.toBeNull();
+  // if (lighterV2.hasConstantPriceLargeAmounts) {
+  //   checkConstantPoolPrices(poolPrices!, amounts, dexKey);
+  // } else {
+  //   checkPoolPrices(poolPrices!, amounts, side, dexKey);
+  // }
+
+  // Check if onchain pricing equals to calculated ones
+  await checkOnChainPricing(
+    lighterV2,
+    blockNumber,
+    poolPrices![0].prices,
+    amounts,
+    pool!.pool.orderBookId,
+    pool!.isAsk,
+    side == SwapSide.SELL,
+  );
+}
+
+describe('LighterV2', function () {
+  const dexKey = 'LighterV2';
+  let blockNumber: number;
+  let lighterV2: LighterV2;
+
+  describe('ARBITRUM', () => {
+    const network = Network.ARBITRUM;
+    const dexHelper = new DummyDexHelper(network);
+
+    const tokens = Tokens[network];
+    const weth = 'WETH';
+    const usdc = 'USDCe';
+
+    const amountsWETH = [
+      0n,
+      11n * BI_POWS[tokens[weth].decimals - 2],
+      212n * BI_POWS[tokens[weth].decimals - 3],
+      3123n * BI_POWS[tokens[weth].decimals - 4],
+      41234n * BI_POWS[tokens[weth].decimals - 5],
+      512345n * BI_POWS[tokens[weth].decimals - 6],
+      6123456n * BI_POWS[tokens[weth].decimals - 7],
+      71234567n * BI_POWS[tokens[weth].decimals - 8],
+      812345678n * BI_POWS[tokens[weth].decimals - 9],
+      9123456789n * BI_POWS[tokens[weth].decimals - 10],
+      101234567890n * BI_POWS[tokens[weth].decimals - 11],
+    ];
+
+    const amountsUSDC = [
+      0n,
+      100n * BI_POWS[tokens[usdc].decimals],
+      200n * BI_POWS[tokens[usdc].decimals],
+      300n * BI_POWS[tokens[usdc].decimals],
+      400n * BI_POWS[tokens[usdc].decimals],
+      500n * BI_POWS[tokens[usdc].decimals],
+      600n * BI_POWS[tokens[usdc].decimals],
+      7001n * BI_POWS[tokens[usdc].decimals - 1],
+      80012n * BI_POWS[tokens[usdc].decimals - 2],
+      900123n * BI_POWS[tokens[usdc].decimals - 3],
+      10001234n * BI_POWS[tokens[usdc].decimals - 4],
+    ];
+
+    beforeAll(async () => {
+      blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      lighterV2 = new LighterV2(network, dexKey, dexHelper);
+      if (lighterV2.initializePricing) {
+        await lighterV2.initializePricing(blockNumber);
+      }
+    });
+
+    it('getPoolIdentifiers and getPricesVolume SELL WETH for USDC', async function () {
+      await testPricingOnNetwork(
+        lighterV2,
+        network,
+        dexKey,
+        blockNumber,
+        weth,
+        usdc,
+        SwapSide.SELL,
+        amountsWETH,
+      );
+    });
+    it('getPoolIdentifiers and getPricesVolume SELL USDC for WETH', async function () {
+      await testPricingOnNetwork(
+        lighterV2,
+        network,
+        dexKey,
+        blockNumber,
+        usdc,
+        weth,
+        SwapSide.SELL,
+        amountsUSDC,
+      );
+    });
+
+    it('getPoolIdentifiers and getPricesVolume BUY USDC with WETH', async function () {
+      await testPricingOnNetwork(
+        lighterV2,
+        network,
+        dexKey,
+        blockNumber,
+        weth,
+        usdc,
+        SwapSide.BUY,
+        amountsUSDC,
+      );
+    });
+
+    it('getPoolIdentifiers and getPricesVolume BUY WETH with USDC', async function () {
+      await testPricingOnNetwork(
+        lighterV2,
+        network,
+        dexKey,
+        blockNumber,
+        usdc,
+        weth,
+        SwapSide.BUY,
+        amountsWETH,
+      );
+    });
+
+    describe('getTopPoolsForToken', () => {
+      let newLighterV2: LighterV2;
+
+      beforeAll(async () => {
+        // We have to check without calling initializePricing, because
+        // pool-tracker is not calling that function
+        newLighterV2 = new LighterV2(network, dexKey, dexHelper);
+        if (newLighterV2.updatePoolState) {
+          await newLighterV2.updatePoolState();
+        }
+      });
+
+      for (const token of [weth, usdc]) {
+        it(`getTopPoolsForToken ${token}`, async function () {
+          const poolLiquidity = await newLighterV2.getTopPoolsForToken(
+            tokens[token].address,
+            10,
+          );
+          console.log(`${token} Top Pools:`, poolLiquidity);
+
+          if (!newLighterV2.hasConstantPriceLargeAmounts) {
+            checkPoolsLiquidity(
+              poolLiquidity,
+              Tokens[network][token].address,
+              dexKey,
+            );
+          }
+        });
+      }
+    });
+  });
+});

--- a/src/dex/lighter-v2/lighter-v2-pool.ts
+++ b/src/dex/lighter-v2/lighter-v2-pool.ts
@@ -1,0 +1,319 @@
+/* eslint-disable no-console */
+import { Interface } from '@ethersproject/abi';
+import { DeepReadonly } from 'ts-essentials';
+import { Address, Log, Logger, Token } from '../../types';
+import { bigIntify, catchParseLogError } from '../../utils';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { LimitOrder, OrderBook, PoolState } from './types';
+import LighterV2OrderBookABI from '../../abi/lighter-v2/OrderBook.json';
+import { ethers } from 'ethers';
+import { BI_POWS } from '../../bigint-constants';
+
+export class LighterV2EventPool extends StatefulEventSubscriber<PoolState> {
+  handlers: {
+    [event: string]: (
+      event: any,
+      state: DeepReadonly<PoolState>,
+      log: Readonly<Log>,
+    ) => DeepReadonly<PoolState> | null;
+  } = {};
+
+  logDecoder: (log: Log) => any;
+
+  addressesSubscribed: string[];
+
+  readonly orderBookInterface = new Interface(LighterV2OrderBookABI);
+  readonly orderBookContract: ethers.Contract;
+
+  constructor(
+    readonly parentName: string,
+    protected network: number,
+    protected dexHelper: IDexHelper,
+    logger: Logger,
+    readonly orderBookAddress: Address,
+    readonly orderBookId: number,
+    readonly token0: Token,
+    readonly token1: Token,
+    readonly sizeTick: bigint,
+    readonly priceTick: bigint,
+  ) {
+    super(parentName, `${orderBookAddress}`, dexHelper, logger);
+    this.logDecoder = (log: Log) => this.orderBookInterface.parseLog(log);
+    this.addressesSubscribed = [orderBookAddress];
+
+    this.orderBookContract = new ethers.Contract(
+      this.orderBookAddress,
+      this.orderBookInterface,
+      this.dexHelper.provider,
+    );
+
+    // Add handlers
+    this.handlers['CreateOrder'] = this.handleCreateOrder.bind(this);
+    this.handlers['CancelLimitOrder'] = this.handleCancelLimitOrder.bind(this);
+    this.handlers['Swap'] = this.handleSwap.bind(this);
+  }
+
+  async getOrders(blockNumber: number): Promise<OrderBook> {
+    const batchSize = 1000;
+
+    const paramsCalldata = [
+      {
+        target: this.orderBookAddress,
+        callData: this.orderBookContract.interface.encodeFunctionData(
+          'getPaginatedOrders',
+          [0, true, batchSize],
+        ),
+      },
+      {
+        target: this.orderBookAddress,
+        callData: this.orderBookContract.interface.encodeFunctionData(
+          'getPaginatedOrders',
+          [0, false, batchSize],
+        ),
+      },
+    ];
+
+    const paramsResults: ethers.utils.BytesLike[] = (
+      await this.dexHelper.multiContract.methods
+        .aggregate(paramsCalldata)
+        .call({}, blockNumber)
+    ).returnData;
+
+    const [sortedAsks, sortedBids] = paramsResults
+      .map(paramsResult => {
+        return this.orderBookContract.interface.decodeFunctionResult(
+          'getPaginatedOrders',
+          paramsResult,
+        );
+      })
+      .map(rawOrders => {
+        const orders = [];
+        const { isAsk, ids, amount0s, prices } = rawOrders[0];
+        for (let i = 0; i < batchSize; i += 1) {
+          if (ids[i] == 0) {
+            break;
+          }
+          orders.push({
+            isAsk: isAsk,
+            id: ids[i],
+            amount0: bigIntify(amount0s[i]),
+            price: bigIntify(prices[i]),
+          });
+        }
+
+        return orders;
+      });
+
+    return { sortedAsks, sortedBids };
+  }
+
+  /**
+   * The function is called every time any of the subscribed
+   * addresses release log. The function accepts the current
+   * state, updates the state according to the log, and returns
+   * the updated state.
+   * @param state - Current state of event subscriber
+   * @param log - Log released by one of the subscribed addresses
+   * @returns Updates state of the event subscriber after the log
+   */
+  protected processLog(
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<PoolState> | null {
+    try {
+      const event = this.logDecoder(log);
+      if (event.name in this.handlers) {
+        return this.handlers[event.name](event, state, log);
+      }
+    } catch (e) {
+      catchParseLogError(e, this.logger);
+    }
+
+    return null;
+  }
+
+  findOrder(id: number, state: DeepReadonly<PoolState>) {
+    const askIndex = state.orderBook.sortedAsks.findIndex(o => o.id === id);
+    const bidIndex = state.orderBook.sortedBids.findIndex(o => o.id === id);
+
+    if (askIndex != -1) {
+      return { isAsk: true, index: askIndex };
+    } else if (bidIndex != -1) {
+      return { isAsk: false, index: bidIndex };
+    } else {
+      return null;
+    }
+  }
+
+  async initState(blockNumber: number): Promise<DeepReadonly<PoolState>> {
+    const state = await this.generateState(blockNumber);
+    this.setState(state, blockNumber);
+    return state;
+  }
+
+  /**
+   * The function generates state using on-chain calls. This
+   * function is called to regenerate state if the event based
+   * system fails to fetch events and the local state is no
+   * more correct.
+   * @param blockNumber - Blocknumber for which the state should
+   * should be generated
+   * @returns state of the event subscriber at blocknumber
+   */
+  async generateState(blockNumber: number): Promise<DeepReadonly<PoolState>> {
+    const orderBook = await this.getOrders(blockNumber);
+
+    return {
+      sizeTick: this.sizeTick,
+      priceTick: this.priceTick,
+      token0: this.token0,
+      token1: this.token1,
+      pool: this.orderBookAddress,
+      orderBook,
+    };
+  }
+
+  handleCreateOrder(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<PoolState> | null {
+    const base = bigIntify(event.args.amount0Base);
+    const order: LimitOrder = {
+      id: event.args.id,
+      amount0: base * state.sizeTick,
+      price: bigIntify(event.args.priceBase) * state.priceTick,
+      isAsk: event.args.isAsk,
+    };
+
+    const sortedAsks = [...state.orderBook.sortedAsks];
+    const sortedBids = [...state.orderBook.sortedBids];
+
+    if (order.isAsk) {
+      sortedAsks.push(order);
+      sortedAsks.sort((a, b) => {
+        const priceDifference = a.price - b.price;
+        if (priceDifference == bigIntify(0)) {
+          return Number(a.id - b.id); // lower id comes first
+        } else {
+          return priceDifference > bigIntify(0) ? +1 : -1;
+        }
+      });
+    } else {
+      sortedBids.push(order);
+      sortedBids.sort((a, b) => {
+        const priceDifference = b.price - a.price;
+        if (priceDifference == bigIntify(0)) {
+          return Number(a.id - b.id); // lower id comes first
+        } else {
+          return priceDifference > bigIntify(0) ? +1 : -1;
+        }
+      });
+    }
+
+    return {
+      ...state,
+      orderBook: {
+        sortedAsks: sortedAsks,
+        sortedBids: sortedBids,
+      },
+    };
+  }
+
+  handleCancelLimitOrder(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<PoolState> | null {
+    const id = event.args.id;
+    const sortedAsks = [...state.orderBook.sortedAsks];
+    const sortedBids = [...state.orderBook.sortedBids];
+
+    const order = this.findOrder(id, state);
+
+    if (order == null) {
+      console.error(`Could not find order with id ${id} to be canceled`);
+      return null;
+    }
+
+    if (order.isAsk) {
+      sortedAsks.splice(order.index, 1);
+    } else {
+      sortedBids.splice(order.index, 1);
+    }
+
+    return {
+      ...state,
+      orderBook: {
+        sortedAsks: sortedAsks,
+        sortedBids: sortedBids,
+      },
+    };
+  }
+
+  handleSwap(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<PoolState> | null {
+    const askOrder = this.findOrder(event.args.askId, state);
+    const bidOrder = this.findOrder(event.args.bidId, state);
+    const amount0 = bigIntify(event.args.amount0);
+
+    const sortedAsks = [...state.orderBook.sortedAsks];
+    const sortedBids = [...state.orderBook.sortedBids];
+
+    if (askOrder) {
+      const index = askOrder.index;
+      if (sortedAsks[index].amount0 === amount0) {
+        sortedAsks.splice(askOrder.index, 1);
+      } else {
+        sortedAsks[index] = {
+          ...sortedAsks[index],
+          amount0: sortedAsks[index].amount0 - amount0,
+        };
+      }
+    } else if (bidOrder) {
+      const index = bidOrder.index;
+      if (sortedBids[index].amount0 === amount0) {
+        sortedBids.splice(index, 1);
+      } else {
+        sortedBids[index] = {
+          ...sortedBids[index],
+          amount0: sortedBids[index].amount0 - amount0,
+        };
+      }
+    } else {
+      console.error(
+        `Could not find order with askId:${event.args.askId} or bidId:${event.args.bidId} to be canceled`,
+      );
+    }
+
+    return {
+      ...state,
+      orderBook: {
+        sortedAsks: sortedAsks,
+        sortedBids: sortedBids,
+      },
+    };
+  }
+
+  getLockedAssets(state: DeepReadonly<PoolState>): {
+    token0Amount: bigint;
+    token1Amount: bigint;
+  } {
+    let token0Amount = 0n;
+    let token1Amount = 0n;
+
+    state.orderBook.sortedAsks.forEach(order => {
+      token0Amount += order.amount0;
+    });
+    state.orderBook.sortedBids.forEach(order => {
+      token1Amount +=
+        (order.amount0 * order.price) / BI_POWS[state.token0.decimals];
+    });
+
+    return { token0Amount, token1Amount };
+  }
+}

--- a/src/dex/lighter-v2/lighter-v2-price-oracle.test.ts
+++ b/src/dex/lighter-v2/lighter-v2-price-oracle.test.ts
@@ -1,0 +1,40 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+import { DummyDexHelper } from '../../dex-helper';
+import { LighterPriceOracle } from './price-oracle';
+import { LighterV2 } from './lighter-v2';
+import { LighterV2Config } from './config';
+
+describe('LighterV2 Price Oracle', function () {
+  const networks = Object.keys(LighterV2Config.LighterV2);
+
+  // for each network, create `lighterV2` and `initializePricing`
+  // lighterV2 should initialize all the tokens which are used in at least one pair
+  // the test checks that price oracle returns a valid price for all tokens
+  networks.forEach(networkStr => {
+    const network = parseInt(networkStr);
+    it(network.toString(), async () => {
+      const dexKey = 'LighterV2';
+      const dexHelper = new DummyDexHelper(network);
+      const priceOracle = new LighterPriceOracle(dexHelper.httpRequest);
+      const lighterV2 = new LighterV2(network, dexKey, dexHelper);
+
+      const blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      await lighterV2.initializePricing(blockNumber);
+      const tokens = [...lighterV2.tokens.values()];
+
+      for (const token of tokens) {
+        const price = await priceOracle.getTokenPrice(token.symbol);
+        console.log(
+          `${network.toString()} fetched price ${price} for ${token.symbol} ${
+            token.address
+          }`,
+        );
+        expect(price).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/dex/lighter-v2/lighter-v2.ts
+++ b/src/dex/lighter-v2/lighter-v2.ts
@@ -1,0 +1,541 @@
+import { AsyncOrSync, DeepReadonly } from 'ts-essentials';
+import {
+  AdapterExchangeParam,
+  Address,
+  ExchangePrices,
+  Logger,
+  PoolLiquidity,
+  PoolPrices,
+  SimpleExchangeParam,
+  Token,
+} from '../../types';
+import { ETHER_ADDRESS, Network, SwapSide } from '../../constants';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+import { bigIntify, getDexKeysWithNetwork } from '../../utils';
+import { IDex } from '../../dex/idex';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { DexParams, LighterV2Data, LimitOrder, PoolState } from './types';
+import { SimpleExchange } from '../simple-exchange';
+import { Adapters, LighterV2Config } from './config';
+import { LighterV2EventPool } from './lighter-v2-pool';
+import { ethers } from 'ethers';
+import { Interface } from '@ethersproject/abi';
+import LighterV2FactoryABI from '../../abi/lighter-v2/Factory.json';
+import LighterV2RouterABI from '../../abi/lighter-v2/Router.json';
+import ERC20ABI from '../../abi/ERC20.abi.json';
+import { BI_POWS } from '../../bigint-constants';
+import {
+  getSwapExactInputSingleFallbackData,
+  getSwapExactOutputSingleFallbackData,
+} from './fallback';
+import { LighterPriceOracle } from './price-oracle';
+
+export class LighterV2 extends SimpleExchange implements IDex<LighterV2Data> {
+  readonly hasConstantPriceLargeAmounts = false;
+  readonly needWrapNative = false;
+
+  readonly isFeeOnTransferSupported = false;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(LighterV2Config);
+
+  logger: Logger;
+
+  readonly ERC20Interface = new Interface(ERC20ABI);
+  readonly routerContract: ethers.Contract;
+  readonly factoryContract: ethers.Contract;
+  readonly config: DexParams;
+
+  tokens = new Map<string, Token>();
+
+  allSupportedOrderBooks = new Map<
+    string,
+    { pool: LighterV2EventPool; isAsk: boolean }
+  >();
+
+  constructor(
+    readonly network: Network,
+    readonly dexKey: string,
+    readonly dexHelper: IDexHelper,
+    protected adapters = Adapters[network] || {}, // TODO: add any additional optional params to support other fork DEXes
+
+    // consider passing an external priceOracle so different chain integrations will share the same price oracle cache
+    readonly priceOracle: LighterPriceOracle = new LighterPriceOracle(
+      dexHelper.httpRequest,
+    ),
+  ) {
+    super(dexHelper, dexKey);
+    this.logger = dexHelper.getLogger(dexKey);
+    this.config = LighterV2Config.LighterV2[network];
+
+    this.factoryContract = new ethers.Contract(
+      this.config.factory,
+      new Interface(LighterV2FactoryABI),
+      this.dexHelper.provider,
+    );
+
+    this.routerContract = new ethers.Contract(
+      this.config.router,
+      new Interface(LighterV2RouterABI),
+      this.dexHelper.provider,
+    );
+  }
+
+  getTokenFromAddress(address: Address): Token {
+    const token = this.tokens.get(address.toLowerCase());
+    if (token == null) {
+      throw `can't find token with address ${address} on ${this.network}`;
+    }
+    return token;
+  }
+
+  async initializeTokens(tokenAddresses: string[]) {
+    // unique & lowercase
+    tokenAddresses = [...new Set(tokenAddresses)].map(address =>
+      address.toLowerCase(),
+    );
+
+    // set type of calldata
+    const paramsCalldata: {
+      target: string;
+      callData: string;
+    }[] = [];
+
+    // add 2 calls for each token, first for symbol and decimals
+    tokenAddresses.forEach(address => {
+      paramsCalldata.push(
+        {
+          target: address,
+          callData: this.ERC20Interface.encodeFunctionData('symbol'),
+        },
+        {
+          target: address,
+          callData: this.ERC20Interface.encodeFunctionData('decimals'),
+        },
+      );
+    });
+
+    const paramsResults: ethers.utils.BytesLike[] = (
+      await this.dexHelper.multiContract.methods
+        .aggregate(paramsCalldata)
+        .call({})
+    ).returnData;
+
+    for (let i = 0; i < paramsResults.length; i += 2) {
+      const symbol = this.ERC20Interface.decodeFunctionResult(
+        'symbol',
+        paramsResults[i],
+      );
+      const decimals = this.ERC20Interface.decodeFunctionResult(
+        'decimals',
+        paramsResults[i + 1],
+      );
+      const tokenAddress = tokenAddresses[i / 2];
+
+      this.tokens.set(tokenAddress, {
+        address: tokenAddress,
+        symbol: String(symbol),
+        decimals: Number(decimals),
+      });
+    }
+  }
+
+  // Initialize pricing is called once in the start of
+  // pricing service. It is intended to setup the integration
+  // for pricing requests. It is optional for a DEX to
+  // implement this function
+  async initializePricing(blockNumber: number) {
+    const allOrderBooks =
+      await this.factoryContract.callStatic.getAllOrderBooksDetails();
+
+    // make sure all tokens are loaded
+    let tokens = [];
+    for (const orderBook of allOrderBooks) {
+      tokens.push(orderBook.token0);
+      tokens.push(orderBook.token1);
+    }
+    await this.initializeTokens(tokens);
+
+    let promises = [];
+    for (const orderBook of allOrderBooks) {
+      if (
+        this.allSupportedOrderBooks.has(
+          `${orderBook.token0}-${orderBook.token1}`,
+        )
+      ) {
+        continue;
+      }
+
+      const priceTick =
+        (BI_POWS[this.getTokenFromAddress(orderBook.token0).decimals] *
+          bigIntify(orderBook.priceMultiplier)) /
+        bigIntify(orderBook.priceDivider) /
+        bigIntify(orderBook.sizeTick);
+
+      const pool = new LighterV2EventPool(
+        this.dexKey,
+        this.network,
+        this.dexHelper,
+        this.logger,
+        orderBook.orderBookAddress,
+        orderBook.orderBookId,
+        this.getTokenFromAddress(orderBook.token0),
+        this.getTokenFromAddress(orderBook.token1),
+        bigIntify(orderBook.sizeTick),
+        priceTick,
+      );
+
+      this.allSupportedOrderBooks.set(
+        `${orderBook.token0}-${orderBook.token1}`,
+        {
+          pool,
+          isAsk: true,
+        },
+      );
+      this.allSupportedOrderBooks.set(
+        `${orderBook.token1}-${orderBook.token0}`,
+        {
+          pool,
+          isAsk: false,
+        },
+      );
+
+      promises.push(pool.initState(blockNumber));
+    }
+
+    await Promise.all(promises);
+  }
+
+  // Returns the list of contract adapters (name and index)
+  // for a buy/sell. Return null if there are no adapters.
+  getAdapters(side: SwapSide): { name: string; index: number }[] | null {
+    return this.adapters[side] ? this.adapters[side] : null;
+  }
+
+  // Returns list of pool identifiers that can be used
+  // for a given swap. poolIdentifiers must be unique
+  // across DEXes. It is recommended to use
+  // ${dexKey}_${srcToken}-${destToken} as a poolIdentifier
+  async getPoolIdentifiers(
+    srcToken: Token,
+    destToken: Token,
+    side: SwapSide,
+    blockNumber: number,
+  ): Promise<string[]> {
+    srcToken = this.dexHelper.config.wrapETH(srcToken);
+    destToken = this.dexHelper.config.wrapETH(destToken);
+
+    for (const key of [
+      `${srcToken.address}-${destToken.address}`,
+      `${destToken.address}-${srcToken.address}`,
+    ]) {
+      if (this.allSupportedOrderBooks.get(key)) {
+        return [`${this.dexKey}_${key}`];
+      }
+    }
+
+    return [];
+  }
+
+  getPoolByIdentifier(identifier: string) {
+    const [_, key] = identifier.split('_');
+    return this.allSupportedOrderBooks.get(key);
+  }
+
+  // Returns pool prices for amounts.
+  // If limitPools is defined only pools in limitPools
+  // should be used. If limitPools is undefined then
+  // any pools can be used.
+  async getPricesVolume(
+    srcToken: Token,
+    destToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    limitPools?: string[],
+  ): Promise<null | ExchangePrices<LighterV2Data>> {
+    const isNativeSrcToken = srcToken.address == ETHER_ADDRESS;
+    srcToken = this.dexHelper.config.wrapETH(srcToken);
+    destToken = this.dexHelper.config.wrapETH(destToken);
+    const poolIdentifier = await this.getPoolIdentifiers(
+      srcToken,
+      destToken,
+      side,
+      blockNumber,
+    );
+
+    if (poolIdentifier.length == 0) {
+      return null;
+    }
+
+    // LighterV2_0x82aF49447D8a07e3bd95BD0d56f35241523fBab1-0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8
+    // omit LighterV2 from this string, split
+    const [_, key] = poolIdentifier[0].split('_');
+    const orderBook = this.allSupportedOrderBooks.get(key);
+    if (!orderBook) {
+      return null;
+    }
+
+    let state = orderBook.pool.getState(blockNumber);
+    if (!state) {
+      state = await orderBook.pool.initState(blockNumber);
+    }
+
+    const orderBookData = state.orderBook;
+    const limitOrders = orderBook.isAsk
+      ? orderBookData.sortedBids
+      : orderBookData.sortedAsks;
+
+    const outAmounts: bigint[] = await this.getOutAmount(
+      srcToken,
+      destToken,
+      state,
+      amounts,
+      side == SwapSide.SELL,
+      orderBook.isAsk,
+      limitOrders,
+    );
+
+    return [
+      {
+        prices: outAmounts,
+        unit: bigIntify(0),
+        data: {
+          isAsk: orderBook.isAsk,
+          orderBookId: orderBook.pool.orderBookId,
+          exchange: this.routerContract.address,
+        },
+        poolIdentifier: poolIdentifier[0],
+        exchange: this.dexKey,
+        gasCost: 105_000 + (isNativeSrcToken ? 25_000 : 0),
+        poolAddresses: [orderBook.pool.orderBookAddress],
+      },
+    ];
+  }
+
+  // Returns estimated gas cost of calldata for this DEX in multiSwap
+  getCalldataGasCost(poolPrices: PoolPrices<LighterV2Data>): number | number[] {
+    // size is actually variable between 10 and 18, depending on the numbers and how compressed they are
+    return CALLDATA_GAS_COST.wordNonZeroBytes(18);
+  }
+
+  // Encode params required by the exchange adapter
+  // Used for multiSwap, buy & megaSwap
+  // Hint: abiCoder.encodeParameter() could be useful
+  getAdapterParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: LighterV2Data,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    // TODO: complete me!
+    const { exchange } = data;
+
+    // Encode here the payload for adapter
+    const payload = '';
+
+    return {
+      targetExchange: exchange,
+      payload,
+      networkFee: '0',
+    };
+  }
+
+  // Encode call data used by simpleSwap like routers
+  // Used for simpleSwap & simpleBuy
+  // Hint: this.buildSimpleParamWithoutWETHConversion
+  // could be useful
+  async getSimpleParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: LighterV2Data,
+    side: SwapSide,
+  ): Promise<SimpleExchangeParam> {
+    const { exchange, isAsk, orderBookId } = data;
+
+    // Encode here the transaction arguments
+    const swapData =
+      side == SwapSide.SELL
+        ? getSwapExactInputSingleFallbackData(
+            orderBookId,
+            isAsk,
+            srcAmount,
+            destAmount,
+            destToken == ETHER_ADDRESS,
+          )
+        : getSwapExactOutputSingleFallbackData(
+            orderBookId,
+            isAsk,
+            destAmount,
+            srcAmount,
+            destToken == ETHER_ADDRESS,
+          );
+
+    return this.buildSimpleParamWithoutWETHConversion(
+      srcToken,
+      srcAmount,
+      destToken,
+      destAmount,
+      swapData,
+      exchange,
+    );
+  }
+
+  // This is called once before getTopPoolsForToken is
+  // called for multiple tokens. This can be helpful to
+  // update common state required for calculating
+  // getTopPoolsForToken. It is optional for a DEX
+  // to implement this
+  async updatePoolState(): Promise<void> {
+    await this.initializePricing(
+      await this.dexHelper.provider.getBlockNumber(),
+    );
+  }
+
+  // Returns list of top pools based on liquidity. Max
+  // limit number pools should be returned.
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    limit: number,
+  ): Promise<PoolLiquidity[]> {
+    const pools: PoolLiquidity[] = [];
+
+    // find the pools that have the token in allSupportedOrderBooks keys
+    for (const [key, orderBook] of this.allSupportedOrderBooks) {
+      if (pools.length >= limit) {
+        break;
+      }
+      const [tokenAAddress, tokenBAddress] = key.split('-');
+      // if one of these tokens is given token
+      if (tokenAAddress == tokenAddress) {
+        const tokenB = this.getTokenFromAddress(tokenBAddress);
+
+        const pool = orderBook.pool;
+        const state = pool.getState(pool.getStateBlockNumber());
+        if (!state) {
+          continue;
+        }
+
+        const liq = pool.getLockedAssets(state);
+        const token0Liq = this.priceOracle.getTokenValue(
+          state.token0,
+          liq.token0Amount,
+        );
+        const token1Liq = this.priceOracle.getTokenValue(
+          state.token1,
+          liq.token1Amount,
+        );
+
+        await Promise.all([token0Liq, token1Liq]);
+
+        pools.push({
+          exchange: this.dexKey,
+          address: pool.orderBookAddress,
+          connectorTokens: [tokenB],
+          liquidityUSD: (await token0Liq) + (await token1Liq),
+        });
+      }
+    }
+
+    pools.sort((a, b) => {
+      return b.liquidityUSD - a.liquidityUSD;
+    });
+
+    return pools.slice(0, limit);
+  }
+
+  // This is optional function in case if your implementation has acquired any resources
+  // you need to release for graceful shutdown. For example, it may be any interval timer
+  releaseResources(): AsyncOrSync<void> {}
+
+  async getOutAmount(
+    srcToken: Token,
+    destToken: Token,
+    state: DeepReadonly<PoolState>,
+    amountIns: bigint[],
+    isExactInput: boolean,
+    isAsk: boolean,
+    limitOrders: Readonly<LimitOrder[]>,
+  ): Promise<bigint[]> {
+    const swapToken0For1 = isAsk == isExactInput;
+    const token0 = isAsk ? srcToken : destToken;
+
+    return amountIns.map(amountIn => {
+      // This is important, reviewer should check this
+      // there is a size tick in the order book and we need to round the amountIn
+      if (swapToken0For1) {
+        if (!isExactInput && amountIn % state.sizeTick != 0n) {
+          amountIn += state.sizeTick;
+        }
+        amountIn -= amountIn % state.sizeTick;
+      }
+
+      let remainingAmountIn = amountIn;
+      let runningAmountOut = 0n;
+      for (const limitOrder of limitOrders) {
+        if (isAsk == limitOrder.isAsk) {
+          continue;
+        }
+
+        let orderAmountIn = limitOrder.amount0;
+        let orderPrice = limitOrder.price;
+        let orderAmountOut =
+          (orderAmountIn * orderPrice) / BI_POWS[token0.decimals];
+
+        if (swapToken0For1) {
+          let swapAmount0 =
+            remainingAmountIn >= orderAmountIn
+              ? orderAmountIn
+              : remainingAmountIn;
+          let shouldStop = swapAmount0 == orderAmountIn;
+
+          let swapAmount1 =
+            (swapAmount0 * orderPrice) / BI_POWS[token0.decimals];
+
+          runningAmountOut += swapAmount1;
+          remainingAmountIn -= swapAmount0;
+
+          if (shouldStop) {
+            break;
+          }
+        } else {
+          let swapAmount1 =
+            remainingAmountIn >= orderAmountOut
+              ? orderAmountOut
+              : remainingAmountIn;
+          let shouldStop = swapAmount1 == remainingAmountIn;
+
+          // compute swapAmount0 based on swapAmount1
+          let swapAmount0 =
+            (swapAmount1 * BI_POWS[token0.decimals]) / orderPrice;
+
+          if (
+            !isExactInput &&
+            shouldStop &&
+            swapAmount0 % state.sizeTick != 0n
+          ) {
+            swapAmount0 -= swapAmount0 % state.sizeTick;
+            swapAmount0 += state.sizeTick;
+          } else {
+            swapAmount0 -= swapAmount0 % state.sizeTick;
+          }
+
+          // recompute swapAmount1, due to possible precision loss in prev step
+          swapAmount1 = (swapAmount0 * orderPrice) / BI_POWS[token0.decimals];
+
+          runningAmountOut += swapAmount0;
+          remainingAmountIn -= swapAmount1;
+
+          if (shouldStop) {
+            break;
+          }
+        }
+      }
+      return runningAmountOut;
+    });
+  }
+}

--- a/src/dex/lighter-v2/price-oracle.ts
+++ b/src/dex/lighter-v2/price-oracle.ts
@@ -1,0 +1,89 @@
+import { Token } from '../../types';
+import { bigIntify } from '../../utils';
+import { BI_POWS } from '../../bigint-constants';
+import { IRequestWrapper } from '../../dex-helper';
+
+export class LighterPriceOracle {
+  cache = new Map<
+    String,
+    {
+      created: number;
+      price: number;
+    }
+  >();
+
+  constructor(
+    readonly httpRequest: IRequestWrapper,
+    readonly ttlMs: number = 5000,
+  ) {}
+
+  getTokenPriceFromCache(tokenSymbol: string): number | null {
+    const cached = this.cache.get(tokenSymbol);
+    const now = new Date().getTime();
+    if (cached && cached.created + this.ttlMs > now) {
+      return cached.price;
+    }
+    return null;
+  }
+
+  setTokenPriceInCache(tokenSymbol: string, price: number) {
+    this.cache.set(tokenSymbol, {
+      created: new Date().getTime(),
+      price: price,
+    });
+  }
+
+  getBinanceSymbol(tokenSymbol: string): string {
+    const validSymbols = ['USDC', 'USDT', 'DAI'];
+    if (validSymbols.includes(tokenSymbol)) return tokenSymbol;
+
+    // remove first W in care of wrapped tokens
+    const wrappedTokens = ['WBTC', 'WETH', 'WMATIC'];
+    if (wrappedTokens.includes(tokenSymbol)) return tokenSymbol.slice(1);
+
+    if (tokenSymbol === 'USDC.e') return 'USDC';
+
+    return tokenSymbol;
+  }
+
+  // returns the price of the token in USDT, using binance prices
+  async getTokenPrice(tokenSymbol?: string): Promise<number> {
+    if (!tokenSymbol) {
+      return 0;
+    }
+
+    // try to get from cache
+    const cached = this.getTokenPriceFromCache(tokenSymbol);
+    if (cached != null) {
+      return cached;
+    }
+
+    if (tokenSymbol == 'USDT') {
+      return 1;
+    }
+
+    tokenSymbol = this.getBinanceSymbol(tokenSymbol);
+    const url = `https://api.binance.com/api/v3/ticker/price?symbol=${tokenSymbol}USDT`;
+
+    let response: any;
+    try {
+      response = await this.httpRequest.get(url);
+      const price = parseFloat(response.price);
+      this.setTokenPriceInCache(tokenSymbol, price);
+      return price;
+    } catch (e) {
+      return 0;
+    }
+  }
+
+  // returns the value of the token, in USDT
+  async getTokenValue(token: Token, amount: bigint): Promise<number> {
+    const price = await this.getTokenPrice(token.symbol);
+    const precision = 10000000;
+    return Number(
+      (amount * bigIntify(price * precision)) /
+        bigIntify(precision) /
+        BI_POWS[token.decimals],
+    );
+  }
+}

--- a/src/dex/lighter-v2/types.ts
+++ b/src/dex/lighter-v2/types.ts
@@ -1,0 +1,33 @@
+import { Address, Token } from '../../types';
+
+export type PoolState = {
+  token0: Token;
+  token1: Token;
+  sizeTick: bigint;
+  priceTick: bigint;
+  pool: Address;
+  orderBook: OrderBook;
+};
+
+export type OrderBook = {
+  sortedAsks: LimitOrder[];
+  sortedBids: LimitOrder[];
+};
+
+export type LimitOrder = {
+  id: number;
+  amount0: bigint;
+  price: bigint;
+  isAsk: boolean;
+};
+
+export type LighterV2Data = {
+  orderBookId: number;
+  isAsk: boolean;
+  exchange: Address;
+};
+
+export type DexParams = {
+  factory: string;
+  router: string;
+};


### PR DESCRIPTION
Integration of the [Lighter V2](https://lighter.xyz/) protocol.
Added support for Arbitrum One network.

Lighter V2 has support for both SELL & BUY
It also has support for multi-swaps build-in, if it's helpful.

Some help is needed for e2e tests for as well configuring Adapters
```
SELL: ContractMethod.multiSwap,
SELL: ContractMethod.megaSwap
BUY:  ContractMethod.buy
```

The following contract methods work as expected
```
SELL: ContractMethod.simpleSwap
BUY:  ContractMethod.simpleBuy
```
