### PR TITLE
Feat: OSwap integration

### DIFF
--- a/src/abi/oswap/oswap.abi.json
+++ b/src/abi/oswap/oswap.abi.json
@@ -1,0 +1,452 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "OperatorChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "traderate0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "traderate1",
+        "type": "uint256"
+      }
+    ],
+    "name": "TraderateChanged",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "approveStETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "requestIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "claimStETHWithdrawalForETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "requestIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "claimStETHWithdrawalForWETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "depositETHForStETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "depositWETHForStETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minimumFunds",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "operator",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "requestStETHWithdrawalForETH",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "requestIds",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minimumFunds",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMinimumFunds",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOperator",
+        "type": "address"
+      }
+    ],
+    "name": "setOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "setOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "buyT1",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "sellT1",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPrices",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "steth",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOutMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactTokensForTokens",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountInMax",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTokensForExactTokens",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "traderate0",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "traderate1",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferEth",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferToken",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "weth",
+    "outputs": [
+      {
+        "internalType": "contract IWEth",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawal",
+    "outputs": [
+      {
+        "internalType": "contract IStETHWithdrawal",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -83,6 +83,7 @@ import { NomiswapV2 } from './uniswap-v2/nomiswap-v2';
 import { Dexalot } from './dexalot/dexalot';
 import { Smardex } from './smardex/smardex';
 import { Wombat } from './wombat/wombat';
+import { OSwap } from './oswap/oswap';
 
 const LegacyDexes = [
   CurveV2,
@@ -163,6 +164,7 @@ const Dexes = [
   SolidlyV3,
   Smardex,
   Wombat,
+  OSwap,
 ];
 
 export type LegacyDexConstructor = new (dexHelper: IDexHelper) => IDexTxBuilder<

--- a/src/dex/oswap/config.ts
+++ b/src/dex/oswap/config.ts
@@ -1,0 +1,32 @@
+import { DexParams } from './types';
+import { DexConfigMap, AdapterMappings } from '../../types';
+import { Network, SwapSide } from '../../constants';
+
+export const OSWAP_GAS_COST = 80_000;
+
+// Important:
+//  - All addresses should be lower case.
+//  - Only tokens with 18 decimals are supported.
+export const OSwapConfig: DexConfigMap<DexParams> = {
+  OSwap: {
+    [Network.MAINNET]: {
+      pools: [
+        {
+          id: 'OSwap_0x85b78aca6deae198fbf201c82daf6ca21942acc6', // Pool identifier: `{dex_key}_{pool_address}`
+          address: '0x85b78aca6deae198fbf201c82daf6ca21942acc6', // Address of the pool
+          token0: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH
+          token1: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84', // STETH
+        },
+      ],
+    },
+  },
+};
+
+export const Adapters: Record<number, AdapterMappings> = {
+  [Network.MAINNET]: {
+    // Note: We re-use the SmarDex adapters since it implements
+    // an Uniswap V2 router compatible interface, which OSWap supports.
+    [SwapSide.SELL]: [{ name: 'Adapter04', index: 6 }],
+    [SwapSide.BUY]: [{ name: 'BuyAdapter02', index: 2 }],
+  },
+};

--- a/src/dex/oswap/config.ts
+++ b/src/dex/oswap/config.ts
@@ -25,7 +25,7 @@ export const OSwapConfig: DexConfigMap<DexParams> = {
 export const Adapters: Record<number, AdapterMappings> = {
   [Network.MAINNET]: {
     // Note: We re-use the SmarDex adapters since it implements
-    // an Uniswap V2 router compatible interface, which OSWap supports.
+    // an Uniswap V2 router compatible interface, which OSwap supports.
     [SwapSide.SELL]: [{ name: 'Adapter04', index: 6 }],
     [SwapSide.BUY]: [{ name: 'BuyAdapter02', index: 2 }],
   },

--- a/src/dex/oswap/oswap-e2e.test.ts
+++ b/src/dex/oswap/oswap-e2e.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import { Tokens, Holders } from '../../../tests/constants-e2e';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+
+function testForNetwork(
+  network: Network,
+  dexKey: string,
+  tokenASymbol: string,
+  tokenBSymbol: string,
+  tokenAAmount: string,
+  tokenBAmount: string,
+) {
+  const provider = new StaticJsonRpcProvider(
+    generateConfig(network).privateHttpProvider,
+    network,
+  );
+  const tokens = Tokens[network];
+  const holders = Holders[network];
+
+  const sideToContractMethods = new Map([
+    [
+      SwapSide.SELL,
+      [
+        ContractMethod.simpleSwap,
+        ContractMethod.multiSwap,
+        ContractMethod.megaSwap,
+      ],
+    ],
+    [SwapSide.BUY, [ContractMethod.simpleBuy, ContractMethod.buy]],
+  ]);
+
+  describe(`${network}`, () => {
+    sideToContractMethods.forEach((contractMethods, side) =>
+      describe(`${side}`, () => {
+        contractMethods.forEach((contractMethod: ContractMethod) => {
+          describe(`${contractMethod}`, () => {
+            it(`${tokenASymbol} -> ${tokenBSymbol}`, async () => {
+              await testE2E(
+                tokens[tokenASymbol],
+                tokens[tokenBSymbol],
+                holders[tokenASymbol],
+                side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+
+            it(`${tokenBSymbol} -> ${tokenASymbol}`, async () => {
+              await testE2E(
+                tokens[tokenBSymbol],
+                tokens[tokenASymbol],
+                holders[tokenBSymbol],
+                side === SwapSide.SELL ? tokenBAmount : tokenAAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+          });
+        });
+      }),
+    );
+  });
+}
+
+describe('Oswap E2E', () => {
+  const dexKey = 'OSwap';
+
+  describe('Mainnet', () => {
+    const network = Network.MAINNET;
+
+    const tokenASymbol: string = 'WETH';
+    const tokenBSymbol: string = 'STETH';
+
+    const tokenAAmount: string = '10000000000000';
+    const tokenBAmount: string = '10000000000000';
+
+    testForNetwork(
+      network,
+      dexKey,
+      tokenASymbol,
+      tokenBSymbol,
+      tokenAAmount,
+      tokenBAmount,
+    );
+  });
+});

--- a/src/dex/oswap/oswap-events.test.ts
+++ b/src/dex/oswap/oswap-events.test.ts
@@ -1,0 +1,88 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { OSwapConfig } from './config';
+import { OSwapEventPool } from './oswap-pool';
+import { Network } from '../../constants';
+import { Address } from '../../types';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { testEventSubscriber } from '../../../tests/utils-events';
+import { OSwapPool, OSwapPoolState } from './types';
+
+jest.setTimeout(50 * 1000);
+
+// eventName -> blockNumbers
+type EventMappings = Record<string, number[]>;
+
+// Helper function. Returns the absolute value of the difference between 2 bigints.
+function absdelta(a: bigint, b: bigint) {
+  const delta = a - b;
+  return delta < 0 ? -delta : delta;
+}
+
+function stateCompare(state1: OSwapPoolState, state2: OSwapPoolState) {
+  const ROUNDING_ERROR = 2;
+
+  expect(state1.traderate0).toEqual(state2.traderate0);
+  expect(state1.traderate1).toEqual(state2.traderate1);
+  // Some ERC20 tokens have rounding error which can lead to the balance computed from Transfer event valuee
+  // to deviate by a couple gwei vs the on-chain balance.
+  // For example stETH: https://docs.lido.fi/guides/lido-tokens-integration-guide/#1-2-wei-corner-case
+  expect(absdelta(state1.balance0, state2.balance0)).toBeLessThanOrEqual(
+    ROUNDING_ERROR,
+  );
+  expect(absdelta(state1.balance1, state2.balance1)).toBeLessThanOrEqual(
+    ROUNDING_ERROR,
+  );
+}
+
+describe('Oswap EventPool Mainnet', function () {
+  const dexKey = 'OSwap';
+  const network = Network.MAINNET;
+  const dexHelper = new DummyDexHelper(network);
+  const logger = dexHelper.getLogger(dexKey);
+  const pool: OSwapPool = OSwapConfig[dexKey][network].pools[0];
+
+  let eventPool: OSwapEventPool;
+
+  // poolAddress -> EventMappings
+  const eventsToTest: Record<Address, EventMappings> = {
+    [pool.address]: {
+      TraderateChanged: [18917344],
+      Transfer: [18922097, 18924756],
+    },
+  };
+
+  beforeEach(async () => {
+    eventPool = new OSwapEventPool(dexKey, pool, network, dexHelper, logger);
+  });
+
+  Object.entries(eventsToTest).forEach(
+    ([poolAddress, events]: [string, EventMappings]) => {
+      describe(`Events for ${poolAddress}`, () => {
+        Object.entries(events).forEach(
+          ([eventName, blockNumbers]: [string, number[]]) => {
+            describe(`${eventName}`, () => {
+              blockNumbers.forEach((blockNumber: number) => {
+                it(`State after ${blockNumber}`, async function () {
+                  await testEventSubscriber(
+                    eventPool,
+                    eventPool.addressesSubscribed,
+                    (_blockNumber: number) =>
+                      eventPool.generateState(_blockNumber),
+                    blockNumber,
+                    `${dexKey}_${poolAddress}`,
+                    dexHelper.provider,
+                    (state1: OSwapPoolState, state2: OSwapPoolState) =>
+                      stateCompare(state1, state2),
+                  );
+                });
+              });
+            });
+          },
+        );
+      });
+    },
+  );
+});

--- a/src/dex/oswap/oswap-integration.test.ts
+++ b/src/dex/oswap/oswap-integration.test.ts
@@ -1,0 +1,287 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide } from '../../constants';
+import { BI_POWS } from '../../bigint-constants';
+import { MultiCallParams } from '../../lib/multi-wrapper';
+import { uint256ToBigInt } from '../../lib/decoders';
+import { getBigIntPow } from '../../utils';
+import {
+  checkPoolPrices,
+  checkPoolsLiquidity,
+  checkConstantPoolPrices,
+} from '../../../tests/utils';
+import { Tokens } from '../../../tests/constants-e2e';
+import { Address } from '../../types';
+import { OSwap } from './oswap';
+import { OSwapPool } from './types';
+
+async function getOnchainTraderates(
+  oswap: OSwap,
+  pool: OSwapPool,
+  blockNumber: number,
+): Promise<{ traderate0: bigint; traderate1: bigint }> {
+  const callData: MultiCallParams<bigint>[] = [
+    {
+      target: pool.address,
+      callData: oswap.iOSwap.encodeFunctionData('traderate0', []),
+      decodeFunction: uint256ToBigInt,
+    },
+    {
+      target: pool.address,
+      callData: oswap.iOSwap.encodeFunctionData('traderate1', []),
+      decodeFunction: uint256ToBigInt,
+    },
+  ];
+
+  const results = await oswap.dexHelper.multiWrapper.aggregate<bigint>(
+    callData,
+    blockNumber,
+    oswap.dexHelper.multiWrapper.defaultBatchSize,
+  );
+
+  return { traderate0: results[0], traderate1: results[1] };
+}
+
+// Check prices passed as arguments against prices calculated from on-chain data.
+async function checkOnChainPricing(
+  oswap: OSwap,
+  pool: OSwapPool,
+  blockNumber: number,
+  prices: bigint[],
+  side: SwapSide,
+  srcAddress: Address,
+  destAddress: Address,
+  amounts: bigint[],
+) {
+  // Get the onchain trade rates from the pool and calculate the prices.
+  const data = await getOnchainTraderates(oswap, pool, blockNumber);
+  let expectedPrices: bigint[] = [];
+  for (const amount of amounts) {
+    const rate =
+      srcAddress.toLowerCase() === pool.token0
+        ? data.traderate0
+        : data.traderate1;
+    if (side === SwapSide.SELL) {
+      expectedPrices.push((amount * rate) / getBigIntPow(36));
+    } else {
+      // SwapSide.BUY
+      expectedPrices.push((amount * getBigIntPow(36)) / rate);
+    }
+  }
+  expect(prices).toEqual(expectedPrices);
+}
+
+async function testPricingOnNetwork(
+  oswap: OSwap,
+  network: Network,
+  dexKey: string,
+  blockNumber: number,
+  srcTokenSymbol: string,
+  destTokenSymbol: string,
+  side: SwapSide,
+  amounts: bigint[],
+) {
+  const networkTokens = Tokens[network];
+  const srcToken = networkTokens[srcTokenSymbol];
+  const destToken = networkTokens[destTokenSymbol];
+
+  const poolIds = await oswap.getPoolIdentifiers(
+    srcToken,
+    destToken,
+    side,
+    blockNumber,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Identifiers: ${poolIds}`,
+  );
+
+  expect(poolIds.length).toBeGreaterThan(0);
+
+  // Get calculated prices based on the stored state.
+  const poolPrices = await oswap.getPricesVolume(
+    srcToken,
+    destToken,
+    amounts,
+    side,
+    blockNumber,
+    poolIds,
+  );
+  console.log(
+    `${side} ${srcTokenSymbol} <> ${destTokenSymbol} Pool Prices: `,
+    poolPrices,
+  );
+
+  expect(poolPrices).not.toBeNull();
+  if (oswap.hasConstantPriceLargeAmounts) {
+    checkConstantPoolPrices(poolPrices!, amounts, dexKey);
+  } else {
+    checkPoolPrices(poolPrices!, amounts, side, dexKey);
+  }
+
+  // Check that the prices calculated from onchain data match with the ones calculated from the stored state.
+  const pool = oswap.getPoolById(poolIds[0]);
+  expect(pool).not.toBeNull();
+  await checkOnChainPricing(
+    oswap,
+    pool as OSwapPool,
+    blockNumber,
+    poolPrices![0].prices,
+    side,
+    srcToken.address,
+    destToken.address,
+    amounts,
+  );
+}
+
+describe('OSwap', function () {
+  const dexKey = 'OSwap';
+  let blockNumber: number;
+  let oswap: OSwap;
+
+  describe('Mainnet', () => {
+    const network = Network.MAINNET;
+    const dexHelper = new DummyDexHelper(network);
+
+    const tokens = Tokens[network];
+
+    const srcTokenSymbol = 'WETH';
+    const destTokenSymbol = 'STETH';
+
+    const amountsForSell = [
+      0n,
+      1n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      2n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      3n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      4n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      5n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      6n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      7n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      8n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      9n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      10n * BI_POWS[tokens[srcTokenSymbol].decimals],
+    ];
+
+    const amountsForBuy = [
+      0n,
+      1n * BI_POWS[tokens[destTokenSymbol].decimals],
+      2n * BI_POWS[tokens[destTokenSymbol].decimals],
+      3n * BI_POWS[tokens[destTokenSymbol].decimals],
+      4n * BI_POWS[tokens[destTokenSymbol].decimals],
+      5n * BI_POWS[tokens[destTokenSymbol].decimals],
+      6n * BI_POWS[tokens[destTokenSymbol].decimals],
+      7n * BI_POWS[tokens[destTokenSymbol].decimals],
+      8n * BI_POWS[tokens[destTokenSymbol].decimals],
+      9n * BI_POWS[tokens[destTokenSymbol].decimals],
+      10n * BI_POWS[tokens[destTokenSymbol].decimals],
+    ];
+
+    // Return a blockNumber to use for the tests.
+    // Check that the pool has enough liquidity to run the tests at the current blockNumber.
+    // If not, fallback to a known blockNumber in the past with
+    // high enough liquidity - the on-chain queries will just be a bit slower to execute.
+    async function getBlockNumberForTesting(oswap: OSwap): Promise<number> {
+      const DEFAULT_BLOCK_NUMBER = 18888241;
+
+      blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      const srcToken = Tokens[network][srcTokenSymbol];
+      const destToken = Tokens[network][destTokenSymbol];
+
+      // Get the pool and its state for the given test pair.
+      const pool = oswap.getPoolByTokenPair(srcToken, destToken);
+      if (!pool)
+        throw new Error(
+          `No pool found for pair ${srcTokenSymbol}-${destTokenSymbol}`,
+        );
+
+      const eventPool = oswap.eventPools[pool.id];
+      const state = await eventPool.getStateOrGenerate(blockNumber, true);
+
+      // Sum up all the amounts from the test scenarios.
+      const sellTotalAmount = amountsForSell.reduce(
+        (a: bigint, b: bigint) => a + b,
+        BigInt(0),
+      );
+      const buyTotalAmount = amountsForBuy.reduce(
+        (a: bigint, b: bigint) => a + b,
+        BigInt(0),
+      );
+
+      if (
+        !oswap.checkLiquidity(
+          pool,
+          state,
+          srcToken,
+          sellTotalAmount,
+          SwapSide.SELL,
+        ) ||
+        !oswap.checkLiquidity(
+          pool,
+          state,
+          destToken,
+          buyTotalAmount,
+          SwapSide.BUY,
+        )
+      ) {
+        return DEFAULT_BLOCK_NUMBER;
+      }
+      return blockNumber;
+    }
+
+    beforeAll(async () => {
+      oswap = new OSwap(network, dexKey, dexHelper);
+
+      blockNumber = await getBlockNumberForTesting(oswap);
+    });
+
+    it('getPoolIdentifiers and getPricesVolume SELL', async function () {
+      await testPricingOnNetwork(
+        oswap,
+        network,
+        dexKey,
+        blockNumber,
+        srcTokenSymbol,
+        destTokenSymbol,
+        SwapSide.SELL,
+        amountsForSell,
+      );
+    });
+
+    it('getPoolIdentifiers and getPricesVolume BUY', async function () {
+      await testPricingOnNetwork(
+        oswap,
+        network,
+        dexKey,
+        blockNumber,
+        srcTokenSymbol,
+        destTokenSymbol,
+        SwapSide.BUY,
+        amountsForBuy,
+      );
+    });
+
+    it('getTopPoolsForToken', async function () {
+      // We have to check without calling initializePricing, because
+      // pool-tracker is not calling that function
+      const newOSwap = new OSwap(network, dexKey, dexHelper);
+      if (newOSwap.updatePoolState) {
+        await newOSwap.updatePoolState();
+      }
+
+      const poolLiquidity = await newOSwap.getTopPoolsForToken(
+        tokens[srcTokenSymbol].address,
+        10,
+      );
+
+      if (!newOSwap.hasConstantPriceLargeAmounts) {
+        checkPoolsLiquidity(
+          poolLiquidity,
+          Tokens[network][srcTokenSymbol].address,
+          dexKey,
+        );
+      }
+    });
+  });
+});

--- a/src/dex/oswap/oswap-pool.ts
+++ b/src/dex/oswap/oswap-pool.ts
@@ -1,0 +1,190 @@
+import { Interface } from '@ethersproject/abi';
+import { DeepReadonly } from 'ts-essentials';
+import { Log, Logger, Token } from '../../types';
+import { catchParseLogError } from '../../utils';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { MultiCallParams } from '../../lib/multi-wrapper';
+import { uint256ToBigInt } from '../../lib/decoders';
+import { OSwapPool, OSwapPoolState } from './types';
+import OSwapABI from '../../abi/oswap/oswap.abi.json';
+import ERC20ABI from '../../abi/ERC20.abi.json';
+
+export class OSwapEventPool extends StatefulEventSubscriber<OSwapPoolState> {
+  handlers: {
+    [event: string]: (
+      event: any,
+      state: DeepReadonly<OSwapPoolState>,
+      log: Readonly<Log>,
+    ) => DeepReadonly<OSwapPoolState> | null;
+  } = {};
+
+  logDecoder: (log: Log) => any;
+
+  addressesSubscribed: string[];
+
+  constructor(
+    readonly parentName: string,
+    readonly pool: OSwapPool,
+    protected network: number,
+    protected dexHelper: IDexHelper,
+    logger: Logger,
+    protected iOSwap = new Interface(OSwapABI),
+    protected iERC20 = new Interface(ERC20ABI),
+  ) {
+    super(parentName, pool.id, dexHelper, logger);
+
+    this.logDecoder = (log: Log) => this.parseLog(log);
+
+    this.addressesSubscribed = [pool.address, pool.token0, pool.token1];
+    this.handlers['TraderateChanged'] = this.handleTraderateChanged.bind(this);
+    this.handlers['Transfer'] = this.handleTransfer.bind(this);
+  }
+
+  protected parseLog(log: Log) {
+    if (log.address.toLowerCase() === this.pool.address) {
+      return this.iOSwap.parseLog(log);
+    }
+    return this.iERC20.parseLog(log);
+  }
+
+  /**
+   * The function is called every time any of the subscribed
+   * addresses release log. The function accepts the current
+   * state, updates the state according to the log, and returns
+   * the updated state.
+   * @param state - Current state of event subscriber
+   * @param log - Log released by one of the subscribed addresses
+   * @returns Updates state of the event subscriber after the log
+   */
+  protected processLog(
+    state: DeepReadonly<OSwapPoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<OSwapPoolState> | null {
+    try {
+      const event = this.logDecoder(log);
+      if (event.name in this.handlers) {
+        return this.handlers[event.name](event, state, log);
+      }
+    } catch (e) {
+      catchParseLogError(e, this.logger);
+    }
+
+    return null;
+  }
+
+  /**
+   * The function generates state using on-chain calls. This
+   * function is called to regenerate state if the event based
+   * system fails to fetch events and the local state is no
+   * more correct.
+   * @param blockNumber - Blocknumber for which the state should
+   * should be generated
+   * @returns state of the event subscriber at blocknumber
+   */
+  async generateState(
+    blockNumber: number,
+  ): Promise<DeepReadonly<OSwapPoolState>> {
+    const iERC20 = new Interface(ERC20ABI);
+    const callData: MultiCallParams<bigint>[] = [
+      {
+        target: this.pool.token0,
+        callData: iERC20.encodeFunctionData('balanceOf', [this.pool.address]),
+        decodeFunction: uint256ToBigInt,
+      },
+      {
+        target: this.pool.token1,
+        callData: iERC20.encodeFunctionData('balanceOf', [this.pool.address]),
+        decodeFunction: uint256ToBigInt,
+      },
+      {
+        target: this.pool.address,
+        callData: this.iOSwap.encodeFunctionData('traderate0', []),
+        decodeFunction: uint256ToBigInt,
+      },
+      {
+        target: this.pool.address,
+        callData: this.iOSwap.encodeFunctionData('traderate1', []),
+        decodeFunction: uint256ToBigInt,
+      },
+    ];
+
+    const results = await this.dexHelper.multiWrapper.aggregate<bigint>(
+      callData,
+      blockNumber,
+      this.dexHelper.multiWrapper.defaultBatchSize,
+    );
+
+    return {
+      balance0: results[0],
+      balance1: results[1],
+      traderate0: results[2],
+      traderate1: results[3],
+    };
+  }
+
+  async getStateOrGenerate(
+    blockNumber: number,
+    readonly: boolean = true,
+  ): Promise<OSwapPoolState> {
+    let state = this.getState(blockNumber);
+    if (!state) {
+      state = await this.generateState(blockNumber);
+      if (!readonly) this.setState(state, blockNumber);
+    }
+    return state;
+  }
+
+  /**
+   * Handle a trade rate change on the pool.
+   */
+  handleTraderateChanged(
+    event: any,
+    state: DeepReadonly<OSwapPoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<OSwapPoolState> | null {
+    return {
+      ...state,
+      traderate0: event.args.traderate0.toBigInt(),
+      traderate1: event.args.traderate1.toBigInt(),
+    };
+  }
+
+  /**
+   * Process the transfer events for tokens in/out of the pool
+   * to keep the state's token balances up to date.
+   */
+  handleTransfer(
+    event: any,
+    state: DeepReadonly<OSwapPoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<OSwapPoolState> | null {
+    let balance0: bigint = state.balance0;
+    let balance1: bigint = state.balance1;
+
+    const tokenAddress = log.address.toLowerCase();
+    const fromAddress = event.args.from.toLowerCase();
+    const toAddress = event.args.to.toLowerCase();
+    const amount = event.args.value.toBigInt();
+
+    if (fromAddress == this.pool.address) {
+      if (tokenAddress === this.pool.token0) {
+        balance0 -= amount;
+      } else if (tokenAddress === this.pool.token1) {
+        balance1 -= amount;
+      }
+    } else if (toAddress == this.pool.address) {
+      if (tokenAddress === this.pool.token0) {
+        balance0 += amount;
+      } else if (tokenAddress === this.pool.token1) {
+        balance1 += amount;
+      }
+    }
+
+    return {
+      ...state,
+      balance0,
+      balance1,
+    };
+  }
+}

--- a/src/dex/oswap/oswap.ts
+++ b/src/dex/oswap/oswap.ts
@@ -74,11 +74,12 @@ export class OSwap extends SimpleExchange implements IDex<OSwapData> {
   }
 
   // Returns the pool matching the specified token pair or null if none found.
+  // Note: OSwap V1 does not support more than 1 pool per pair.
   getPoolByTokenPair(srcToken: Token, destToken: Token): OSwapPool | null {
     const srcAddress = srcToken.address.toLowerCase();
     const destAddress = destToken.address.toLowerCase();
 
-    // A pair can only be made of 2 different tokens.
+    // A pair must have 2 different tokens.
     if (srcAddress === destAddress) return null;
 
     for (const pool of this.pools) {

--- a/src/dex/oswap/oswap.ts
+++ b/src/dex/oswap/oswap.ts
@@ -1,0 +1,367 @@
+import { Interface } from '@ethersproject/abi';
+import { AsyncOrSync } from 'ts-essentials';
+import {
+  Token,
+  Address,
+  ExchangePrices,
+  PoolPrices,
+  AdapterExchangeParam,
+  SimpleExchangeParam,
+  PoolLiquidity,
+  Logger,
+} from '../../types';
+import { SwapSide, Network } from '../../constants';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+import { getDexKeysWithNetwork, getBigIntPow } from '../../utils';
+import { IDex } from '../../dex/idex';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { OSwapData, OSwapPool, OSwapPoolState } from './types';
+import {
+  SimpleExchange,
+  getLocalDeadlineAsFriendlyPlaceholder,
+} from '../simple-exchange';
+import { OSwapConfig, Adapters, OSWAP_GAS_COST } from './config';
+import { OSwapEventPool } from './oswap-pool';
+import OSwapABI from '../../abi/oswap/oswap.abi.json';
+
+export class OSwap extends SimpleExchange implements IDex<OSwapData> {
+  readonly eventPools: { [id: string]: OSwapEventPool } = {};
+
+  readonly hasConstantPriceLargeAmounts = false;
+
+  // This may change in the future, but currently OSwap does not support native ETH.
+  readonly needWrapNative = true;
+
+  readonly isFeeOnTransferSupported = false;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(OSwapConfig);
+
+  logger: Logger;
+
+  readonly iOSwap: Interface;
+
+  readonly pools: [OSwapPool];
+
+  constructor(
+    readonly network: Network,
+    readonly dexKey: string,
+    readonly dexHelper: IDexHelper,
+    protected adapters = Adapters[network] || {},
+  ) {
+    super(dexHelper, dexKey);
+    this.logger = dexHelper.getLogger(dexKey);
+    this.iOSwap = new Interface(OSwapABI);
+
+    this.pools = OSwapConfig[dexKey][network].pools;
+
+    // Create an OSwapEventPool per pool, to track each pool's state by subscribing to on-chain events.
+    for (const pool of this.pools) {
+      this.eventPools[pool.id] = new OSwapEventPool(
+        dexKey,
+        pool,
+        network,
+        dexHelper,
+        this.logger,
+      );
+    }
+  }
+
+  // Returns the list of contract adapters (name and index)
+  // for a buy/sell. Return null if there are no adapters.
+  getAdapters(side: SwapSide): { name: string; index: number }[] | null {
+    return this.adapters[side] ? this.adapters[side] : null;
+  }
+
+  // Returns the pool matching the specified token pair or null if none found.
+  getPoolByTokenPair(srcToken: Token, destToken: Token): OSwapPool | null {
+    const srcAddress = srcToken.address.toLowerCase();
+    const destAddress = destToken.address.toLowerCase();
+
+    // A pair can only be made of 2 different tokens.
+    if (srcAddress === destAddress) return null;
+
+    for (const pool of this.pools) {
+      if (
+        (srcAddress === pool.token0 && destAddress === pool.token1) ||
+        (srcAddress === pool.token1 && destAddress === pool.token0)
+      ) {
+        return pool;
+      }
+    }
+    return null;
+  }
+
+  getPoolById(id: string): OSwapPool | null {
+    for (const pool of this.pools) {
+      if (pool.id === id) return pool;
+    }
+    return null;
+  }
+
+  // Returns a list of pool using the token.
+  getPoolsByTokenAddress(tokenAddress: Address): OSwapPool[] {
+    const address = tokenAddress.toLowerCase();
+    let pools: OSwapPool[] = [];
+    for (const pool of this.pools) {
+      if (address === pool.token0 || address === pool.token1) {
+        pools.push(pool);
+      }
+    }
+    return pools;
+  }
+
+  // Returns the list of pool identifiers that can be used
+  // for a given swap. poolIdentifiers must be unique
+  // across DEXes. It is recommended to use
+  // ${dexKey}_${poolAddress} as a poolIdentifier
+  async getPoolIdentifiers(
+    srcToken: Token,
+    destToken: Token,
+    side: SwapSide,
+    blockNumber: number,
+  ): Promise<string[]> {
+    const pool = this.getPoolByTokenPair(srcToken, destToken);
+    return pool ? [pool.id] : [];
+  }
+
+  // Sell: Given "amount" of "from" token, how much of "to" token will be received by the trader.
+  // Buy: Given "amount" of "dest" token, how much of "to" token is required from the trader.
+  // Note: OSwap traderate is at precision 36.
+  calcPrice(
+    pool: OSwapPool,
+    state: OSwapPoolState,
+    from: Token,
+    amount: bigint,
+    side: SwapSide,
+  ): bigint {
+    const rate =
+      from.address.toLowerCase() === pool.token0
+        ? state.traderate0
+        : state.traderate1;
+    return side === SwapSide.SELL
+      ? (amount * rate) / getBigIntPow(36)
+      : (amount * getBigIntPow(36)) / rate;
+  }
+
+  // Returns true if the pool has enough liquidity for the swap. False otherwise.
+  checkLiquidity(
+    pool: OSwapPool,
+    state: OSwapPoolState,
+    from: Token,
+    amount: bigint,
+    side: SwapSide,
+  ): boolean {
+    if (side === SwapSide.SELL) {
+      const needed = this.calcPrice(pool, state, from, amount, side);
+      return from.address.toLowerCase() === pool.token0
+        ? needed <= state.balance1
+        : needed <= state.balance0;
+    }
+    // SwapSide.BUY
+    return from.address.toLowerCase() === pool.token0
+      ? amount <= state.balance1
+      : amount <= state.balance0;
+  }
+
+  // Returns pool prices for amounts.
+  // If limitPools is defined only pools in limitPools
+  // should be used. If limitPools is undefined then
+  // any pool can be used.
+  async getPricesVolume(
+    srcToken: Token,
+    destToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    limitPools?: string[],
+  ): Promise<null | ExchangePrices<OSwapData>> {
+    // Get the pool to use.
+    const pool = this.getPoolByTokenPair(srcToken, destToken);
+    if (!pool) return null;
+
+    // Make sure the pool meets the optional limitPools filter.
+    if (limitPools && !limitPools.includes(pool.id)) return null;
+
+    const eventPool = this.eventPools[pool.id];
+    if (!eventPool)
+      throw new Error(`OSwap pool ${pool.id}: No EventPool found.`);
+
+    const state = await eventPool.getStateOrGenerate(blockNumber);
+
+    // Ensure there is enough liquidity in the pool to process all the requested swaps.
+    const totalAmount = amounts.reduce(
+      (a: bigint, b: bigint) => a + b,
+      BigInt(0),
+    );
+    if (!this.checkLiquidity(pool, state, srcToken, totalAmount, side)) {
+      return null;
+    }
+    // Calculate the prices
+    const unitAmount = getBigIntPow(18);
+    const unitPrice = this.calcPrice(pool, state, srcToken, unitAmount, side);
+    const prices = amounts.map(amount =>
+      this.calcPrice(pool, state, srcToken, amount, side),
+    );
+
+    return [
+      {
+        prices,
+        unit: unitPrice,
+        data: {
+          pool: pool.address,
+          receiver: this.augustusAddress,
+          path: [srcToken.address, destToken.address],
+        },
+        exchange: this.dexKey,
+        poolIdentifier: pool.id,
+        gasCost: OSWAP_GAS_COST,
+        poolAddresses: [pool.address],
+      },
+    ];
+  }
+
+  // Returns estimated gas cost of calldata for this DEX in multiSwap
+  getCalldataGasCost(poolPrices: PoolPrices<OSwapData>): number | number[] {
+    return (
+      CALLDATA_GAS_COST.DEX_OVERHEAD +
+      // ParentStruct header
+      CALLDATA_GAS_COST.OFFSET_SMALL +
+      // ParentStruct -> path[] header
+      CALLDATA_GAS_COST.OFFSET_SMALL +
+      // ParentStruct -> path length
+      CALLDATA_GAS_COST.LENGTH_SMALL +
+      // ParentStruct -> path[0]
+      CALLDATA_GAS_COST.ADDRESS +
+      // ParentStruct -> path[1]
+      CALLDATA_GAS_COST.ADDRESS +
+      // ParentStruct -> receiver header
+      CALLDATA_GAS_COST.OFFSET_SMALL +
+      // ParentStruct -> receiver
+      CALLDATA_GAS_COST.ADDRESS
+    );
+  }
+
+  // Encode params required by the exchange adapter
+  // Used for multiSwap, buy & megaSwap
+  getAdapterParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: OSwapData,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    const payload = this.abiCoder.encodeParameter(
+      {
+        ParentStruct: {
+          path: 'address[]',
+          receiver: 'address',
+        },
+      },
+      {
+        path: data.path,
+        receiver: data.receiver,
+      },
+    );
+    return {
+      targetExchange: data.pool,
+      payload,
+      networkFee: '0',
+    };
+  }
+
+  // Encode call data used by simpleSwap like routers
+  // Used for simpleSwap & simpleBuy
+  async getSimpleParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: OSwapData,
+    side: SwapSide,
+  ): Promise<SimpleExchangeParam> {
+    let method: string;
+    let args: any;
+
+    const deadline = getLocalDeadlineAsFriendlyPlaceholder();
+    if (side === SwapSide.SELL) {
+      method = 'swapExactTokensForTokens';
+      args = [srcAmount, destAmount, data.path, data.receiver, deadline];
+    } else {
+      method = 'swapTokensForExactTokens';
+      args = [destAmount, srcAmount, data.path, data.receiver, deadline];
+    }
+
+    const swapData = this.iOSwap.encodeFunctionData(method, args);
+
+    return this.buildSimpleParamWithoutWETHConversion(
+      srcToken,
+      srcAmount,
+      destToken,
+      destAmount,
+      swapData,
+      data.pool,
+    );
+  }
+
+  // This is called once before getTopPoolsForToken is
+  // called for multiple tokens. This can be helpful to
+  // update common state required for calculating
+  // getTopPoolsForToken. It is optional for a DEX
+  // to implement this
+  async updatePoolState(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  // Returns a list of top pools based on liquidity. Max
+  // limit number pools should be returned.
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    limit: number,
+  ): Promise<PoolLiquidity[]> {
+    // Get the list of pools using the token.
+    const pools = this.getPoolsByTokenAddress(tokenAddress);
+    if (!pools.length) return [];
+
+    const results = await Promise.all<PoolLiquidity>(
+      pools.map(async pool => {
+        // Get the pool's balance and its USD value.
+        const eventPool = this.eventPools[pool.id];
+        const blockNumber =
+          await this.dexHelper.web3Provider.eth.getBlockNumber();
+        const state = await eventPool.getStateOrGenerate(blockNumber);
+
+        const usd0 = await this.dexHelper.getTokenUSDPrice(
+          { address: pool.token0, decimals: 18 },
+          state.balance0,
+        );
+        const usd1 = await this.dexHelper.getTokenUSDPrice(
+          { address: pool.token1, decimals: 18 },
+          state.balance1,
+        );
+
+        // Get the other token in the pair.
+        const pairedToken =
+          pool.token0 === tokenAddress.toLowerCase()
+            ? { address: pool.token1, decimals: 18 }
+            : { address: pool.token0, decimals: 18 };
+
+        return {
+          exchange: this.dexKey,
+          address: pool.address,
+          connectorTokens: [pairedToken],
+          liquidityUSD: usd0 + usd1,
+        };
+      }),
+    );
+    return results
+      .filter(r => r)
+      .sort((a, b) => a.liquidityUSD - b.liquidityUSD)
+      .slice(0, limit);
+  }
+
+  // This is optional function in case if your implementation has acquired any resources
+  // you need to release for graceful shutdown. For example, it may be any interval timer
+  releaseResources(): AsyncOrSync<void> {}
+}

--- a/src/dex/oswap/types.ts
+++ b/src/dex/oswap/types.ts
@@ -1,0 +1,30 @@
+import { Address } from '../../types';
+
+// OSwapPoolState is the state of the event subscriber. It is the minimum
+// set of parameters required to compute pool prices.
+export type OSwapPoolState = {
+  traderate0: bigint;
+  traderate1: bigint;
+  balance0: bigint;
+  balance1: bigint;
+};
+
+// OSwapPoolState is the state of the event subscriber. It is the minimum
+// set of parameters required to compute pool prices.
+export type OSwapData = {
+  pool: Address;
+  receiver: Address;
+  path: Address[];
+};
+
+// Each pool has a contract address and token pairs.
+export type OSwapPool = {
+  id: string;
+  address: Address,
+  token0: Address,
+  token1: Address
+};
+
+export type DexParams = {
+  pools: [OSwapPool];
+};


### PR DESCRIPTION
This PR adds support for a new DEX: OSwap.

**OSwap**
OSwap is a Mainnet DEX built by the team at [Origin Protocol](https://originprotocol.com).
In its V1, OSwap is hyper focused on a few LST pairs. Some characteristics of the V1 include:
- Super gas optimized contract (~12K gas for a swap, excluding tokens transfer cost)
- Very low fees, typically under 1bps (lower than Curve and Uniswap).
- Currently $1.25M in liquidity

The first pair to launch (more to come) is WETH/stETH. It went live last year on Mainnet and within less than 2 weeks has achieved over $10M in trading volume.

**Deployment address**
The WETH/stETH pool is deployed on Mainnet at address [0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6](https://etherscan.io/address/0x85B78AcA6Deae198fBF201c82DAF6Ca21942acc6)

**Contract code and documentation**
The contracts code and documentation can be found in this open source repository: https://github.com/OriginProtocol/origin-swap

**Interface**
There is no router, each pair has a pool that should be called directly for doing swaps.
The pool's interface is Uniswap V2 Router compatible: it exposes the methods swapExactTokensForTokens and swapTokensForExactTokens.

**Integration**
- Adapters: we made the decision to re-use the Smardex adapters given that they implement the Uniswap V2 Router swap interface. We felt this would be less work for the Paraswap team vs having to write and deploy yet another adapter contract for OSwap.
- Each pair is serviced by a separate pool, with its associated token pair and deployment addresses defined in the config file.
- Note that at the moment OSwap does not support native ETH, only WETH. We may add support for it in the future.

**Tests**
Tests can be run via `yarn test-integration oswap`