### PR TITLE
Integrate AirSwap V4

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,11 @@
   },
   "dependencies": {
     "@0x/utils": "^4.5.2",
+    "@airswap/constants": "4.1.8",
+    "@airswap/registry": "4.1.3",
+    "@airswap/swap-erc20": "4.1.6",
+    "@airswap/types": "4.1.3",
+    "@airswap/utils": "4.1.12",
     "@ethersproject/abi": "^5.7.0",
     "@hashflow/sdk": "1.2.4",
     "@hashflow/taker-js": "0.3.4",

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ type BaseConfig = {
   adapterAddresses: { [name: string]: Address };
   uniswapV2ExchangeRouterAddress: Address;
   uniswapV3EventLoggingSampleRate?: number;
+  airSwapOverrideServerURLs: string[];
   rfqConfigs: Record<string, RFQConfig>;
   rpcPollingMaxAllowedStateDelayInBlocks: number;
   rpcPollingBlocksBackToTriggerUpdate: number;
@@ -67,6 +68,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     hashFlowDisabledMMs:
       process.env[`HASHFLOW_DISABLED_MMS_1`]?.split(',') || [],
     uniswapV3EventLoggingSampleRate: 0,
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_1`]?.split(',') || [],
     rfqConfigs: {
       DummyParaSwapPool: {
         maker: process.env.TEST_ADDRESS!,
@@ -145,6 +148,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     },
     uniswapV2ExchangeRouterAddress:
       '0x53e693c6C7FFC4446c53B205Cf513105Bf140D7b',
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_3`]?.split(',') || [],
     rfqConfigs: {},
     rpcPollingMaxAllowedStateDelayInBlocks: 5,
     rpcPollingBlocksBackToTriggerUpdate: 3,
@@ -175,6 +180,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     rpcPollingBlocksBackToTriggerUpdate: 1,
     uniswapV2ExchangeRouterAddress:
       '0x53e693c6C7FFC4446c53B205Cf513105Bf140D7b',
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_56`]?.split(',') || [],
     rfqConfigs: {},
     forceRpcFallbackDexs: [],
   },
@@ -203,6 +210,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     uniswapV2ExchangeRouterAddress:
       '0xf3938337F7294fEf84e9B2c6D548A93F956Cc281',
     uniswapV3EventLoggingSampleRate: 0,
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_137`]?.split(',') || [],
     rfqConfigs: {},
     rpcPollingMaxAllowedStateDelayInBlocks: 2,
     rpcPollingBlocksBackToTriggerUpdate: 1,
@@ -234,6 +243,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     },
     uniswapV2ExchangeRouterAddress:
       '0x53e693c6C7FFC4446c53B205Cf513105Bf140D7b',
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_43114`]?.split(',') || [],
     rfqConfigs: {},
     rpcPollingMaxAllowedStateDelayInBlocks: 2,
     rpcPollingBlocksBackToTriggerUpdate: 1,
@@ -263,6 +274,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     },
     uniswapV2ExchangeRouterAddress:
       '0xAB86e2bC9ec5485a9b60E684BA6d49bf4686ACC2',
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_250`]?.split(',') || [],
     rfqConfigs: {},
     rpcPollingMaxAllowedStateDelayInBlocks: 2,
     rpcPollingBlocksBackToTriggerUpdate: 1,
@@ -294,6 +307,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     uniswapV2ExchangeRouterAddress:
       '0xB41dD984730dAf82f5C41489E21ac79D5e3B61bC',
     uniswapV3EventLoggingSampleRate: 0,
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_42161`]?.split(',') || [],
     rfqConfigs: {},
     rpcPollingMaxAllowedStateDelayInBlocks: 4,
     rpcPollingBlocksBackToTriggerUpdate: 3,
@@ -323,6 +338,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     uniswapV2ExchangeRouterAddress:
       '0xB41dD984730dAf82f5C41489E21ac79D5e3B61bC',
     uniswapV3EventLoggingSampleRate: 0,
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_10`]?.split(',') || [],
     rfqConfigs: {},
     rpcPollingMaxAllowedStateDelayInBlocks: 5,
     rpcPollingBlocksBackToTriggerUpdate: 3,
@@ -353,6 +370,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     hashFlowDisabledMMs:
       process.env[`HASHFLOW_DISABLED_MMS_10`]?.split(',') || [],
     uniswapV3EventLoggingSampleRate: 0,
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_1101`]?.split(',') || [],
     rfqConfigs: {},
     forceRpcFallbackDexs: [],
     // FIXME: Not set properly
@@ -381,6 +400,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     uniswapV2ExchangeRouterAddress:
       '0x75d199EfB540e47D27D52c62Da3E7daC2B9e834F',
     uniswapV3EventLoggingSampleRate: 0,
+    airSwapOverrideServerURLs:
+      process.env[`AIRSWAP_SERVER_URLS_8453`]?.split(',') || [],
     rfqConfigs: {},
     rpcPollingMaxAllowedStateDelayInBlocks: 5,
     rpcPollingBlocksBackToTriggerUpdate: 3,
@@ -420,6 +441,7 @@ export function generateConfig(network: number): Config {
     adapterAddresses: { ...baseConfig.adapterAddresses },
     uniswapV2ExchangeRouterAddress: baseConfig.uniswapV2ExchangeRouterAddress,
     uniswapV3EventLoggingSampleRate: baseConfig.uniswapV3EventLoggingSampleRate,
+    airSwapOverrideServerURLs: baseConfig.airSwapOverrideServerURLs,
     rfqConfigs: baseConfig.rfqConfigs,
     rpcPollingMaxAllowedStateDelayInBlocks:
       baseConfig.rpcPollingMaxAllowedStateDelayInBlocks,

--- a/src/dex/airswap/airswap-e2e.test.ts
+++ b/src/dex/airswap/airswap-e2e.test.ts
@@ -1,0 +1,77 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { ethers } from 'ethers';
+import { Network, ContractMethod, SwapSide, MAX_UINT } from '../../constants';
+import { generateConfig } from '../../config';
+import { newTestE2E } from '../../../tests/utils-e2e';
+import { SmartTokens, GENERIC_ADDR1 } from '../../../tests/constants-e2e';
+import { startTestServer } from './test-server.test';
+import { AirSwapConfig } from './config';
+
+const PK_KEY = process.env.TEST_PK_KEY;
+if (!PK_KEY) {
+  throw new Error('Missing TEST_PK_KEY');
+}
+
+const testAccount = new ethers.Wallet(PK_KEY!);
+
+jest.setTimeout(1000 * 60 * 3);
+
+describe('AirSwap E2E Mainnet', () => {
+  let stopServer: undefined | Function = undefined;
+
+  beforeAll(() => {
+    stopServer = startTestServer(testAccount);
+  });
+
+  const network = Network.MAINNET;
+  const smartTokens = SmartTokens[network];
+
+  const srcToken = smartTokens.WETH;
+  const destToken = smartTokens.DAI;
+
+  const config = generateConfig(network);
+
+  describe('AirSwap', () => {
+    const dexKey = 'AirSwap';
+
+    srcToken.addBalance(testAccount.address, MAX_UINT);
+    srcToken.addAllowance(
+      testAccount.address,
+      AirSwapConfig.AirSwap[network].swapERC20Address,
+      MAX_UINT,
+    );
+
+    destToken.addBalance(testAccount.address, MAX_UINT);
+    destToken.addAllowance(
+      testAccount.address,
+      AirSwapConfig.AirSwap[network].swapERC20Address,
+      MAX_UINT,
+    );
+
+    describe('Simpleswap', () => {
+      it('SELL WETH -> DAI', async () => {
+        await newTestE2E({
+          config,
+          srcToken,
+          destToken,
+          senderAddress: GENERIC_ADDR1,
+          thirdPartyAddress: testAccount.address,
+          _amount: '1000000000000000000',
+          swapSide: SwapSide.SELL,
+          dexKey: dexKey,
+          contractMethod: ContractMethod.simpleSwap,
+          network: network,
+          sleepMs: 3000,
+        });
+      });
+    });
+  });
+
+  afterAll(() => {
+    if (stopServer) {
+      stopServer();
+    }
+  });
+});

--- a/src/dex/airswap/airswap-events.test.ts
+++ b/src/dex/airswap/airswap-events.test.ts
@@ -1,0 +1,75 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { AirSwapRegistry } from './registry';
+import { Network } from '../../constants';
+import { Address } from '../../types';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { testEventSubscriber } from '../../../tests/utils-events';
+import { AirSwapRegistryState } from './types';
+import { AirSwapConfig } from './config';
+
+jest.setTimeout(50 * 1000);
+
+async function fetchPoolState(
+  registry: AirSwapRegistry,
+  blockNumber: number,
+  poolAddress: string,
+): Promise<AirSwapRegistryState> {
+  return {
+    stakerServerURLs: {},
+    protocolsByStaker: {},
+    stakersByProtocol: {},
+    tokensByStaker: {},
+    stakersByToken: {},
+  };
+}
+
+type EventMappings = Record<string, number[]>;
+
+describe('AirSwap EventPool Mainnet', function () {
+  const dexKey = 'AirSwap';
+  const network = Network.MAINNET;
+  const dexHelper = new DummyDexHelper(network);
+  const logger = dexHelper.getLogger(dexKey);
+  let registry: AirSwapRegistry;
+
+  const eventsToTest: Record<Address, EventMappings> = {
+    [AirSwapConfig.AirSwap[network].registryAddress]: {
+      SetServerURL: [0],
+      AddProtocols: [0],
+      RemoveProtocols: [0],
+      UnsetServer: [0],
+    },
+  };
+
+  beforeEach(async () => {
+    registry = new AirSwapRegistry(dexKey, network, dexHelper, logger);
+  });
+
+  Object.entries(eventsToTest).forEach(
+    ([registryAddress, events]: [string, EventMappings]) => {
+      describe(`Events for ${registryAddress}`, () => {
+        Object.entries(events).forEach(
+          ([eventName, blockNumbers]: [string, number[]]) => {
+            describe(`${eventName}`, () => {
+              blockNumbers.forEach((blockNumber: number) => {
+                it(`State after ${blockNumber}`, async function () {
+                  await testEventSubscriber(
+                    registry,
+                    registry.addressesSubscribed,
+                    (_blockNumber: number) =>
+                      fetchPoolState(registry, _blockNumber, registryAddress),
+                    blockNumber,
+                    `${dexKey}_${registryAddress}`,
+                    dexHelper.provider,
+                  );
+                });
+              });
+            });
+          },
+        );
+      });
+    },
+  );
+});

--- a/src/dex/airswap/airswap-integration.test.ts
+++ b/src/dex/airswap/airswap-integration.test.ts
@@ -1,0 +1,74 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { ethers } from 'ethers';
+import { DummyDexHelper } from '../../dex-helper';
+import { Network, SwapSide } from '../../constants';
+import { AirSwap } from './airswap';
+import { checkPoolPrices, sleep } from '../../../tests/utils';
+import { BI_POWS } from '../../bigint-constants';
+import { startTestServer } from './test-server.test';
+import { SmartTokens } from '../../../tests/constants-e2e';
+
+const PK_KEY = process.env.TEST_PK_KEY;
+if (!PK_KEY) {
+  throw new Error('Mising TEST_PK_KEY');
+}
+
+const testAccount = new ethers.Wallet(PK_KEY!);
+const stopServer = startTestServer(testAccount);
+
+const smartTokens = SmartTokens[1];
+const WETH = smartTokens.WETH.token;
+const DAI = smartTokens.DAI.token;
+
+const amountsForSell = [
+  0n,
+  1n * BI_POWS[WETH.decimals],
+  2n * BI_POWS[WETH.decimals],
+  3n * BI_POWS[WETH.decimals],
+  4n * BI_POWS[WETH.decimals],
+  5n * BI_POWS[WETH.decimals],
+  6n * BI_POWS[WETH.decimals],
+  7n * BI_POWS[WETH.decimals],
+  8n * BI_POWS[WETH.decimals],
+  9n * BI_POWS[WETH.decimals],
+  10n * BI_POWS[WETH.decimals],
+];
+
+const dexKey = 'AirSwap';
+
+describe('AirSwap', function () {
+  it('getPoolIdentifiers and getPricesVolume', async function () {
+    const dexHelper = new DummyDexHelper(Network.MAINNET);
+    const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+    const airswap = new AirSwap(Network.MAINNET, dexKey, dexHelper);
+
+    airswap.initializePricing(blocknumber);
+    await sleep(5000);
+
+    const pools = await airswap.getPoolIdentifiers(
+      WETH,
+      DAI,
+      SwapSide.SELL,
+      blocknumber,
+    );
+    expect(pools.length).toBeGreaterThan(0);
+
+    const poolPrices = await airswap.getPricesVolume(
+      WETH,
+      DAI,
+      amountsForSell,
+      SwapSide.SELL,
+      blocknumber,
+      pools,
+    );
+
+    expect(poolPrices).not.toBeNull();
+    checkPoolPrices(poolPrices!, amountsForSell, SwapSide.SELL, dexKey);
+  });
+
+  afterAll(() => {
+    stopServer();
+  });
+});

--- a/src/dex/airswap/airswap.ts
+++ b/src/dex/airswap/airswap.ts
@@ -1,0 +1,423 @@
+import { Interface } from 'ethers/lib/utils';
+import { assert } from 'ts-essentials';
+import { OptimalSwapExchange } from '@paraswap/core';
+import SwapERC20 from '@airswap/swap-erc20/build/contracts/SwapERC20.sol/SwapERC20.json';
+import { getPriceForAmount } from '@airswap/utils';
+import { Pricing } from '@airswap/types';
+
+import { Fetcher } from '../../lib/fetcher/fetcher';
+import {
+  Token,
+  ExchangePrices,
+  ExchangeTxInfo,
+  PreprocessTransactionOptions,
+  PoolLiquidity,
+  SimpleExchangeParam,
+  AdapterExchangeParam,
+  Address,
+  PoolPrices,
+  Logger,
+} from '../../types';
+
+import { Network, SwapSide } from '../../constants';
+import { SimpleExchange } from '../simple-exchange';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { IDex } from '../../dex/idex';
+import { getDexKeysWithNetwork } from '../../utils';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+
+import { AirSwapConfig } from './config';
+import { AirSwapOrderResponse } from './types';
+import { AirSwapPricingResponse } from './types';
+import { AirSwapRegistry } from './registry';
+import {
+  getServerPricingKey,
+  getPoolIdentifier,
+  getAllPricingERC20,
+  getOrderERC20,
+  caster,
+} from './utils';
+
+export const MIN_EXPIRY = 100000;
+export const CACHE_TTL = 3000;
+export const POLLING_INTERVAL = 3000;
+export const GAS_COST = 100_000;
+
+/**
+ * AirSwap
+ * https://airswap.io/
+ */
+export class AirSwap
+  extends SimpleExchange
+  implements IDex<AirSwapOrderResponse>
+{
+  readonly isStatePollingDex = true;
+  readonly hasConstantPriceLargeAmounts = false;
+  readonly needWrapNative = true;
+  readonly needsSequentialPreprocessing = true;
+  readonly isFeeOnTransferSupported = false;
+
+  protected swapInterface = new Interface(SwapERC20.abi);
+  private swapERC20Address: string;
+
+  private registry: AirSwapRegistry | null = null;
+  private worker: Fetcher<AirSwapPricingResponse> | null = null;
+  private overrideServerURLs: string[] = [];
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(AirSwapConfig);
+  logger: Logger;
+
+  constructor(
+    protected network: Network,
+    public dexKey: string,
+    readonly dexHelper: IDexHelper,
+  ) {
+    super(dexHelper, dexKey);
+    this.logger = dexHelper.getLogger(dexKey);
+    this.swapERC20Address = AirSwapConfig.AirSwap[network].swapERC20Address;
+  }
+
+  /**
+   * @name initializePricing
+   * @description Called by the engine at startup
+   */
+  async initializePricing(blockNumber: number): Promise<void> {
+    this.overrideServerURLs =
+      this.dexHelper.config.data.airSwapOverrideServerURLs;
+
+    // Start the Registry to track server URLs
+    this.registry = new AirSwapRegistry(
+      this.dexKey,
+      this.network,
+      this.dexHelper,
+      this.logger,
+    );
+
+    if (!this.dexHelper.config.isSlave) {
+      // Only poll pricing if this instance is not a slave
+
+      if (this.overrideServerURLs.length) {
+        // Poll a specific list of URLs from config
+        this.startWorker(this.overrideServerURLs);
+      } else {
+        // Poll active URLs; restart poller when updated
+        this.registry.setUpdateCallback(this.startWorker.bind(this));
+        this.registry.initialize(blockNumber, {
+          forceRegenerate: true,
+        });
+      }
+    }
+  }
+
+  /**
+   * @name releaseResources
+   * @description Called by the adapter when server URLs change
+   * @param urls string[] array of URLs to poll
+   */
+  startWorker(urls: string[]): void {
+    this.worker?.stopPolling();
+
+    // Start a Fetcher to update pricing on an interval
+    this.worker = new Fetcher(
+      this.dexHelper.httpRequest,
+      urls.map(url => ({
+        info: {
+          requestOptions: { url },
+          requestFunc: (options: any) => {
+            return getAllPricingERC20(options, this.dexHelper);
+          },
+          caster: caster.bind(this),
+        },
+        handler: async (resp: AirSwapPricingResponse) => {
+          const serverPricingKey = getServerPricingKey(url);
+
+          // Write pricing to cache to be read async
+          await this.dexHelper.cache.rawset(
+            serverPricingKey,
+            JSON.stringify(resp.result),
+            CACHE_TTL,
+          );
+        },
+      })),
+      POLLING_INTERVAL,
+      this.logger,
+    );
+    this.worker.startPolling();
+  }
+
+  /**
+   * @name releaseResources
+   * @description Called by the engine at shutdown
+   */
+  releaseResources(): void {
+    this.worker?.stopPolling();
+  }
+
+  /**
+   * @name getPoolIdentifiers
+   * @description Called by the engine to get pool identifiers for a token pair
+   * @param quoteToken the first token of the pair
+   * @param baseToken the second token of the pair
+   * @param side either sell or buy
+   * @param blockNumber not used
+   */
+  async getPoolIdentifiers(
+    quoteToken: Token,
+    baseToken: Token,
+    side: SwapSide,
+    _: number,
+  ): Promise<string[]> {
+    const serverURLs: string[] =
+      this.overrideServerURLs ||
+      this.registry?.getServerURLs(quoteToken.address, baseToken.address);
+    let tokenOne: Token;
+    let tokenTwo: Token;
+    if (side === SwapSide.SELL) {
+      tokenOne = this.dexHelper.config.wrapETH(quoteToken);
+      tokenTwo = this.dexHelper.config.wrapETH(baseToken);
+    } else {
+      tokenOne = this.dexHelper.config.wrapETH(baseToken);
+      tokenTwo = this.dexHelper.config.wrapETH(quoteToken);
+    }
+    // Our pools are servers so identifiers include URL
+    return serverURLs?.map(url =>
+      getPoolIdentifier(this.dexKey, tokenOne, tokenTwo, url),
+    );
+  }
+
+  /**
+   * @name getPricesVolume
+   * @description Called by the engine to get pricing for a token pair
+   * @param quoteToken the first token of the pair
+   * @param baseToken the second token of the pair
+   * @param amounts the amounts to get prices for
+   * @param side either sell or buy
+   * @param blockNumber
+   * @param limitPools a set of pool identifiers to use
+   */
+  async getPricesVolume(
+    quoteToken: Token,
+    baseToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    limitPools?: string[],
+  ): Promise<null | ExchangePrices<AirSwapOrderResponse>> {
+    const poolIdentifiers =
+      limitPools ??
+      (await this.getPoolIdentifiers(quoteToken, baseToken, side, blockNumber));
+    const result: ExchangePrices<AirSwapOrderResponse> = [];
+
+    // Get pricing by each of our servers (pools)
+    await poolIdentifiers.forEach(async poolIdentifier => {
+      const prices: bigint[] = [];
+      const url = decodeURIComponent(poolIdentifier.split('-')[3]);
+      const serverPricingKey = getServerPricingKey(url);
+
+      // Get pricing from cache written by worker (fetcher)
+      const cached = await this.dexHelper.cache.rawget(serverPricingKey);
+      if (cached) {
+        const pricing: Pricing[] = JSON.parse(cached) || [];
+
+        // For each amount get price from cached pricing
+        amounts.forEach(async amount => {
+          try {
+            const price = getPriceForAmount(
+              side === SwapSide.SELL ? 'sell' : 'buy',
+              amount.toString(),
+              baseToken.address,
+              quoteToken.address,
+              pricing,
+            );
+            if (price) prices.push(BigInt(price));
+          } catch (e) {
+            prices.push(BigInt(0));
+            this.logger.warn('getPricesVolume', url, e);
+          }
+        });
+      }
+      result.push({
+        gasCost: GAS_COST,
+        exchange: this.dexKey,
+        data: { url },
+        prices,
+        unit: BigInt(1),
+        poolIdentifier: getPoolIdentifier(
+          this.dexKey,
+          this.dexHelper.config.wrapETH(baseToken),
+          this.dexHelper.config.wrapETH(quoteToken),
+          url,
+        ),
+        poolAddresses: [this.swapERC20Address],
+      } as PoolPrices<AirSwapOrderResponse>);
+    });
+    return result;
+  }
+
+  /**
+   * @name preProcessTransaction
+   * @description Called by the engine to get a signed order
+   * @param optimalSwapExchange order request params
+   * @param quoteToken the first token of the pair
+   * @param baseToken the second token of the pair
+   * @param side either sell or buy
+   * @param options transaction options
+   */
+  async preProcessTransaction(
+    optimalSwapExchange: OptimalSwapExchange<AirSwapOrderResponse>,
+    quoteToken: Token,
+    baseToken: Token,
+    side: SwapSide,
+    options: PreprocessTransactionOptions,
+  ): Promise<[OptimalSwapExchange<AirSwapOrderResponse>, ExchangeTxInfo]> {
+    const url = optimalSwapExchange.data?.url;
+    assert(
+      !!url,
+      `${this.dexKey}-${this.network}: url was not provided to preProcessTransaction`,
+    );
+
+    // Call the server to get an order
+    const order = await getOrderERC20(
+      side,
+      this.dexHelper,
+      url,
+      this.network.toString(),
+      this.swapERC20Address,
+      baseToken.address,
+      optimalSwapExchange.srcAmount,
+      quoteToken.address,
+      this.augustusAddress,
+      MIN_EXPIRY.toString(),
+      options.txOrigin,
+    );
+
+    return [
+      {
+        ...optimalSwapExchange,
+        data: {
+          url,
+          order,
+        },
+      },
+      { deadline: BigInt(order.expiry) },
+    ];
+  }
+
+  /**
+   * @name getSimpleParam
+   * @description Called by the engine to get a signed order
+   * @param quoteToken the first token of the pair
+   * @param baseToken the second token of the pair
+   * @param quoteAmount the amount of quoteToken
+   * @param baseAmount the amount of baseToken
+   * @param side either sell or buy
+   */
+  async getSimpleParam(
+    quoteToken: string,
+    baseToken: string,
+    quoteAmount: string,
+    baseAmount: string,
+    data: AirSwapOrderResponse,
+    side: SwapSide,
+  ): Promise<SimpleExchangeParam> {
+    const { order } = data;
+
+    assert(
+      order !== undefined,
+      `${this.dexKey}-${this.network}: order undefined`,
+    );
+
+    const values = [
+      order.nonce,
+      order.expiry,
+      order.signerWallet,
+      order.signerToken,
+      order.signerAmount,
+      order.senderToken,
+      order.senderAmount,
+      order.v,
+      order.r,
+      order.s,
+    ];
+
+    const swapData = this.swapInterface.encodeFunctionData('swapLight', values);
+
+    return this.buildSimpleParamWithoutWETHConversion(
+      order.senderToken,
+      order.senderAmount,
+      order.signerToken,
+      order.signerAmount,
+      swapData,
+      this.swapERC20Address,
+    );
+  }
+
+  /**
+   * @name getTopPoolsForToken
+   * @description Called by the engine to get token pool sizes
+   * @param tokenAddress the address of the token
+   * @param limit max number of results
+   */
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    limit: number,
+  ): Promise<PoolLiquidity[]> {
+    // TODO
+    return [];
+  }
+
+  /**
+   * @name getTokenFromAddress
+   * @description Called by the engine to get token metadata
+   * @param address the address of the token
+   */
+  getTokenFromAddress?(address: Address): Token {
+    return { address, decimals: 0 };
+  }
+
+  async updatePoolState(): Promise<void> {
+    // Pricing is updated on an interval by the fetcher.
+    return Promise.resolve();
+  }
+
+  async isBlacklisted(userAddress?: string | undefined): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  async setBlacklist(userAddress: string): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  // @TODO PARASWAP
+  getAdapters(side: SwapSide): { name: string; index: number }[] | null {
+    return null;
+  }
+  // @TODO PARASWAP
+  getCalldataGasCost(
+    poolPrices: PoolPrices<AirSwapOrderResponse>,
+  ): number | number[] {
+    return CALLDATA_GAS_COST.DEX_NO_PAYLOAD;
+  }
+  // @TODO PARASWAP
+  getAdapterParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: AirSwapOrderResponse,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    // TODO: complete me!
+    const { url } = data;
+
+    // Encode here the payload for adapter
+    const payload = '';
+
+    return {
+      targetExchange: url,
+      payload,
+      networkFee: '0',
+    };
+  }
+}

--- a/src/dex/airswap/config.ts
+++ b/src/dex/airswap/config.ts
@@ -1,0 +1,21 @@
+import { DexConfigMap } from '../../types';
+import { mainnets } from '@airswap/constants';
+//@ts-ignore
+import registryBlocks from '@airswap/registry/deploys-blocks';
+import { AirSwapDeployment } from './types';
+
+const AirSwap: any = {};
+let length = mainnets.length;
+while (length--) {
+  AirSwap[mainnets[length]] = {
+    swapERC20Address: '0x0C9b31Dc37718417608CE22bb1ba940f702BF90B',
+    registryAddress: '0x339Eb75235CBf823C6352D529A258226ecF59cfF',
+    registryBlock: registryBlocks[mainnets[length]],
+    domainName: 'SWAP_ERC20',
+    domainVersion: '4.1',
+  };
+}
+
+export const AirSwapConfig: DexConfigMap<AirSwapDeployment> = {
+  AirSwap,
+};

--- a/src/dex/airswap/registry.ts
+++ b/src/dex/airswap/registry.ts
@@ -1,0 +1,327 @@
+import _ from 'lodash';
+import { Interface, LogDescription } from 'ethers/lib/utils';
+import { DeepReadonly } from 'ts-essentials';
+import { Protocols } from '@airswap/constants';
+
+import { Log, Logger, BlockHeader } from '../../types';
+import { catchParseLogError } from '../../utils';
+import {
+  StatefulEventSubscriber,
+  InitializeStateOptions,
+} from '../../stateful-event-subscriber';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+
+import { AirSwapRegistryState } from './types';
+import { remove } from './utils';
+import { AirSwapConfig } from './config';
+import Registry from '@airswap/registry/build/contracts/Registry.sol/Registry.json';
+
+const EMPTY_STATE: AirSwapRegistryState = {
+  stakerServerURLs: {},
+  protocolsByStaker: {},
+  stakersByProtocol: {},
+  tokensByStaker: {},
+  stakersByToken: {},
+};
+
+/**
+ * AirSwap Server URL Registry
+ * Determines active server URLs by contract state and emitted events.
+ */
+export class AirSwapRegistry extends StatefulEventSubscriber<AirSwapRegistryState> {
+  handlers: {
+    [event: string]: (
+      event: any,
+      state: DeepReadonly<AirSwapRegistryState>,
+      log: Readonly<Log>,
+    ) => DeepReadonly<AirSwapRegistryState> | null;
+  } = {};
+  logDecoder: (log: Log) => any;
+  registryInterface: Interface;
+  addressesSubscribed: string[];
+  updateCallback: Function | null = null;
+
+  constructor(
+    protected dexKey: string,
+    protected network: number,
+    protected dexHelper: IDexHelper,
+    protected logger: Logger,
+    protected serverURLsOverride?: string[],
+  ) {
+    super(dexKey, 'REGISTRY', dexHelper, logger);
+    this.registryInterface = new Interface(Registry.abi);
+    this.addressesSubscribed = [AirSwapConfig.AirSwap[network].registryAddress];
+    this.handlers['SetServerURL'] = this.handleSetServerURL.bind(this);
+    this.handlers['AddProtocols'] = this.handleAddProtocols.bind(this);
+    this.handlers['RemoveProtocols'] = this.handleRemoveProtocols.bind(this);
+    this.handlers['UnsetServer'] = this.handleUnsetServer.bind(this);
+    this.logDecoder = this.registryInterface.parseLog.bind(this);
+  }
+
+  /**
+   * @name setUpdateCallback
+   * @description Set a callback handler for URL updates
+   * @param callback the callback function
+   */
+  setUpdateCallback(callback: Function) {
+    this.updateCallback = callback;
+  }
+
+  /**
+   * @name callUpdateCallback
+   * @description Call the update callback handler
+   */
+  callUpdateCallback() {
+    this.updateCallback && this.updateCallback(this.getServerURLs());
+  }
+
+  /**
+   * @name getServerURLs
+   * @description Get active URLs
+   * @param tokenOne optional first token of a pair
+   * @param tokenTwo optional second token of a pair
+   */
+  getServerURLs(tokenOne?: string, tokenTwo?: string): string[] {
+    if (this.serverURLsOverride?.length) {
+      return this.serverURLsOverride;
+    }
+    const stakers =
+      this.state?.stakersByProtocol[Protocols.RequestForQuoteERC20] || [];
+    return stakers
+      ?.filter(staker => {
+        if (tokenOne && !this.state?.stakersByToken[tokenOne].includes(staker))
+          return false;
+        if (tokenTwo && !this.state?.stakersByToken[tokenTwo].includes(staker))
+          return false;
+        return this.state?.stakerServerURLs[staker];
+      })
+      .map(staker => {
+        return this.state?.stakerServerURLs[staker] || '';
+      });
+  }
+
+  /**
+   * @name initialize
+   * @description Called by instantiator; calls on super
+   * @param blockNumber block number to initialize for
+   * @param options options for initial state
+   */
+  async initialize(
+    blockNumber: number,
+    options?: InitializeStateOptions<AirSwapRegistryState>,
+  ) {
+    await super.initialize(blockNumber, options);
+  }
+
+  /**
+   * @name handleSetServerURL
+   * @description handle SetServerURL contract event
+   * @param event the event itself
+   * @param state state to update
+   */
+  handleSetServerURL(
+    event: LogDescription,
+    state: DeepReadonly<AirSwapRegistryState>,
+  ) {
+    const staker = event.args[0];
+    const url = event.args[1];
+    const newState = _.cloneDeep(state) as AirSwapRegistryState;
+    newState.stakerServerURLs[staker] = url;
+
+    this.callUpdateCallback();
+    return newState;
+  }
+
+  /**
+   * @name handleAddProtocols
+   * @description handle AddProtocols contract event
+   * @param event the event itself
+   * @param state state to update
+   */
+  handleAddProtocols(
+    event: LogDescription,
+    state: DeepReadonly<AirSwapRegistryState>,
+  ) {
+    const staker = event.args[0];
+    const protocols = event.args[1];
+    const newState = _.cloneDeep(state) as AirSwapRegistryState;
+
+    // Emitted protocols are new so we can just push.
+    protocols.forEach((protocol: string) => {
+      newState.stakersByProtocol[protocol].push(staker);
+      newState.protocolsByStaker[staker].push(protocol);
+    });
+
+    this.callUpdateCallback();
+    return newState;
+  }
+
+  /**
+   * @name handleRemoveProtocols
+   * @description handle RemoveProtocols contract event
+   * @param event the event itself
+   * @param state state to update
+   */
+  handleRemoveProtocols(
+    event: LogDescription,
+    state: DeepReadonly<AirSwapRegistryState>,
+  ) {
+    const staker = event.args[0];
+    const protocols = event.args[1];
+    const newState = _.cloneDeep(state) as AirSwapRegistryState;
+
+    protocols.forEach((protocol: string) => {
+      newState.stakersByProtocol[protocol] = remove(
+        newState.stakersByProtocol[protocol],
+        staker,
+      );
+      newState.protocolsByStaker[staker] = remove(
+        newState.protocolsByStaker[staker],
+        protocol,
+      );
+    });
+
+    this.callUpdateCallback();
+    return newState;
+  }
+
+  /**
+   * @name handleAddTokens
+   * @description handle AddTokens contract event
+   * @param event the event itself
+   * @param state state to update
+   */
+  handleAddTokens(
+    event: LogDescription,
+    state: DeepReadonly<AirSwapRegistryState>,
+  ) {
+    const staker = event.args[0];
+    const tokens = event.args[1];
+    const newState = _.cloneDeep(state) as AirSwapRegistryState;
+
+    // Emitted tokens are new so we can just push.
+    tokens.forEach((token: string) => {
+      newState.stakersByProtocol[token].push(staker);
+      newState.tokensByStaker[staker].push(token);
+    });
+    return newState;
+  }
+
+  /**
+   * @name handleRemoveTokens
+   * @description handle RemoveTokens contract event
+   * @param event the event itself
+   * @param state state to update
+   */
+  handleRemoveTokens(
+    event: LogDescription,
+    state: DeepReadonly<AirSwapRegistryState>,
+  ) {
+    const staker = event.args[0];
+    const tokens = event.args[1];
+    const newState = _.cloneDeep(state) as AirSwapRegistryState;
+
+    tokens.forEach((token: string) => {
+      newState.stakersByToken[token] = remove(
+        newState.stakersByToken[token],
+        staker,
+      );
+      newState.tokensByStaker[staker] = remove(
+        newState.tokensByStaker[staker],
+        token,
+      );
+    });
+    return newState;
+  }
+
+  /**
+   * @name handleUnsetServer
+   * @description handle UnsetServer contract event
+   * @param event the event itself
+   * @param state state to update
+   */
+  handleUnsetServer(
+    event: LogDescription,
+    state: DeepReadonly<AirSwapRegistryState>,
+  ) {
+    const staker = event.args[0];
+    const protocols = event.args[2];
+    const newState = _.cloneDeep(state) as AirSwapRegistryState;
+
+    delete newState.stakerServerURLs[staker];
+    delete newState.protocolsByStaker[staker];
+
+    protocols.forEach((protocol: string) => {
+      newState.stakersByProtocol[protocol] = remove(
+        newState.stakersByProtocol[protocol],
+        staker,
+      );
+    });
+
+    this.callUpdateCallback();
+    return newState;
+  }
+
+  /**
+   * @name generateState
+   * @description generate initial state from logs until a block
+   * @param blockNumber block number to stop at
+   */
+  async generateState(
+    blockNumber: number,
+  ): Promise<DeepReadonly<AirSwapRegistryState>> {
+    const logs = await this.dexHelper.provider.getLogs({
+      address: AirSwapConfig.AirSwap[this.network].registryAddress,
+      fromBlock: AirSwapConfig.AirSwap[this.network].registryBlock,
+      toBlock: blockNumber,
+    });
+    let state: DeepReadonly<AirSwapRegistryState> = EMPTY_STATE;
+    logs.forEach((log: Log) => {
+      state = this.processLog(state, log) || state;
+    });
+    return state;
+  }
+
+  /**
+   * @name processLog
+   * @description process a log (event) emitted on the contract
+   * @param state state to update
+   * @param log actual log emitted
+   */
+  protected processLog(
+    state: DeepReadonly<AirSwapRegistryState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<AirSwapRegistryState> | null {
+    try {
+      const event = this.logDecoder(log);
+      if (event.name in this.handlers) {
+        return this.handlers[event.name](event, state, log);
+      }
+    } catch (e) {
+      catchParseLogError(e, this.logger);
+    }
+    return null;
+  }
+
+  /**
+   * @name processBlockLogs
+   * @description process the logs for a block
+   * @param state state to update
+   * @param logs logs emitted on the block
+   * @param blockHeader the block
+   */
+  protected async processBlockLogs(
+    state: DeepReadonly<AirSwapRegistryState>,
+    logs: Readonly<Log>[],
+    blockHeader: Readonly<BlockHeader>,
+  ): Promise<DeepReadonly<AirSwapRegistryState> | null> {
+    const _state = _.cloneDeep(state);
+    let newState = await super.processBlockLogs(_state, logs, blockHeader);
+    if (!newState) {
+      this.logger.warn('received empty state generate new one');
+      newState = await this.generateState(blockHeader.number);
+    }
+
+    return newState;
+  }
+}

--- a/src/dex/airswap/test-server.test.ts
+++ b/src/dex/airswap/test-server.test.ts
@@ -1,0 +1,140 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { ethers } from 'ethers';
+import express from 'express';
+import {
+  createOrderERC20,
+  createOrderERC20Signature,
+  toAtomicString,
+  toDecimalString,
+  getCostFromPricing,
+} from '@airswap/utils';
+import { Pricing } from '@airswap/types';
+import { SmartTokens } from '../../../tests/constants-e2e';
+import { PORT_TEST_SERVER } from '../../constants';
+
+const smartTokens = SmartTokens[1];
+const Levels: Pricing[] = [
+  {
+    baseToken: smartTokens.DAI.address,
+    quoteToken: smartTokens.WETH.address,
+    minimum: '0',
+    bid: [['10000000000000000000', '0.9']],
+    ask: [['10000000000000000000', '1.1']],
+  },
+  {
+    baseToken: smartTokens.WETH.address,
+    quoteToken: smartTokens.DAI.address,
+    minimum: '0',
+    bid: [['10000000000000000000', '1']],
+    ask: [['10000000000000000000', '1']],
+  },
+];
+
+const EXPIRY = 100000;
+const PROTOCOL_FEE = 7;
+
+export function result(id: string, result: any) {
+  return {
+    jsonrpc: '2.0',
+    id,
+    result,
+  };
+}
+
+export function error(id: string, code: any, message: any) {
+  return JSON.stringify({
+    jsonrpc: '2.0',
+    id,
+    error: { code, message },
+  });
+}
+
+export const startTestServer = (account: ethers.Wallet) => {
+  const app = express();
+  app.use(express.json({ strict: false }));
+  app.post('/', async (req, res) => {
+    const id = req.body.id;
+    const method = req.body.method;
+    const params = req.body.params;
+    let response;
+
+    if (method === 'getAllPricingERC20') {
+      response = result(id, Levels);
+    } else if (
+      method === 'getSignerSideOrderERC20' ||
+      method === 'getSenderSideOrderERC20'
+    ) {
+      let { signerToken, senderWallet, senderToken } = params;
+
+      const signerDecimals = 6;
+      const senderDecimals = 6;
+      let signerAmount;
+      let senderAmount;
+
+      try {
+        switch (method) {
+          case 'getSignerSideOrderERC20':
+            senderAmount = toDecimalString(params.senderAmount, senderDecimals);
+            signerAmount = getCostFromPricing(
+              'buy',
+              senderAmount,
+              senderToken,
+              signerToken,
+              Levels,
+            );
+            break;
+          case 'getSenderSideOrderERC20':
+            signerAmount = toDecimalString(params.signerAmount, signerDecimals);
+            senderAmount = getCostFromPricing(
+              'sell',
+              signerAmount,
+              signerToken,
+              senderToken,
+              Levels,
+            );
+            break;
+        }
+
+        if (signerAmount && senderAmount) {
+          const order = createOrderERC20({
+            nonce: String(Date.now()),
+            expiry: String(Math.floor(Date.now() / 1000) + Number(EXPIRY)),
+            protocolFee: String(PROTOCOL_FEE),
+            signerWallet: account.address,
+            signerToken,
+            signerAmount: toAtomicString(signerAmount, signerDecimals),
+            senderWallet,
+            senderToken,
+            senderAmount: toAtomicString(senderAmount, senderDecimals),
+          });
+
+          const signature = await createOrderERC20Signature(
+            order,
+            account.privateKey,
+            params.swapContract,
+            params.chainId,
+            '4.1',
+            'SWAP_ERC20',
+          );
+
+          response = result(id, {
+            ...order,
+            ...signature,
+          });
+        } else {
+          response = error(id, -33601, 'Not serving pair');
+        }
+      } catch (e: any) {
+        response = error(id, -33603, e.message);
+      }
+    }
+    return res.status(200).json(response);
+  });
+
+  const server = app.listen(PORT_TEST_SERVER);
+  return () => {
+    server.close();
+  };
+};

--- a/src/dex/airswap/types.ts
+++ b/src/dex/airswap/types.ts
@@ -1,0 +1,44 @@
+import { Address } from '../../types';
+import { Levels, OrderERC20 } from '@airswap/types';
+
+export type AirSwapDeployment = {
+  swapERC20Address: Address;
+  registryAddress: Address;
+  registryBlock: number;
+  domainName: string;
+  domainVersion: string;
+};
+
+export type AirSwapRegistryResponse = string[];
+
+export type AirSwapPricingResponse = {
+  jsonrpc: string;
+  id: string;
+  result: [
+    {
+      baseToken: string;
+      quoteToken: string;
+      minimum: string;
+      bid: Levels;
+      ask: Levels;
+    },
+  ];
+};
+
+export type AirSwapFetcherConfig = {
+  interval: number;
+  cacheTTL: number;
+};
+
+export type AirSwapOrderResponse = {
+  url: string;
+  order?: OrderERC20;
+};
+
+export type AirSwapRegistryState = {
+  stakerServerURLs: Record<string, string>;
+  protocolsByStaker: Record<string, string[]>;
+  stakersByProtocol: Record<string, string[]>;
+  tokensByStaker: Record<string, string[]>;
+  stakersByToken: Record<string, string[]>;
+};

--- a/src/dex/airswap/utils.ts
+++ b/src/dex/airswap/utils.ts
@@ -1,0 +1,125 @@
+import { v4 as uuid } from 'uuid';
+import joi from 'joi';
+import { Token } from '../../types';
+import { validateAndCast } from '../../lib/validators';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { SwapSide } from '../../constants';
+import { AirSwapPricingResponse } from './types';
+
+export function getServerPricingKey(url: string): string {
+  return `${encodeURIComponent(url)}-PRICING`.toLowerCase();
+}
+
+export function getPoolKey(srcAddress: string, destAddress: string): string {
+  return `${srcAddress}-${destAddress}-POOL`.toLowerCase();
+}
+
+export function getPoolIdentifier(
+  dexKey: string,
+  srcToken: Token,
+  destToken: Token,
+  url: string,
+): string {
+  return `${dexKey}-${destToken.address}-${
+    srcToken.address
+  }-${encodeURIComponent(url)}`;
+}
+
+export async function getAllPricingERC20(options: any, dexHelper: IDexHelper) {
+  return await dexHelper.httpRequest.request({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+    data: {
+      id: uuid(),
+      method: 'getAllPricingERC20',
+      params: {},
+    },
+    ...options,
+  });
+}
+
+export async function getOrderERC20(
+  side: SwapSide,
+  dexHelper: IDexHelper,
+  url: string,
+  chainId: string,
+  swapContract: string,
+  signerToken: string,
+  amount: string,
+  senderToken: string,
+  senderWallet: string,
+  minExpiry: string,
+  proxyingFor: string,
+) {
+  const params: any = {
+    chainId,
+    swapContract,
+    signerToken,
+    senderToken,
+    senderWallet,
+    minExpiry,
+    proxyingFor,
+  };
+  let method;
+  if (side === SwapSide.SELL) {
+    method = 'getSignerSideOrderERC20';
+    params.senderAmount = amount;
+  } else {
+    method = 'getSenderSideOrderERC20';
+    params.signerAmount = amount;
+  }
+  const response = await dexHelper.httpRequest.request({
+    url,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    data: {
+      id: uuid(),
+      method,
+      params,
+    },
+  });
+  return response.data.result;
+}
+
+export function remove(array: string[], item: string) {
+  let length = array.length;
+  while (length--) {
+    if (array[length] === item) {
+      array.splice(length, 1);
+      break;
+    }
+  }
+  return array;
+}
+
+export const pricingResponseValidator = joi.object({
+  jsonrpc: joi.string(),
+  id: joi.string(),
+  result: joi.array().items({
+    baseToken: joi.string().required(),
+    quoteToken: joi.string().required(),
+    minimum: joi.string().optional(),
+    bid: joi
+      .array()
+      .items(
+        joi.array().items(joi.string().required(), joi.string().required()),
+      ),
+    ask: joi
+      .array()
+      .items(
+        joi.array().items(joi.string().required(), joi.string().required()),
+      ),
+  }),
+});
+
+export function caster(data: unknown) {
+  return validateAndCast<AirSwapPricingResponse>(
+    data,
+    pricingResponseValidator,
+  );
+}

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -83,6 +83,7 @@ import { NomiswapV2 } from './uniswap-v2/nomiswap-v2';
 import { Dexalot } from './dexalot/dexalot';
 import { Smardex } from './smardex/smardex';
 import { Wombat } from './wombat/wombat';
+import { AirSwap } from './airswap/airswap';
 
 const LegacyDexes = [
   CurveV2,
@@ -163,6 +164,7 @@ const Dexes = [
   SolidlyV3,
   Smardex,
   Wombat,
+  AirSwap,
 ];
 
 export type LegacyDexConstructor = new (dexHelper: IDexHelper) => IDexTxBuilder<

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,6 +269,7 @@ export type Config = {
   privateHttpProvider: string;
   adapterAddresses: { [name: string]: Address };
   uniswapV2ExchangeRouterAddress: Address;
+  airSwapOverrideServerURLs: string[];
   rfqConfigs: Record<string, RFQConfig>;
   rpcPollingMaxAllowedStateDelayInBlocks: number;
   rpcPollingBlocksBackToTriggerUpdate: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,45 @@
   resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
   integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
 
+"@airswap/constants@4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@airswap/constants/-/constants-4.1.8.tgz#a77e31b5213a28b72d619af069eba6279d640a46"
+  integrity sha512-2lau0XmaYCLglwqgKqhygfW5VsK0+PQojMUsD16RitvSZZZR460lX1x6fj1GnOiWW50NE81srY4rp39OmYV+RQ==
+
+"@airswap/registry@4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@airswap/registry/-/registry-4.1.3.tgz#c3dd45fca0439436b8e93cb282c7239f102c1920"
+  integrity sha512-YD/Azfq4MhxYr+gZo/FKB68wuO0+zEzjTjAFH+VzoEMDA0kIzBx9UHL4HtC2a5SYByd5lBg9Pid7ORMAs+gZSg==
+  dependencies:
+    "@openzeppelin/contracts" "^4.8.3"
+
+"@airswap/swap-erc20@4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@airswap/swap-erc20/-/swap-erc20-4.1.6.tgz#e78cd9c5f35bbeea7107481eaf671e9ba9e6d4db"
+  integrity sha512-jg4ZXp7Dj3wDGgSDi3bPXjprrzyxCV1pMJOxmHgILvAzPIGJOEEvlxJrTXKXdf4djRuuXGl7bDy9VxwmzqEO8g==
+  dependencies:
+    "@openzeppelin/contracts" "^4.8.3"
+
+"@airswap/types@4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@airswap/types/-/types-4.1.3.tgz#213dc7ce4310d3a792bd038ec4359f24b1a9e250"
+  integrity sha512-kEbIZmkzTLjaYFUkEMflcTKXtvWbZza+ReqBsMF2Ol1wrx0xlP+16GM36xH3Tcujz7nHXmh/oGSWZENnhxJF1g==
+  dependencies:
+    "@uniswap/token-lists" "^1.0.0-beta.31"
+
+"@airswap/utils@4.1.12":
+  version "4.1.12"
+  resolved "https://registry.yarnpkg.com/@airswap/utils/-/utils-4.1.12.tgz#57d0881a5d17bcf2eb5b4abb9fbd0b1f031e8027"
+  integrity sha512-U+l9pJkolL4EwHEN+9n1dlNGfkRbdBA4JieDD0x/uw8n3dFCpA3oJoGc42wo/9Cg4pP1yEq233ZU6ixEfIxB4A==
+  dependencies:
+    "@airswap/constants" "4.1.8"
+    "@airswap/types" "4.1.3"
+    "@metamask/eth-sig-util" "^5.0.2"
+    bignumber.js "^9.0.1"
+    ethereumjs-util "^7.1.5"
+    ethers "^5.6.9"
+    lz-string "^1.5.0"
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -425,6 +464,11 @@
     crc-32 "^1.2.0"
     ethereumjs-util "^7.1.5"
 
+"@ethereumjs/rlp@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-4.0.1.tgz#626fabfd9081baab3d0a3074b0c7ecaf674aaa41"
+  integrity sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==
+
 "@ethereumjs/tx@^3.2.1":
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.5.2.tgz#197b9b6299582ad84f9527ca961466fce2296c1c"
@@ -432,6 +476,15 @@
   dependencies:
     "@ethereumjs/common" "^2.6.4"
     ethereumjs-util "^7.1.5"
+
+"@ethereumjs/util@^8.0.6":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/util/-/util-8.1.0.tgz#299df97fb6b034e0577ce9f94c7d9d1004409ed4"
+  integrity sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==
+  dependencies:
+    "@ethereumjs/rlp" "^4.0.1"
+    ethereum-cryptography "^2.0.0"
+    micro-ftch "^0.3.1"
 
 "@ethersproject/abi@5.0.7":
   version "5.0.7"
@@ -1180,6 +1233,25 @@
     tweetnacl "^1.0.3"
     tweetnacl-util "^0.15.1"
 
+"@metamask/eth-sig-util@^5.0.2":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-5.1.0.tgz#a47f62800ee1917fef976ba67544a0ccd7d1bd6b"
+  integrity sha512-mlgziIHYlA9pi/XZerChqg4NocdOgBPB9NmxgXWQO2U2hH8RGOJQrz6j/AIKkYxgCMIE2PY000+joOwXfzeTDQ==
+  dependencies:
+    "@ethereumjs/util" "^8.0.6"
+    bn.js "^4.12.0"
+    ethereum-cryptography "^2.0.0"
+    ethjs-util "^0.1.6"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+
+"@noble/curves@1.1.0", "@noble/curves@~1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.1.0.tgz#f13fc667c89184bc04cccb9b11e8e7bae27d8c3d"
+  integrity sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==
+  dependencies:
+    "@noble/hashes" "1.3.1"
+
 "@noble/curves@1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
@@ -1192,6 +1264,11 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
   integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
 
+"@noble/hashes@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
+  integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
+
 "@noble/hashes@1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
@@ -1201,6 +1278,11 @@
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.5.tgz#1a0377f3b9020efe2fae03290bd2a12140c95c11"
   integrity sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==
+
+"@noble/hashes@~1.3.0", "@noble/hashes@~1.3.1":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
+  integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
 
 "@noble/secp256k1@1.6.3", "@noble/secp256k1@~1.6.0":
   version "1.6.3"
@@ -1456,6 +1538,11 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.8.1.tgz#709cfc4bbb3ca9f4460d60101f15dac6b7a2d5e4"
   integrity sha512-xQ6eUZl+RDyb/FiZe1h+U7qr/f4p/SrTSQcTPH2bjur3C5DbuW/zFgCU/b1P/xcIaEqJep+9ju4xDRi3rmChdQ==
 
+"@openzeppelin/contracts@^4.8.3":
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.5.tgz#1eed23d4844c861a1835b5d33507c1017fa98de8"
+  integrity sha512-ZK+W5mVhRppff9BE6YdR8CC52C8zAvsVAiWhEtQ5+oNxFE6h1WdeWo+FJSF8KKvtxxVYZ7MTP/5KoVpAU3aSWg==
+
 "@paraswap/core@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@paraswap/core/-/core-1.1.0.tgz#5ec7415be69dc657a9d82b0fde4e20f632cca1b6"
@@ -1484,12 +1571,29 @@
     "@noble/secp256k1" "~1.6.0"
     "@scure/base" "~1.1.0"
 
+"@scure/bip32@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.1.tgz#7248aea723667f98160f593d621c47e208ccbb10"
+  integrity sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==
+  dependencies:
+    "@noble/curves" "~1.1.0"
+    "@noble/hashes" "~1.3.1"
+    "@scure/base" "~1.1.0"
+
 "@scure/bip39@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.1.0.tgz#92f11d095bae025f166bef3defcc5bf4945d419a"
   integrity sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==
   dependencies:
     "@noble/hashes" "~1.1.1"
+    "@scure/base" "~1.1.0"
+
+"@scure/bip39@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.2.1.tgz#5cee8978656b272a917b7871c981e0541ad6ac2a"
+  integrity sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==
+  dependencies:
+    "@noble/hashes" "~1.3.0"
     "@scure/base" "~1.1.0"
 
 "@sentry/core@5.30.0":
@@ -2024,6 +2128,11 @@
     "@typescript-eslint/types" "5.47.0"
     eslint-visitor-keys "^3.3.0"
 
+"@uniswap/token-lists@^1.0.0-beta.31":
+  version "1.0.0-beta.33"
+  resolved "https://registry.yarnpkg.com/@uniswap/token-lists/-/token-lists-1.0.0-beta.33.tgz#966ba96c9ccc8f0e9e09809890b438203f2b1911"
+  integrity sha512-JQkXcpRI3jFG8y3/CGC4TS8NkDgcxXaOQuYW8Qdvd6DcDiIyg2vVYCG9igFEzF0G6UvxgHkBKC7cWCgzZNYvQg==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -2463,7 +2572,7 @@ bn.js@4.11.6:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
   integrity sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==
 
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9:
+bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -3822,6 +3931,16 @@ ethereum-cryptography@^1.0.3:
     "@scure/bip32" "1.1.0"
     "@scure/bip39" "1.1.0"
 
+ethereum-cryptography@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-2.1.2.tgz#18fa7108622e56481157a5cb7c01c0c6a672eb67"
+  integrity sha512-Z5Ba0T0ImZ8fqXrJbpHcbpAvIswRte2wGNR/KePnu8GbbvgJ47lMxT/ZZPG6i9Jaht4azPDop4HaM00J0J59ug==
+  dependencies:
+    "@noble/curves" "1.1.0"
+    "@noble/hashes" "1.3.1"
+    "@scure/bip32" "1.3.1"
+    "@scure/bip39" "1.2.1"
+
 ethereum-types@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/ethereum-types/-/ethereum-types-2.1.6.tgz#57d9d515fad86ab987c0f6962c4203be37da8579"
@@ -3875,7 +3994,7 @@ ethereumjs-util@^7.0.10, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.5:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@^5.7.0, ethers@^5.7.2:
+ethers@^5.6.9, ethers@^5.7.0, ethers@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
   integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
@@ -5776,6 +5895,11 @@ lru_map@^0.3.3:
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -5858,6 +5982,11 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
+
+micro-ftch@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/micro-ftch/-/micro-ftch-0.3.1.tgz#6cb83388de4c1f279a034fb0cf96dfc050853c5f"
+  integrity sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==
 
 micromatch@^4.0.4:
   version "4.0.5"


### PR DESCRIPTION
**AirSwap** (https://airswap.io/) is an RFQ DEX.
Counter-party discovery and token pricing are communicated off-chain; atomic token swaps are settled on-chain. AirSwap itself is a technology provider and runs no infrastructure of its own. [More info on our wiki](https://about.airswap.io/about/glossary#request-for-quote-rfq).

**Notes**
AirSwap uses a smart contract (Registry) for server URL discovery.
* We use [StatefulEventSubscriber](https://github.com/dmosites/paraswap-dex-lib/blob/master/src/stateful-event-subscriber.ts) for the Registry.
* Registry is instantiated for every AirSwap instance.

AirSwap calls multiple third-party server URLs for pricing and orders.
* We use [Fetcher](https://github.com/dmosites/paraswap-dex-lib/blob/master/src/lib/fetcher/fetcher.ts) to make HTTP calls on an interval.
* Fetcher is not instantiated for slave AirSwap instances.
* Prices are communicated to slaves via the cache.

Limitation: Tests cannot pass reliably on third-party servers, so:
* During tests an env var overrides URLs to point to a local server.
* Alternatively, we could pass a `isLocal` flag into `initializePricing`
* Alternatively, we could check `process.env.NODE_ENV` is `test`

**Flow**
1. `initializePricing` is called by the engine
  a. Registry starts up; hydrates; listens for event updates to track active server URLs
  b. Worker starts up (if not a slave process); writes pricing from active servers URLs to cache.
2. `getPoolIdentifiers` returns unique identifiers for active server URLs for a given token pair.
3. `getPricesVolume` pulls identifiers for a pair and reads the cache for pricing.
4. `preProcessTransaction` calls get*SideOrder on winning server.
5. `getSimpleParam` encodes the function call for the SwapERC20 contract.

**Tests**
For the initial review, simple tests are passing.
`airswap-e2e.test.ts`, `airswap-events.test.ts`, `airswap-integration.test.ts`.