### PR TITLE
Feature: VirtuSwap integration

### DIFF
--- a/src/abi/virtuswap/vPair.json
+++ b/src/abi/virtuswap/vPair.json
@@ -1,0 +1,1128 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "tokens",
+        "type": "address[]"
+      }
+    ],
+    "name": "AllowListChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newBlocksDelay",
+        "type": "uint256"
+      }
+    ],
+    "name": "BlocksDelayChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalSupply",
+        "type": "uint256"
+      }
+    ],
+    "name": "Burn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "fee",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "vFee",
+        "type": "uint16"
+      }
+    ],
+    "name": "FeeChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "lpTokens",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "poolLPTokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newReserveRatioWarningThreshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReserveRatioWarningThresholdChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rRatio",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReserveSync",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newThreshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReserveThresholdChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "Swap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "ikPool",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "SwapReserve",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "balance0",
+        "type": "uint112"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint112",
+        "name": "balance1",
+        "type": "uint112"
+      }
+    ],
+    "name": "vSync",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "allowList",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "allowListLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "allowListMap",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "blocksDelay",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount1",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "calculateReserveRatio",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "rRatio",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "closed",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "emergencyToggle",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fee",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBalances",
+    "outputs": [
+      {
+        "internalType": "uint112",
+        "name": "_balance0",
+        "type": "uint112"
+      },
+      {
+        "internalType": "uint112",
+        "name": "_balance1",
+        "type": "uint112"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTokens",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "_token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_token1",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastSwapBlock",
+    "outputs": [
+      {
+        "internalType": "uint128",
+        "name": "",
+        "type": "uint128"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "reserveToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "nativePool",
+        "type": "address"
+      }
+    ],
+    "name": "liquidateReserve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxReserveRatio",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pairBalance0",
+    "outputs": [
+      {
+        "internalType": "uint112",
+        "name": "",
+        "type": "uint112"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pairBalance1",
+    "outputs": [
+      {
+        "internalType": "uint112",
+        "name": "",
+        "type": "uint112"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveRatioFactor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveRatioWarningThreshold",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "reserves",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "reservesBaseValue",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reservesBaseValueSum",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_allowList",
+        "type": "address[]"
+      }
+    ],
+    "name": "setAllowList",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint128",
+        "name": "_newBlocksDelay",
+        "type": "uint128"
+      }
+    ],
+    "name": "setBlocksDelay",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint16",
+        "name": "_fee",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "_vFee",
+        "type": "uint16"
+      }
+    ],
+    "name": "setFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "threshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxReserveThreshold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_reserveRatioWarningThreshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "setReserveRatioWarningThreshold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "swapNative",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_amountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "incentivesLimitPct",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "swapNativeToReserve",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "_leftoverToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_leftoverAmount",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "swapReserveToNative",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token0",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token1",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vFee",
+    "outputs": [
+      {
+        "internalType": "uint16",
+        "name": "",
+        "type": "uint16"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abi/virtuswap/vPairFactory.json
+++ b/src/abi/virtuswap/vPairFactory.json
@@ -1,0 +1,422 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "allowList",
+        "type": "address[]"
+      }
+    ],
+    "name": "DefaultAllowListChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newExchangeReserve",
+        "type": "address"
+      }
+    ],
+    "name": "ExchangeReserveAddressChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "FactoryNewAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newEmergencyAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "FactoryNewEmergencyAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newPendingAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "FactoryNewPendingAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newPendingEmergencyAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "FactoryNewPendingEmergencyAdmin",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newVPoolManager",
+        "type": "address"
+      }
+    ],
+    "name": "FactoryVPoolManagerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "poolAddress",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "factory",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "fee",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "vFee",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxReserveRatio",
+        "type": "uint256"
+      }
+    ],
+    "name": "PairCreated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "acceptAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptEmergencyAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "admin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "allPairs",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "allPairsLength",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenA",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenB",
+        "type": "address"
+      }
+    ],
+    "name": "createPair",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "pair",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "emergencyAdmin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "exchangeReserves",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "pairs",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingAdmin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingEmergencyAdmin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "poolCreationDefaults",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "factory",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      },
+      {
+        "internalType": "uint16",
+        "name": "fee",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint16",
+        "name": "vFee",
+        "type": "uint16"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxReserveRatio",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "_defaultAllowList",
+        "type": "address[]"
+      }
+    ],
+    "name": "setDefaultAllowList",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_exchangeReserves",
+        "type": "address"
+      }
+    ],
+    "name": "setExchangeReservesAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newPendingAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "setPendingAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newPendingEmergencyAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "setPendingEmergencyAdmin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_vPoolManager",
+        "type": "address"
+      }
+    ],
+    "name": "setVPoolManagerAddress",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vPoolManager",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abi/virtuswap/vPoolManager.json
+++ b/src/abi/virtuswap/vPoolManager.json
@@ -1,0 +1,186 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_pairFactory",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "jkPair",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      }
+    ],
+    "name": "getVirtualPool",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint24",
+            "name": "fee",
+            "type": "uint24"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance1",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "commonToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "jkPair",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "ikPair",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct VirtualPoolModel",
+        "name": "vPool",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      }
+    ],
+    "name": "getVirtualPools",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint24",
+            "name": "fee",
+            "type": "uint24"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance1",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "commonToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "jkPair",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "ikPair",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct VirtualPoolModel[]",
+        "name": "vPools",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pairFactory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "jkPair",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balance0",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "balance1",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateVirtualPoolBalances",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/abi/virtuswap/vRouter.json
+++ b/src/abi/virtuswap/vRouter.json
@@ -1,0 +1,1021 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_factory",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_WETH9",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newFactoryAddress",
+        "type": "address"
+      }
+    ],
+    "name": "RouterFactoryChanged",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "WETH9",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenA",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenB",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountADesired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountBDesired",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountAMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountBMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "addLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountB",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "pairAddress",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_factory",
+        "type": "address"
+      }
+    ],
+    "name": "changeFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "factory",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAmountIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAmountOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAmountsIn",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsIn",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAmountsOut",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "amountsOut",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "jkPair",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      }
+    ],
+    "name": "getMaxVirtualTradeAmountRtoN",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "jkPair",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "getVirtualAmountIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "jkPair",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "getVirtualAmountOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "jkPair",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      }
+    ],
+    "name": "getVirtualPool",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint24",
+            "name": "fee",
+            "type": "uint24"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance1",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "commonToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "jkPair",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "ikPair",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct VirtualPoolModel",
+        "name": "vPool",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token0",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1",
+        "type": "address"
+      }
+    ],
+    "name": "getVirtualPools",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint24",
+            "name": "fee",
+            "type": "uint24"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "balance1",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "commonToken",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "jkPair",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "ikPair",
+            "type": "address"
+          }
+        ],
+        "internalType": "struct VirtualPoolModel[]",
+        "name": "vPools",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "data",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "multicall",
+    "outputs": [
+      {
+        "internalType": "bytes[]",
+        "name": "results",
+        "type": "bytes[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "inputToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "outputToken",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      }
+    ],
+    "name": "quote",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenA",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenB",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "liquidity",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountAMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountBMin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "removeLiquidity",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountA",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountB",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapETHForExactTokens",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactETHForTokens",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactTokensForETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactTokensForTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "commonToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapReserveETHForExactTokens",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "commonToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapReserveExactETHForTokens",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "commonToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapReserveExactTokensForETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "commonToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minAmountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapReserveExactTokensForTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "commonToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapReserveTokensForExactETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "commonToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "ikPair",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapReserveTokensForExactTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTokensForExactETH",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "path",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapTokensForExactTokens",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+]

--- a/src/config.ts
+++ b/src/config.ts
@@ -200,6 +200,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
       PolygonAdapter01: '0xE44769f42E1e9592f86B82f206407a8f7C84b4ed',
       PolygonAdapter02: '0x84bEF12C9931cE12662cc9F2366b6a5029E4BD29',
       PolygonBuyAdapter: '0xBAEeb4540f59d30E567a5B563CC0c4587eDd9366',
+      PolygonVirtuSwapAdapter: '', //TODO: deploy VirtuSwap adapter from https://github.com/Virtuswap/v1-core/blob/paraswap/contracts/paraswap/VirtuSwapAdapter.sol
     },
     uniswapV2ExchangeRouterAddress:
       '0xf3938337F7294fEf84e9B2c6D548A93F956Cc281',
@@ -294,6 +295,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
       ArbitrumAdapter02: '0x58a5f0b73969800FAFf8556cD2187E3FCE71A6cb',
       ArbitrumAdapter03: '0x97bdD2B98D9802b0e387FefdB2882C1b2dc2c344',
       ArbitrumBuyAdapter: '0x005213c48d4aafFcA0b6D1CbA8710F4D035C18f9',
+      ArbitrumVirtuSwapAdapter: '', //TODO: deploy VirtuSwap adapter from https://github.com/Virtuswap/v1-core/blob/paraswap/contracts/paraswap/VirtuSwapAdapter.sol
     },
     uniswapV2ExchangeRouterAddress:
       '0xB41dD984730dAf82f5C41489E21ac79D5e3B61bC',

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -87,6 +87,7 @@ import { Wombat } from './wombat/wombat';
 import { Swell } from './swell/swell';
 import { PharaohV1 } from './solidly/forks-override/pharaohV1';
 import { EtherFi } from './etherfi';
+import { VirtuSwap } from './virtuswap/virtuswap';
 
 const LegacyDexes = [
   CurveV2,
@@ -170,6 +171,7 @@ const Dexes = [
   Wombat,
   Swell,
   PharaohV1,
+  VirtuSwap,
 ];
 
 export type LegacyDexConstructor = new (dexHelper: IDexHelper) => IDexTxBuilder<

--- a/src/dex/virtuswap/config.ts
+++ b/src/dex/virtuswap/config.ts
@@ -11,6 +11,8 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
         '0x637bc1e6555f050fef1c3804f2f03647a960ac0a39ac52c519c3c6d9da312ae0',
       router: '0x3E3d15ea98429E546f30215AEfBB69A4244A8Ea9',
       isTimestampBased: false,
+      realPoolGasCost: 150 * 1000, // TODO: specify gas cost
+      virtualPoolGasCost: 250 * 1000, // TODO: specify gas cost
     },
     [Network.ARBITRUM]: {
       factoryAddress: '0x389DB0B69e74A816f1367aC081FdF24B5C7C2433',
@@ -19,6 +21,8 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
         '0x759724dfe39927d24bcfec0e232ca16e126330842301d9947db2223f5ddca426',
       router: '0xB455da5a32E7E374dB6d1eDfdb86C167DD983f40',
       isTimestampBased: true,
+      realPoolGasCost: 150 * 1000, // TODO: specify gas cost
+      virtualPoolGasCost: 250 * 1000, // TODO: specify gas cost
     },
     // TODO: should something else be added?
   },

--- a/src/dex/virtuswap/config.ts
+++ b/src/dex/virtuswap/config.ts
@@ -6,6 +6,7 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
   VirtuSwap: {
     [Network.POLYGON]: {
       factoryAddress: '0xd4E3668A9C39ebB603f02A6987fC915dBC906B43',
+      vPoolManagerAddress: '0x2F5BAbA26070C548D424345B2bEc05943F633FaB',
       initCode:
         '0x637bc1e6555f050fef1c3804f2f03647a960ac0a39ac52c519c3c6d9da312ae0',
       router: '0x3E3d15ea98429E546f30215AEfBB69A4244A8Ea9',
@@ -13,8 +14,9 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
     },
     [Network.ARBITRUM]: {
       factoryAddress: '0x389DB0B69e74A816f1367aC081FdF24B5C7C2433',
+      vPoolManagerAddress: '0x0DFb6f538b0A8eDfB5aF03a47144b942004b1a26',
       initCode:
-        '0xdc4e81218e68ffcafc69ffad9b578a347f7fbeae462b5f9ce3c6538deb0443c2',
+        '0x759724dfe39927d24bcfec0e232ca16e126330842301d9947db2223f5ddca426',
       router: '0xB455da5a32E7E374dB6d1eDfdb86C167DD983f40',
       isTimestampBased: true,
     },

--- a/src/dex/virtuswap/config.ts
+++ b/src/dex/virtuswap/config.ts
@@ -13,6 +13,9 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
       isTimestampBased: false,
       realPoolGasCost: 265 * 1000,
       virtualPoolGasCost: 365 * 1000,
+      getTokensURL: 'https://api.virtuswap.io/graph/tokens?chainId=137',
+      getTokensPricesURL:
+        'https://api.virtuswap.io/tokensPricesUsd?chainId=137',
     },
     [Network.ARBITRUM]: {
       factoryAddress: '0x389DB0B69e74A816f1367aC081FdF24B5C7C2433',
@@ -23,6 +26,9 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
       isTimestampBased: true,
       realPoolGasCost: 345 * 1000, // Tenderly shows much higher values for Arbitrum for unknown reasons
       virtualPoolGasCost: 555 * 1000, // Tenderly shows much higher values for Arbitrum for unknown reasons
+      getTokensURL: 'https://api.virtuswap.io/graph/tokens?chainId=42161',
+      getTokensPricesURL:
+        'https://api.virtuswap.io/tokensPricesUsd?chainId=42161',
     },
   },
 };

--- a/src/dex/virtuswap/config.ts
+++ b/src/dex/virtuswap/config.ts
@@ -11,8 +11,8 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
         '0x637bc1e6555f050fef1c3804f2f03647a960ac0a39ac52c519c3c6d9da312ae0',
       router: '0x3E3d15ea98429E546f30215AEfBB69A4244A8Ea9',
       isTimestampBased: false,
-      realPoolGasCost: 225 * 1000,
-      virtualPoolGasCost: 315 * 1000,
+      realPoolGasCost: 265 * 1000,
+      virtualPoolGasCost: 365 * 1000,
     },
     [Network.ARBITRUM]: {
       factoryAddress: '0x389DB0B69e74A816f1367aC081FdF24B5C7C2433',
@@ -21,24 +21,23 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
         '0x759724dfe39927d24bcfec0e232ca16e126330842301d9947db2223f5ddca426',
       router: '0xB455da5a32E7E374dB6d1eDfdb86C167DD983f40',
       isTimestampBased: true,
-      realPoolGasCost: 315 * 1000, // Tenderly shows much higher values for Arbitrum for unknown reasons
-      virtualPoolGasCost: 465 * 1000, // Tenderly shows much higher values for Arbitrum for unknown reasons
+      realPoolGasCost: 345 * 1000, // Tenderly shows much higher values for Arbitrum for unknown reasons
+      virtualPoolGasCost: 555 * 1000, // Tenderly shows much higher values for Arbitrum for unknown reasons
     },
   },
 };
 
 export const Adapters: Record<number, AdapterMappings> = {
-  // TODO: update names and indexes?
   [Network.POLYGON]: {
     [SwapSide.SELL]: [
       {
-        name: 'PolygonAdapter01',
-        index: 4,
+        name: 'PolygonVirtuSwapAdapter',
+        index: 1,
       },
     ],
     [SwapSide.BUY]: [
       {
-        name: 'PolygonBuyAdapter',
+        name: 'PolygonVirtuSwapAdapter',
         index: 1,
       },
     ],
@@ -46,13 +45,13 @@ export const Adapters: Record<number, AdapterMappings> = {
   [Network.ARBITRUM]: {
     [SwapSide.SELL]: [
       {
-        name: 'ArbitrumAdapter01',
-        index: 2,
+        name: 'ArbitrumVirtuSwapAdapter',
+        index: 1,
       },
     ],
     [SwapSide.BUY]: [
       {
-        name: 'ArbitrumBuyAdapter',
+        name: 'ArbitrumVirtuSwapAdapter',
         index: 1,
       },
     ],

--- a/src/dex/virtuswap/config.ts
+++ b/src/dex/virtuswap/config.ts
@@ -11,8 +11,8 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
         '0x637bc1e6555f050fef1c3804f2f03647a960ac0a39ac52c519c3c6d9da312ae0',
       router: '0x3E3d15ea98429E546f30215AEfBB69A4244A8Ea9',
       isTimestampBased: false,
-      realPoolGasCost: 150 * 1000, // TODO: specify gas cost
-      virtualPoolGasCost: 250 * 1000, // TODO: specify gas cost
+      realPoolGasCost: 225 * 1000,
+      virtualPoolGasCost: 315 * 1000,
     },
     [Network.ARBITRUM]: {
       factoryAddress: '0x389DB0B69e74A816f1367aC081FdF24B5C7C2433',
@@ -21,10 +21,9 @@ export const VirtuSwapConfig: DexConfigMap<DexParams> = {
         '0x759724dfe39927d24bcfec0e232ca16e126330842301d9947db2223f5ddca426',
       router: '0xB455da5a32E7E374dB6d1eDfdb86C167DD983f40',
       isTimestampBased: true,
-      realPoolGasCost: 150 * 1000, // TODO: specify gas cost
-      virtualPoolGasCost: 250 * 1000, // TODO: specify gas cost
+      realPoolGasCost: 315 * 1000, // Tenderly shows much higher values for Arbitrum for unknown reasons
+      virtualPoolGasCost: 465 * 1000, // Tenderly shows much higher values for Arbitrum for unknown reasons
     },
-    // TODO: should something else be added?
   },
 };
 

--- a/src/dex/virtuswap/config.ts
+++ b/src/dex/virtuswap/config.ts
@@ -1,0 +1,55 @@
+import { DexParams } from './types';
+import { DexConfigMap, AdapterMappings } from '../../types';
+import { Network, SwapSide } from '../../constants';
+
+export const VirtuSwapConfig: DexConfigMap<DexParams> = {
+  VirtuSwap: {
+    [Network.POLYGON]: {
+      factoryAddress: '0xd4E3668A9C39ebB603f02A6987fC915dBC906B43',
+      initCode:
+        '0x637bc1e6555f050fef1c3804f2f03647a960ac0a39ac52c519c3c6d9da312ae0',
+      router: '0x3E3d15ea98429E546f30215AEfBB69A4244A8Ea9',
+      isTimestampBased: false,
+    },
+    [Network.ARBITRUM]: {
+      factoryAddress: '0x389DB0B69e74A816f1367aC081FdF24B5C7C2433',
+      initCode:
+        '0xdc4e81218e68ffcafc69ffad9b578a347f7fbeae462b5f9ce3c6538deb0443c2',
+      router: '0xB455da5a32E7E374dB6d1eDfdb86C167DD983f40',
+      isTimestampBased: true,
+    },
+    // TODO: should something else be added?
+  },
+};
+
+export const Adapters: Record<number, AdapterMappings> = {
+  // TODO: update names and indexes?
+  [Network.POLYGON]: {
+    [SwapSide.SELL]: [
+      {
+        name: 'PolygonAdapter01',
+        index: 4,
+      },
+    ],
+    [SwapSide.BUY]: [
+      {
+        name: 'PolygonBuyAdapter',
+        index: 1,
+      },
+    ],
+  },
+  [Network.ARBITRUM]: {
+    [SwapSide.SELL]: [
+      {
+        name: 'ArbitrumAdapter01',
+        index: 2,
+      },
+    ],
+    [SwapSide.BUY]: [
+      {
+        name: 'ArbitrumBuyAdapter',
+        index: 1,
+      },
+    ],
+  },
+};

--- a/src/dex/virtuswap/constants.ts
+++ b/src/dex/virtuswap/constants.ts
@@ -1,0 +1,4 @@
+export const BASE_FACTOR = 1000n;
+export const RESERVE_RATIO_FACTOR = BASE_FACTOR * 100n;
+
+export const PRICE_FEE_FACTOR = 10n ** 3n;

--- a/src/dex/virtuswap/lib/BigIntMath.ts
+++ b/src/dex/virtuswap/lib/BigIntMath.ts
@@ -1,0 +1,28 @@
+import { _require } from '../../../utils';
+import { BI_MAX_UINT256 } from '../../../bigint-constants';
+
+export class BigIntMath {
+  static max(...args: bigint[]): bigint {
+    return args.reduce((m, e) => (e > m ? e : m));
+  }
+
+  static min(...args: bigint[]): bigint {
+    return args.reduce((m, e) => (e < m ? e : m));
+  }
+
+  /**
+   * @see FullMath.mulDiv
+   */
+  static mulDiv(a: bigint, b: bigint, denominator: bigint) {
+    const result = (a * b) / denominator;
+
+    _require(
+      result <= BI_MAX_UINT256,
+      '',
+      { result, BI_MAX_UINT: BI_MAX_UINT256 },
+      'result <= BI_MAX_UINT',
+    );
+
+    return result;
+  }
+}

--- a/src/dex/virtuswap/lib/PoolAddress.ts
+++ b/src/dex/virtuswap/lib/PoolAddress.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers';
 import { Address } from '../../../types';
+import { normalizeAddress } from '../../../utils';
 
 export function orderAddresses(
   tokenA: Address,
@@ -25,5 +26,7 @@ export function computeAddress(
   initCodeHash: string,
 ): Address {
   const salt = getSalt(token0, token1);
-  return ethers.utils.getCreate2Address(factory, salt, initCodeHash);
+  return normalizeAddress(
+    ethers.utils.getCreate2Address(factory, salt, initCodeHash),
+  );
 }

--- a/src/dex/virtuswap/lib/PoolAddress.ts
+++ b/src/dex/virtuswap/lib/PoolAddress.ts
@@ -1,0 +1,29 @@
+import { ethers } from 'ethers';
+import { Address } from '../../../types';
+
+export function orderAddresses(
+  tokenA: Address,
+  tokenB: Address,
+): [Address, Address] {
+  return tokenA < tokenB ? [tokenA, tokenB] : [tokenB, tokenA];
+}
+
+export function getSalt(tokenA: Address, tokenB: Address): string {
+  const [token0, token1] = orderAddresses(tokenA, tokenB);
+  return ethers.utils.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      ['address', 'address'],
+      [token0, token1],
+    ),
+  );
+}
+
+export function computeAddress(
+  factory: Address,
+  token0: Address,
+  token1: Address,
+  initCodeHash: string,
+): Address {
+  const salt = getSalt(token0, token1);
+  return ethers.utils.getCreate2Address(factory, salt, initCodeHash);
+}

--- a/src/dex/virtuswap/lib/vSwapLibrary.ts
+++ b/src/dex/virtuswap/lib/vSwapLibrary.ts
@@ -1,0 +1,281 @@
+import { assert } from 'ts-essentials';
+import { _require } from '../../../utils';
+import { Address } from '../../../types';
+import { VirtualPoolTokens, VirtualPoolState, PoolState } from '../types';
+import { RESERVE_RATIO_FACTOR, PRICE_FEE_FACTOR } from '../constants';
+import { BigIntMath } from './BigIntMath';
+
+export function findCommonToken(
+  ikToken0: Address,
+  ikToken1: Address,
+  jkToken0: Address,
+  jkToken1: Address,
+): VirtualPoolTokens {
+  return ikToken0 === jkToken0
+    ? { ik0: ikToken1, ik1: ikToken0, jk0: jkToken1, jk1: jkToken0 }
+    : ikToken0 === jkToken1
+    ? { ik0: ikToken1, ik1: ikToken0, jk0: jkToken0, jk1: jkToken1 }
+    : ikToken1 === jkToken0
+    ? { ik0: ikToken0, ik1: ikToken1, jk0: jkToken1, jk1: jkToken0 }
+    : { ik0: ikToken0, ik1: ikToken1, jk0: jkToken0, jk1: jkToken1 };
+}
+
+export function calculateVPool(
+  ikTokenABalance: bigint,
+  ikTokenBBalance: bigint,
+  jkTokenABalance: bigint,
+  jkTokenBBalance: bigint,
+): Pick<VirtualPoolState, `balance${0 | 1}`> {
+  const balance0 =
+    (ikTokenABalance * BigIntMath.min(ikTokenBBalance, jkTokenBBalance)) /
+    BigIntMath.max(ikTokenBBalance, 1n);
+  const balance1 =
+    (jkTokenABalance * BigIntMath.min(ikTokenBBalance, jkTokenBBalance)) /
+    BigIntMath.max(jkTokenBBalance, 1n);
+  return {
+    balance0,
+    balance1,
+  };
+}
+
+export function getAmountIn(
+  amountOut: bigint,
+  pairBalanceIn: bigint,
+  pairBalanceOut: bigint,
+  fee: number,
+): bigint {
+  const numerator = pairBalanceIn * amountOut * PRICE_FEE_FACTOR;
+  const denominator = (pairBalanceOut - amountOut) * BigInt(fee);
+  return numerator / denominator + 1n;
+}
+
+export function getAmountOut(
+  amountIn: bigint,
+  pairBalanceIn: bigint,
+  pairBalanceOut: bigint,
+  fee: number,
+): bigint {
+  const amountInWithFee = amountIn * BigInt(fee);
+  const numerator = amountInWithFee * pairBalanceOut;
+  const denominator = pairBalanceIn * PRICE_FEE_FACTOR + amountInWithFee;
+  return numerator / denominator;
+}
+
+export function quote(
+  amountA: bigint,
+  balanceA: bigint,
+  balanceB: bigint,
+): bigint {
+  _require(
+    amountA > 0n,
+    'VSWAP: INSUFFICIENT_AMOUNT',
+    { amountA },
+    'amountA > 0n',
+  );
+  _require(
+    balanceA > 0n && balanceB > 0n,
+    'VSWAP: INSUFFICIENT_LIQUIDITY',
+    { balanceA, balanceB },
+    'balanceA > 0n && balanceB > 0n',
+  );
+  return (amountA * balanceB) / balanceA;
+}
+
+export function sortBalances(
+  tokenIn: Address,
+  baseToken: Address,
+  pairBalance0: bigint,
+  pairBalance1: bigint,
+): [bigint, bigint] {
+  return baseToken === tokenIn
+    ? [pairBalance0, pairBalance1]
+    : [pairBalance1, pairBalance0];
+}
+
+export function getVirtualPool(
+  jkPair: PoolState,
+  ikPair: PoolState,
+  blockNumber: number,
+): VirtualPoolState {
+  _require(
+    blockNumber >= ikPair.lastSwapBlock + ikPair.blocksDelay,
+    'VSWAP: LOCKED_VPOOL',
+    {
+      blockNumber,
+      lastSwapBlock: ikPair.lastSwapBlock,
+      blocksDelay: ikPair.blocksDelay,
+    },
+    'blockNumber >= lastSwapBlock + blocksDelay',
+  );
+
+  const vPoolTokens = findCommonToken(
+    ikPair.token0,
+    ikPair.token1,
+    jkPair.token0,
+    jkPair.token1,
+  );
+
+  _require(
+    vPoolTokens.ik0 !== vPoolTokens.jk0 && vPoolTokens.ik1 === vPoolTokens.jk1,
+    'VSWAP: INVALID_VPOOL',
+    {
+      ik0: vPoolTokens.ik0,
+      jk0: vPoolTokens.jk0,
+      ik1: vPoolTokens.ik1,
+      jk1: vPoolTokens.jk1,
+    },
+    'ik0 !== jk0 && ik1 === jk1',
+  );
+
+  _require(
+    jkPair.reserves[vPoolTokens.ik0] !== undefined,
+    'VSWAP: NOT_ALLOWED',
+    { ik0: vPoolTokens.ik0, reserves: Object.keys(jkPair.reserves) },
+    'reserves.includes(ik0)',
+  );
+
+  const ikBalances = sortBalances(
+    vPoolTokens.ik0,
+    ikPair.token0,
+    ikPair.pairBalance0,
+    ikPair.pairBalance1,
+  );
+  const jkBalances = sortBalances(
+    vPoolTokens.jk0,
+    jkPair.token0,
+    jkPair.pairBalance0,
+    jkPair.pairBalance1,
+  );
+
+  const vPool = calculateVPool(
+    ikBalances[0],
+    ikBalances[1],
+    jkBalances[0],
+    jkBalances[1],
+  );
+
+  return {
+    ...vPool,
+    fee: jkPair.vFee,
+    token0: vPoolTokens.ik0,
+    token1: vPoolTokens.jk0,
+    commonToken: vPoolTokens.ik1,
+    jkPair,
+    ikPair,
+  };
+}
+
+export function getMaxVirtualTradeAmountRtoN(vPool: VirtualPoolState): bigint {
+  const fee = BigInt(vPool.fee);
+  const balance0 = vPool.jkPair.pairBalance0;
+  const balance1 = vPool.jkPair.pairBalance1;
+  const vBalance0 = vPool.balance0;
+  const vBalance1 = vPool.balance1;
+  const reserveRatioFactor = RESERVE_RATIO_FACTOR;
+  const priceFeeFactor = PRICE_FEE_FACTOR;
+  const maxReserveRatio = vPool.jkPair.maxReserveRatio;
+  const reserves = vPool.jkPair.reserves[vPool.token0]?.balance ?? 0n;
+  const reservesBaseValueSum =
+    vPool.jkPair.reservesBaseValueSum -
+    (vPool.jkPair.reserves[vPool.token0]?.baseValue ?? 0n);
+
+  _require(
+    balance0 > 0n && balance0 <= 10n ** 32n,
+    'invalid balance0',
+    { balance0 },
+    'balance0 > 0n && balance0 <= 10n ** 32n',
+  );
+  _require(
+    balance1 > 0n && balance1 <= 10n ** 32n,
+    'invalid balance1',
+    { balance1 },
+    'balance1 > 0n && balance1 <= 10n ** 32n',
+  );
+  _require(
+    vBalance0 > 0n && vBalance0 <= 10n ** 32n,
+    'invalid vBalance0',
+    { vBalance0 },
+    'vBalance0 > 0n && vBalance0 <= 10n ** 32n',
+  );
+  _require(
+    vBalance1 > 0n && vBalance1 <= 10n ** 32n,
+    'invalid vBalance1',
+    { vBalance1 },
+    'vBalance1 > 0n && vBalance1 <= 10n ** 32n',
+  );
+  _require(
+    fee > 0n && fee <= priceFeeFactor,
+    'invalid fee',
+    { fee, priceFeeFactor },
+    'fee > 0n && fee <= priceFeeFactor',
+  );
+  _require(
+    maxReserveRatio > 0n && maxReserveRatio <= reserveRatioFactor,
+    'invalid maxReserveRatio',
+    { maxReserveRatio, reserveRatioFactor },
+    'maxReserveRatio > 0n && maxReserveRatio <= reserveRatioFactor',
+  );
+
+  // reserves are full, the answer is 0
+  if (reservesBaseValueSum > 2n * balance0 * maxReserveRatio) return 0n;
+
+  let maxAmountIn: bigint;
+  if (vPool.jkPair.token0 === vPool.token1) {
+    _require(
+      vBalance1 <= balance0,
+      'invalid vBalance1',
+      { vBalance1, balance0 },
+      'vBalance1 <= balance0',
+    );
+    const a = vBalance1 * reserveRatioFactor;
+    const b =
+      vBalance0 *
+        (-2n * balance0 * maxReserveRatio +
+          vBalance1 *
+            (2n * maxReserveRatio +
+              (priceFeeFactor * reserveRatioFactor) / fee) +
+          reserveRatioFactor * reservesBaseValueSum) +
+      reserves * reserveRatioFactor * vBalance1;
+    const c1 = (priceFeeFactor * vBalance0) / fee;
+    const c2 =
+      2n * balance0 * maxReserveRatio * vBalance0 -
+      reserveRatioFactor *
+        (reserves * vBalance1 + reservesBaseValueSum * vBalance0);
+
+    const [negativeC, uc2] = c2 < 0 ? [false, -c2] : [true, c2];
+
+    maxAmountIn = vBalance0;
+
+    // Newton's method
+    for (let i = 0; i < 7; i++) {
+      const derivative = 2n * a * maxAmountIn + b;
+
+      const [negativeDerivative, uDerivative] =
+        derivative < 0 ? [true, -derivative] : [false, derivative];
+
+      maxAmountIn = negativeC
+        ? BigIntMath.mulDiv(a, BigInt(maxAmountIn * maxAmountIn), uDerivative) +
+          BigIntMath.mulDiv(c1, uc2, uDerivative)
+        : BigIntMath.mulDiv(a, BigInt(maxAmountIn * maxAmountIn), uDerivative) -
+          BigIntMath.mulDiv(c1, uc2, uDerivative);
+
+      if (negativeDerivative) maxAmountIn = -maxAmountIn;
+    }
+  } else {
+    _require(
+      vBalance1 <= balance1,
+      'invalid vBalance1',
+      { vBalance1, balance1 },
+      'vBalance1 <= balance1',
+    );
+    maxAmountIn =
+      BigIntMath.mulDiv(
+        balance1 * vBalance0,
+        2n * balance0 * maxReserveRatio -
+          reserveRatioFactor * reservesBaseValueSum,
+        balance0 * reserveRatioFactor * vBalance1,
+      ) - reserves;
+  }
+  assert(maxAmountIn >= 0n);
+  return maxAmountIn;
+}

--- a/src/dex/virtuswap/lib/vSwapLibrary.ts
+++ b/src/dex/virtuswap/lib/vSwapLibrary.ts
@@ -3,6 +3,7 @@ import { _require } from '../../../utils';
 import { Address } from '../../../types';
 import { VirtualPoolTokens, VirtualPoolState, PoolState } from '../types';
 import { RESERVE_RATIO_FACTOR, PRICE_FEE_FACTOR } from '../constants';
+import { BI_MAX_UINT256 } from '../../../bigint-constants';
 import { BigIntMath } from './BigIntMath';
 
 export function findCommonToken(
@@ -44,8 +45,10 @@ export function getAmountIn(
   pairBalanceOut: bigint,
   fee: number,
 ): bigint {
+  if (amountOut <= 0n) return 0n;
   const numerator = pairBalanceIn * amountOut * PRICE_FEE_FACTOR;
   const denominator = (pairBalanceOut - amountOut) * BigInt(fee);
+  if (denominator <= 0n) return BI_MAX_UINT256;
   return numerator / denominator + 1n;
 }
 
@@ -55,6 +58,7 @@ export function getAmountOut(
   pairBalanceOut: bigint,
   fee: number,
 ): bigint {
+  if (amountIn <= 0n) return 0n;
   const amountInWithFee = amountIn * BigInt(fee);
   const numerator = amountInWithFee * pairBalanceOut;
   const denominator = pairBalanceIn * PRICE_FEE_FACTOR + amountInWithFee;

--- a/src/dex/virtuswap/types.ts
+++ b/src/dex/virtuswap/types.ts
@@ -12,6 +12,7 @@ export type PoolState = {
   blocksDelay: number;
   reservesBaseValueSum: bigint;
   maxReserveRatio: bigint;
+  rRatio: bigint;
   reserves: Record<Address, { balance: bigint; baseValue: bigint }>;
 };
 

--- a/src/dex/virtuswap/types.ts
+++ b/src/dex/virtuswap/types.ts
@@ -1,0 +1,30 @@
+import { Address } from '../../types';
+
+export type PoolState = {
+  pairBalance0: bigint;
+  pairBalance1: bigint;
+  fee: number;
+  vFee: number;
+  lastSwapBlock: number;
+  blocksDelay: number;
+  reservesBaseValueSum: bigint;
+  maxReserveRatio: bigint;
+  reserves: Record<Address, { balance: bigint; baseValue: bigint }>;
+};
+
+export type VirtuSwapData = {
+  // TODO: VirtuSwapData is the dex data that is
+  // returned by the API that can be used for
+  // tx building. The data structure should be minimal.
+  // Complete me!
+  exchange: Address;
+};
+
+export type DexParams = {
+  // TODO: DexParams is set of parameters the can
+  // be used to initiate a DEX fork.
+  factoryAddress: Address;
+  initCode: string;
+  router: Address;
+  isTimestampBased: boolean;
+};

--- a/src/dex/virtuswap/types.ts
+++ b/src/dex/virtuswap/types.ts
@@ -22,16 +22,20 @@ export type VirtualPoolTokens = {
   ik1: Address;
 };
 
-export type VirtualPoolState = {
+type GenericVirtualPoolState<TPair extends Address | PoolState> = {
   fee: number;
   token0: Address;
   token1: Address;
   balance0: bigint;
   balance1: bigint;
   commonToken: Address;
-  jkPair: PoolState;
-  ikPair: PoolState;
+  jkPair: TPair;
+  ikPair: TPair;
 };
+
+export type VirtualPoolState = GenericVirtualPoolState<PoolState>;
+
+export type PlainVirtualPoolState = GenericVirtualPoolState<Address>;
 
 export type FactoryState = {
   pools: Address[];
@@ -54,6 +58,7 @@ export type DexParams = {
   // TODO: DexParams is set of parameters the can
   // be used to initiate a DEX fork.
   factoryAddress: Address;
+  vPoolManagerAddress: Address;
   initCode: string;
   router: Address;
   isTimestampBased: boolean;

--- a/src/dex/virtuswap/types.ts
+++ b/src/dex/virtuswap/types.ts
@@ -47,25 +47,21 @@ export type OnPoolCreatedCallback = (
   blockNumber: number,
 ) => AsyncOrSync<void>;
 
-type RealPoolDataPart = {
+type RealPoolData = {
   isVirtual: false;
-  path: Address[];
+  path: [Address, Address];
 };
 
-type VirtualPoolDataPart = {
+type VirtualPoolData = {
   isVirtual: true;
   tokenOut: Address;
   commonToken: Address;
   ikPair: Address;
 };
 
-export type VirtuSwapData = {
-  router: Address;
-} & (RealPoolDataPart | VirtualPoolDataPart);
+export type VirtuSwapData = RealPoolData | VirtualPoolData;
 
 export type DexParams = {
-  // TODO: DexParams is set of parameters the can
-  // be used to initiate a DEX fork.
   factoryAddress: Address;
   vPoolManagerAddress: Address;
   initCode: string;

--- a/src/dex/virtuswap/types.ts
+++ b/src/dex/virtuswap/types.ts
@@ -42,8 +42,8 @@ export type FactoryState = {
   pools: Address[];
 };
 
-export type OnPoolCreatedCallback = (
-  pool: Address,
+export type OnPoolsCreatedCallback = (
+  pools: Address[],
   blockNumber: number,
 ) => AsyncOrSync<void>;
 

--- a/src/dex/virtuswap/types.ts
+++ b/src/dex/virtuswap/types.ts
@@ -47,13 +47,21 @@ export type OnPoolCreatedCallback = (
   blockNumber: number,
 ) => AsyncOrSync<void>;
 
-export type VirtuSwapData = {
-  // TODO: VirtuSwapData is the dex data that is
-  // returned by the API that can be used for
-  // tx building. The data structure should be minimal.
-  // Complete me!
-  exchange: Address;
+type RealPoolDataPart = {
+  isVirtual: false;
+  path: Address[];
 };
+
+type VirtualPoolDataPart = {
+  isVirtual: true;
+  tokenOut: Address;
+  commonToken: Address;
+  ikPair: Address;
+};
+
+export type VirtuSwapData = {
+  router: Address;
+} & (RealPoolDataPart | VirtualPoolDataPart);
 
 export type DexParams = {
   // TODO: DexParams is set of parameters the can
@@ -63,4 +71,6 @@ export type DexParams = {
   initCode: string;
   router: Address;
   isTimestampBased: boolean;
+  realPoolGasCost: number;
+  virtualPoolGasCost: number;
 };

--- a/src/dex/virtuswap/types.ts
+++ b/src/dex/virtuswap/types.ts
@@ -69,4 +69,6 @@ export type DexParams = {
   isTimestampBased: boolean;
   realPoolGasCost: number;
   virtualPoolGasCost: number;
+  getTokensURL?: string;
+  getTokensPricesURL?: string;
 };

--- a/src/dex/virtuswap/types.ts
+++ b/src/dex/virtuswap/types.ts
@@ -15,6 +15,24 @@ export type PoolState = {
   reserves: Record<Address, { balance: bigint; baseValue: bigint }>;
 };
 
+export type VirtualPoolTokens = {
+  jk0: Address;
+  jk1: Address;
+  ik0: Address;
+  ik1: Address;
+};
+
+export type VirtualPoolState = {
+  fee: number;
+  token0: Address;
+  token1: Address;
+  balance0: bigint;
+  balance1: bigint;
+  commonToken: Address;
+  jkPair: PoolState;
+  ikPair: PoolState;
+};
+
 export type FactoryState = {
   pools: Address[];
 };

--- a/src/dex/virtuswap/types.ts
+++ b/src/dex/virtuswap/types.ts
@@ -1,6 +1,9 @@
 import { Address } from '../../types';
+import { AsyncOrSync } from 'ts-essentials';
 
 export type PoolState = {
+  token0: Address;
+  token1: Address;
   pairBalance0: bigint;
   pairBalance1: bigint;
   fee: number;
@@ -11,6 +14,15 @@ export type PoolState = {
   maxReserveRatio: bigint;
   reserves: Record<Address, { balance: bigint; baseValue: bigint }>;
 };
+
+export type FactoryState = {
+  pools: Address[];
+};
+
+export type OnPoolCreatedCallback = (
+  pool: Address,
+  blockNumber: number,
+) => AsyncOrSync<void>;
 
 export type VirtuSwapData = {
   // TODO: VirtuSwapData is the dex data that is

--- a/src/dex/virtuswap/utils.ts
+++ b/src/dex/virtuswap/utils.ts
@@ -1,0 +1,51 @@
+import { MultiResult } from '../../lib/multi-wrapper';
+import { BytesLike, defaultAbiCoder } from 'ethers/lib/utils';
+import {
+  addressDecode,
+  booleanDecode,
+  extractSuccessAndValue,
+  generalDecoder,
+} from '../../lib/decoders';
+import { parseInt } from 'lodash';
+
+class AbiCoderResultParser<TResult> {
+  constructor(
+    readonly decoderFactory: (
+      type?: string,
+    ) => (val: MultiResult<BytesLike> | BytesLike) => TResult,
+  ) {}
+
+  create<TName extends string>(name: TName, type: string) {
+    return {
+      name,
+      type,
+      decodeFunction: this.decoderFactory(type),
+    } as const;
+  }
+}
+
+export const abiCoderParsers = {
+  Address: new AbiCoderResultParser(() => addressDecode),
+
+  BigInt: new AbiCoderResultParser(
+    (type?: string) =>
+      (result: MultiResult<BytesLike> | BytesLike): bigint =>
+        generalDecoder(result, [type ?? 'uint256'], 0n, value =>
+          value[0].toBigInt(),
+        ),
+  ),
+
+  Int: new AbiCoderResultParser(
+    (type?: string) =>
+      (result: MultiResult<BytesLike> | BytesLike): number => {
+        const [isSuccess, toDecode] = extractSuccessAndValue(result);
+        if (!isSuccess) return 0;
+        return parseInt(
+          defaultAbiCoder.decode([type ?? 'uint256'], toDecode)[0],
+          10,
+        );
+      },
+  ),
+
+  Bool: new AbiCoderResultParser(() => booleanDecode),
+} as const;

--- a/src/dex/virtuswap/virtuswap-e2e.test.ts
+++ b/src/dex/virtuswap/virtuswap-e2e.test.ts
@@ -76,17 +76,11 @@ function testForNetwork(
       SwapSide.SELL,
       [
         ContractMethod.simpleSwap,
-        // ContractMethod.multiSwap, //TODO: add support
-        // ContractMethod.megaSwap, //TODO: add support
+        ContractMethod.multiSwap,
+        ContractMethod.megaSwap,
       ],
     ],
-    [
-      SwapSide.BUY,
-      [
-        ContractMethod.simpleBuy,
-        // ContractMethod.buy, //TODO: add support
-      ],
-    ],
+    [SwapSide.BUY, [ContractMethod.simpleBuy, ContractMethod.buy]],
   ]);
 
   describe(`Network id: ${network}`, () => {

--- a/src/dex/virtuswap/virtuswap-e2e.test.ts
+++ b/src/dex/virtuswap/virtuswap-e2e.test.ts
@@ -13,6 +13,8 @@ import { Network, ContractMethod, SwapSide } from '../../constants';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { generateConfig } from '../../config';
 
+jest.setTimeout(50 * 1000);
+
 function testForNetwork(
   network: Network,
   dexKey: string,

--- a/src/dex/virtuswap/virtuswap-e2e.test.ts
+++ b/src/dex/virtuswap/virtuswap-e2e.test.ts
@@ -1,0 +1,167 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import {
+  Tokens,
+  Holders,
+  NativeTokenSymbols,
+} from '../../../tests/constants-e2e';
+import { BI_POWS } from '../../bigint-constants';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+
+/*
+  README
+  ======
+
+  This test script should add e2e tests for VirtuSwap. The tests
+  should cover as many cases as possible. Most of the DEXes follow
+  the following test structure:
+    - DexName
+      - ForkName + Network
+        - ContractMethod
+          - ETH -> Token swap
+          - Token -> ETH swap
+          - Token -> Token swap
+
+  The template already enumerates the basic structure which involves
+  testing simpleSwap, multiSwap, megaSwap contract methods for
+  ETH <> TOKEN and TOKEN <> TOKEN swaps. You should replace tokenA and
+  tokenB with any two highly liquid tokens on VirtuSwap for the tests
+  to work. If the tokens that you would like to use are not defined in
+  Tokens or Holders map, you can update the './tests/constants-e2e'
+
+  Other than the standard cases that are already added by the template
+  it is highly recommended to add test cases which could be specific
+  to testing VirtuSwap (Eg. Tests based on poolType, special tokens,
+  etc).
+
+  You can run this individual test script by running:
+  `npx jest src/dex/virtuswap/virtuswap-e2e.test.ts`
+
+  e2e tests use the Tenderly fork api. Please add the following to your
+  .env file:
+  TENDERLY_TOKEN=Find this under Account>Settings>Authorization.
+  TENDERLY_ACCOUNT_ID=Your Tenderly account name.
+  TENDERLY_PROJECT=Name of a Tenderly project you have created in your
+  dashboard.
+
+  (This comment should be removed from the final implementation)
+*/
+
+function testForNetwork(
+  network: Network,
+  dexKey: string,
+  tokenASymbol: string,
+  tokenBSymbol: string,
+  tokenAAmount: string,
+  tokenBAmount: string,
+  nativeTokenAmount: string,
+) {
+  const provider = new StaticJsonRpcProvider(
+    generateConfig(network).privateHttpProvider,
+    network,
+  );
+  const tokens = Tokens[network];
+  const holders = Holders[network];
+  const nativeTokenSymbol = NativeTokenSymbols[network];
+
+  const sideToContractMethods = new Map([
+    [
+      SwapSide.SELL,
+      [
+        ContractMethod.simpleSwap,
+        // ContractMethod.multiSwap, //TODO: add support
+        // ContractMethod.megaSwap, //TODO: add support
+      ],
+    ],
+    [
+      SwapSide.BUY,
+      [
+        ContractMethod.simpleBuy,
+        // ContractMethod.buy, //TODO: add support
+      ],
+    ],
+  ]);
+
+  describe(`Network id: ${network}`, () => {
+    sideToContractMethods.forEach((contractMethods, side) =>
+      describe(`${side}`, () => {
+        contractMethods.forEach((contractMethod: ContractMethod) => {
+          describe(`${contractMethod}`, () => {
+            it(`${nativeTokenSymbol} -> ${tokenASymbol}`, async () => {
+              await testE2E(
+                tokens[nativeTokenSymbol],
+                tokens[tokenASymbol],
+                holders[nativeTokenSymbol],
+                side === SwapSide.SELL ? nativeTokenAmount : tokenAAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+            it(`${tokenASymbol} -> ${nativeTokenSymbol}`, async () => {
+              await testE2E(
+                tokens[tokenASymbol],
+                tokens[nativeTokenSymbol],
+                holders[tokenASymbol],
+                side === SwapSide.SELL ? tokenAAmount : nativeTokenAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+            it(`${tokenASymbol} -> ${tokenBSymbol}`, async () => {
+              await testE2E(
+                tokens[tokenASymbol],
+                tokens[tokenBSymbol],
+                holders[tokenASymbol],
+                side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+          });
+        });
+      }),
+    );
+  });
+}
+
+describe('VirtuSwap E2E', () => {
+  const dexKey = 'VirtuSwap';
+  const networks = [Network.POLYGON, Network.ARBITRUM];
+
+  for (const network of networks) {
+    const tokenASymbol: string = 'VRSW';
+    const tokenBSymbol: string = Tokens[network]['USDCe'] ? 'USDCe' : 'USDC';
+
+    const tokenAAmount: string = '10000000000000000000';
+    const tokenBAmount: string = (
+      100n * BI_POWS[Tokens[network][tokenBSymbol].decimals]
+    ).toString();
+    const nativeTokenAmount = '100000000000000000';
+
+    testForNetwork(
+      network,
+      dexKey,
+      tokenASymbol,
+      tokenBSymbol,
+      tokenAAmount,
+      tokenBAmount,
+      nativeTokenAmount,
+    );
+
+    // TODO: Add any additional test cases required to test VirtuSwap
+  }
+});

--- a/src/dex/virtuswap/virtuswap-e2e.test.ts
+++ b/src/dex/virtuswap/virtuswap-e2e.test.ts
@@ -13,45 +13,6 @@ import { Network, ContractMethod, SwapSide } from '../../constants';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { generateConfig } from '../../config';
 
-/*
-  README
-  ======
-
-  This test script should add e2e tests for VirtuSwap. The tests
-  should cover as many cases as possible. Most of the DEXes follow
-  the following test structure:
-    - DexName
-      - ForkName + Network
-        - ContractMethod
-          - ETH -> Token swap
-          - Token -> ETH swap
-          - Token -> Token swap
-
-  The template already enumerates the basic structure which involves
-  testing simpleSwap, multiSwap, megaSwap contract methods for
-  ETH <> TOKEN and TOKEN <> TOKEN swaps. You should replace tokenA and
-  tokenB with any two highly liquid tokens on VirtuSwap for the tests
-  to work. If the tokens that you would like to use are not defined in
-  Tokens or Holders map, you can update the './tests/constants-e2e'
-
-  Other than the standard cases that are already added by the template
-  it is highly recommended to add test cases which could be specific
-  to testing VirtuSwap (Eg. Tests based on poolType, special tokens,
-  etc).
-
-  You can run this individual test script by running:
-  `npx jest src/dex/virtuswap/virtuswap-e2e.test.ts`
-
-  e2e tests use the Tenderly fork api. Please add the following to your
-  .env file:
-  TENDERLY_TOKEN=Find this under Account>Settings>Authorization.
-  TENDERLY_ACCOUNT_ID=Your Tenderly account name.
-  TENDERLY_PROJECT=Name of a Tenderly project you have created in your
-  dashboard.
-
-  (This comment should be removed from the final implementation)
-*/
-
 function testForNetwork(
   network: Network,
   dexKey: string,

--- a/src/dex/virtuswap/virtuswap-e2e.test.ts
+++ b/src/dex/virtuswap/virtuswap-e2e.test.ts
@@ -57,8 +57,10 @@ function testForNetwork(
   dexKey: string,
   tokenASymbol: string,
   tokenBSymbol: string,
+  tokenCSymbol: string,
   tokenAAmount: string,
   tokenBAmount: string,
+  tokenCAmount: string,
   nativeTokenAmount: string,
 ) {
   const provider = new StaticJsonRpcProvider(
@@ -92,44 +94,87 @@ function testForNetwork(
       describe(`${side}`, () => {
         contractMethods.forEach((contractMethod: ContractMethod) => {
           describe(`${contractMethod}`, () => {
-            it(`${nativeTokenSymbol} -> ${tokenASymbol}`, async () => {
-              await testE2E(
-                tokens[nativeTokenSymbol],
-                tokens[tokenASymbol],
-                holders[nativeTokenSymbol],
-                side === SwapSide.SELL ? nativeTokenAmount : tokenAAmount,
-                side,
-                dexKey,
-                contractMethod,
-                network,
-                provider,
-              );
+            describe('Real pools', () => {
+              it(`${nativeTokenSymbol} -> ${tokenASymbol}`, async () => {
+                await testE2E(
+                  tokens[nativeTokenSymbol],
+                  tokens[tokenASymbol],
+                  holders[nativeTokenSymbol],
+                  side === SwapSide.SELL ? nativeTokenAmount : tokenAAmount,
+                  side,
+                  dexKey,
+                  contractMethod,
+                  network,
+                  provider,
+                );
+              });
+              it(`${tokenASymbol} -> ${nativeTokenSymbol}`, async () => {
+                await testE2E(
+                  tokens[tokenASymbol],
+                  tokens[nativeTokenSymbol],
+                  holders[tokenASymbol],
+                  side === SwapSide.SELL ? tokenAAmount : nativeTokenAmount,
+                  side,
+                  dexKey,
+                  contractMethod,
+                  network,
+                  provider,
+                );
+              });
+              it(`${tokenASymbol} -> ${tokenBSymbol}`, async () => {
+                await testE2E(
+                  tokens[tokenASymbol],
+                  tokens[tokenBSymbol],
+                  holders[tokenASymbol],
+                  side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
+                  side,
+                  dexKey,
+                  contractMethod,
+                  network,
+                  provider,
+                );
+              });
             });
-            it(`${tokenASymbol} -> ${nativeTokenSymbol}`, async () => {
-              await testE2E(
-                tokens[tokenASymbol],
-                tokens[nativeTokenSymbol],
-                holders[tokenASymbol],
-                side === SwapSide.SELL ? tokenAAmount : nativeTokenAmount,
-                side,
-                dexKey,
-                contractMethod,
-                network,
-                provider,
-              );
-            });
-            it(`${tokenASymbol} -> ${tokenBSymbol}`, async () => {
-              await testE2E(
-                tokens[tokenASymbol],
-                tokens[tokenBSymbol],
-                holders[tokenASymbol],
-                side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
-                side,
-                dexKey,
-                contractMethod,
-                network,
-                provider,
-              );
+            describe('Virtual pools', () => {
+              it(`${nativeTokenSymbol} -> ${tokenCSymbol}`, async () => {
+                await testE2E(
+                  tokens[nativeTokenSymbol],
+                  tokens[tokenCSymbol],
+                  holders[nativeTokenSymbol],
+                  side === SwapSide.SELL ? nativeTokenAmount : tokenCAmount,
+                  side,
+                  dexKey,
+                  contractMethod,
+                  network,
+                  provider,
+                );
+              });
+              it(`${tokenCSymbol} -> ${nativeTokenSymbol}`, async () => {
+                await testE2E(
+                  tokens[tokenCSymbol],
+                  tokens[nativeTokenSymbol],
+                  holders[tokenCSymbol],
+                  side === SwapSide.SELL ? tokenCAmount : nativeTokenAmount,
+                  side,
+                  dexKey,
+                  contractMethod,
+                  network,
+                  provider,
+                );
+              });
+              it(`${tokenASymbol} -> ${tokenCSymbol}`, async () => {
+                await testE2E(
+                  tokens[tokenASymbol],
+                  tokens[tokenCSymbol],
+                  holders[tokenASymbol],
+                  side === SwapSide.SELL ? tokenAAmount : tokenCAmount,
+                  side,
+                  dexKey,
+                  contractMethod,
+                  network,
+                  provider,
+                );
+              });
             });
           });
         });
@@ -145,23 +190,28 @@ describe('VirtuSwap E2E', () => {
   for (const network of networks) {
     const tokenASymbol: string = 'VRSW';
     const tokenBSymbol: string = Tokens[network]['USDCe'] ? 'USDCe' : 'USDC';
+    const tokenCSymbol: string = 'USDT'; // 3rd token to test virtual pools
 
     const tokenAAmount: string = '10000000000000000000';
     const tokenBAmount: string = (
       100n * BI_POWS[Tokens[network][tokenBSymbol].decimals]
     ).toString();
-    const nativeTokenAmount = '100000000000000000';
+    const tokenCAmount: string = '1000000';
+    const nativeTokenAmount: string =
+      NativeTokenSymbols[network] === 'ETH'
+        ? '1000000000000000'
+        : '100000000000000000';
 
     testForNetwork(
       network,
       dexKey,
       tokenASymbol,
       tokenBSymbol,
+      tokenCSymbol,
       tokenAAmount,
       tokenBAmount,
+      tokenCAmount,
       nativeTokenAmount,
     );
-
-    // TODO: Add any additional test cases required to test VirtuSwap
   }
 });

--- a/src/dex/virtuswap/virtuswap-e2e.test.ts
+++ b/src/dex/virtuswap/virtuswap-e2e.test.ts
@@ -146,7 +146,7 @@ describe('VirtuSwap E2E', () => {
 
   for (const network of networks) {
     const tokenASymbol: string = 'VRSW';
-    const tokenBSymbol: string = Tokens[network]['USDCe'] ? 'USDCe' : 'USDC';
+    const tokenBSymbol: string = 'USDCe';
     const tokenCSymbol: string = 'USDT'; // 3rd token to test virtual pools
 
     const tokenAAmount: string = '10000000000000000000';

--- a/src/dex/virtuswap/virtuswap-events.test.ts
+++ b/src/dex/virtuswap/virtuswap-events.test.ts
@@ -3,127 +3,63 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 import { VirtuSwapEventPool } from './virtuswap-pool';
+import { VirtuSwapFactory } from './virtuswap-factory';
 import { Network } from '../../constants';
 import { Address } from '../../types';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
 import { DummyDexHelper } from '../../dex-helper/index';
 import { testEventSubscriber } from '../../../tests/utils-events';
-import { PoolState } from './types';
 import { DeepReadonly } from 'ts-essentials';
 import { VirtuSwapConfig } from './config';
 
-/*
-  README
-  ======
-
-  This test script adds unit tests for VirtuSwap event based
-  system. This is done by fetching the state on-chain before the
-  event block, manually pushing the block logs to the event-subscriber,
-  comparing the local state with on-chain state.
-
-  Most of the logic for testing is abstracted by `testEventSubscriber`.
-  You need to do two things to make the tests work:
-
-  1. Fetch the block numbers where certain events were released. You
-  can modify the `./scripts/fetch-event-blocknumber.ts` to get the
-  block numbers for different events. Make sure to get sufficient
-  number of blockNumbers to cover all possible cases for the event
-  mutations.
-
-  2. Complete the implementation for fetchPoolState function. The
-  function should fetch the on-chain state of the event subscriber
-  using just the blocknumber.
-
-  The template tests only include the test for a single event
-  subscriber. There can be cases where multiple event subscribers
-  exist for a single DEX. In such cases additional tests should be
-  added.
-
-  You can run this individual test script by running:
-  `npx jest src/dex/virtuswap/virtuswap-events.test.ts`
-
-  (This comment should be removed from the final implementation)
-*/
-
 jest.setTimeout(50 * 1000);
 
-async function fetchPoolState(
-  virtuswapPool: VirtuSwapEventPool,
+async function fetchEventSubscriberState<State>(
+  eventSubscriber: StatefulEventSubscriber<State>,
   blockNumber: number,
-): Promise<DeepReadonly<PoolState>> {
-  return await virtuswapPool.generateState(blockNumber);
+): Promise<DeepReadonly<State>> {
+  return eventSubscriber.generateState(blockNumber);
 }
 
 // eventName -> blockNumbers
 type EventMappings = Record<string, number[]>;
 
-type PoolEventsInfo = {
-  poolAddress: Address;
-  token0Address: Address;
-  token1Address: Address;
-  eventsMap: EventMappings;
-};
+const dexKey = 'VirtuSwap';
 
-//TODO: add tests for vPairFactory events
 describe('VirtuSwap EventPool', function () {
-  const dexKey = 'VirtuSwap';
-
-  // networkId -> PoolEventsInfo[]
-  const eventsToTest: Partial<Record<Network, PoolEventsInfo[]>> = {
-    [Network.POLYGON]: [
-      // VRSW-WETH
-      {
-        poolAddress: '0x68BfaE97d4970ba6f542c2a93Ed2e6eDBBf96c3b',
-        token0Address: '0x57999936fC9A9EC0751a8D146CcE11901Be8beD0',
-        token1Address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
-        eventsMap: {
+  // networkId -> poolAddress -> EventMappings
+  const eventsToTest: Partial<Record<Network, Record<Address, EventMappings>>> =
+    {
+      [Network.POLYGON]: {
+        // VRSW-WETH
+        '0x68BfaE97d4970ba6f542c2a93Ed2e6eDBBf96c3b': {
           ReserveSync: [55283344, 55373346],
           vSync: [55395552, 55402173, 55430710, 55433860],
         },
-      },
-      // WMATIC-USDC.e
-      {
-        poolAddress: '0x61e7Af17bA4F3C41D0d30D15133C02E1Eb6a160b',
-        token0Address: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
-        token1Address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-        eventsMap: {
+        // WMATIC-USDC.e
+        '0x61e7Af17bA4F3C41D0d30D15133C02E1Eb6a160b': {
           ReserveSync: [55323873],
           vSync: [55419625, 55432335],
         },
-      },
-      // WMATIC-DECATS
-      {
-        poolAddress: '0x3EF0458a06b7507112fC67cD2aaa636e93C29d91',
-        token0Address: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
-        token1Address: '0x198f1D316aad1C0Bfd36a79bd1A8e9dba92DAa18',
-        eventsMap: {
+        // WMATIC-DECATS
+        '0x3EF0458a06b7507112fC67cD2aaa636e93C29d91': {
           ReserveSync: [50556813], // Liquidate Reserve
           AllowListChanged: [52799588, 52799593, 52799696], // Set Allow List
         },
-      },
-      // USDC.e-USDT
-      {
-        poolAddress: '0x718C2A6A8F60026E13f406aF077B0D84D075d222',
-        token0Address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-        token1Address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
-        eventsMap: {
+        // USDC.e-USDT
+        '0x718C2A6A8F60026E13f406aF077B0D84D075d222': {
           AllowListChanged: [52799297, 52799705],
           ReserveSync: [55467619, 55468496],
         },
       },
-    ],
-    [Network.ARBITRUM]: [
-      // VRSW-USDC.e
-      {
-        poolAddress: '0xD7d90067A07620EdEc49665B5703E539811aeb17',
-        token0Address: '0xd1E094CabC5aCB9D3b0599C3F76f2D01fF8d3563',
-        token1Address: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
-        eventsMap: {
+      [Network.ARBITRUM]: {
+        // VRSW-USDC.e
+        '0xD7d90067A07620EdEc49665B5703E539811aeb17': {
           ReserveSync: [196701768, 196876948],
           vSync: [197478498],
         },
       },
-    ],
-  };
+    };
 
   Object.entries(eventsToTest).forEach(([networkId, eventsInfos]) => {
     describe(`Network id: ${networkId}`, () => {
@@ -131,19 +67,17 @@ describe('VirtuSwap EventPool', function () {
       const params = VirtuSwapConfig[dexKey][network];
       const dexHelper = new DummyDexHelper(network);
       const logger = dexHelper.getLogger(dexKey);
-      eventsInfos.forEach(eventsInfo => {
-        describe(`Events for ${eventsInfo.poolAddress}`, () => {
+      Object.entries(eventsInfos).forEach(([poolAddress, eventsMap]) => {
+        describe(`Events for ${poolAddress}`, () => {
           const virtuswapPool = new VirtuSwapEventPool(
             dexKey,
             network,
             dexHelper,
             logger,
             params.isTimestampBased,
-            eventsInfo.token0Address,
-            eventsInfo.token1Address,
-            eventsInfo.poolAddress,
+            poolAddress,
           );
-          Object.entries(eventsInfo.eventsMap).forEach(
+          Object.entries(eventsMap).forEach(
             ([eventName, blockNumbers]: [string, number[]]) => {
               describe(`${eventName}`, () => {
                 blockNumbers.forEach((blockNumber: number) => {
@@ -152,9 +86,9 @@ describe('VirtuSwap EventPool', function () {
                       virtuswapPool,
                       virtuswapPool.addressesSubscribed,
                       (_blockNumber: number) =>
-                        fetchPoolState(virtuswapPool, _blockNumber),
+                        fetchEventSubscriberState(virtuswapPool, _blockNumber),
                       blockNumber,
-                      `${dexKey}_${networkId}_${eventsInfo.poolAddress}`,
+                      `${dexKey}_${networkId}_${poolAddress}`,
                       dexHelper.provider,
                     );
                   });
@@ -164,6 +98,54 @@ describe('VirtuSwap EventPool', function () {
           );
         });
       });
+    });
+  });
+});
+
+describe('VirtuSwap Pair Factory', function () {
+  // networkId -> EventMappings
+  const eventsToTest: Partial<Record<Network, EventMappings>> = {
+    [Network.POLYGON]: {
+      PairCreated: [51241515, 52520527, 54425830],
+    },
+    [Network.ARBITRUM]: {
+      PairCreated: [185284849, 185289818, 185290439],
+    },
+  };
+
+  Object.entries(eventsToTest).forEach(([networkId, eventsMap]) => {
+    const network = parseInt(networkId) as Network;
+    const params = VirtuSwapConfig[dexKey][network];
+    describe(`Network id: ${networkId}, factory: ${params.factoryAddress}`, () => {
+      const dexHelper = new DummyDexHelper(network);
+      const logger = dexHelper.getLogger(dexKey);
+      const virtuswapFactory = new VirtuSwapFactory(
+        dexKey,
+        network,
+        dexHelper,
+        logger,
+        () => {},
+        params.factoryAddress,
+      );
+      Object.entries(eventsMap).forEach(
+        ([eventName, blockNumbers]: [string, number[]]) => {
+          describe(`${eventName}`, () => {
+            blockNumbers.forEach((blockNumber: number) => {
+              it(`State after ${blockNumber}`, async function () {
+                await testEventSubscriber(
+                  virtuswapFactory,
+                  virtuswapFactory.addressesSubscribed,
+                  (_blockNumber: number) =>
+                    fetchEventSubscriberState(virtuswapFactory, _blockNumber),
+                  blockNumber,
+                  `${dexKey}_${networkId}_factory_${params.factoryAddress}`,
+                  dexHelper.provider,
+                );
+              });
+            });
+          });
+        },
+      );
     });
   });
 });

--- a/src/dex/virtuswap/virtuswap-events.test.ts
+++ b/src/dex/virtuswap/virtuswap-events.test.ts
@@ -1,0 +1,169 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { VirtuSwapEventPool } from './virtuswap-pool';
+import { Network } from '../../constants';
+import { Address } from '../../types';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { testEventSubscriber } from '../../../tests/utils-events';
+import { PoolState } from './types';
+import { DeepReadonly } from 'ts-essentials';
+import { VirtuSwapConfig } from './config';
+
+/*
+  README
+  ======
+
+  This test script adds unit tests for VirtuSwap event based
+  system. This is done by fetching the state on-chain before the
+  event block, manually pushing the block logs to the event-subscriber,
+  comparing the local state with on-chain state.
+
+  Most of the logic for testing is abstracted by `testEventSubscriber`.
+  You need to do two things to make the tests work:
+
+  1. Fetch the block numbers where certain events were released. You
+  can modify the `./scripts/fetch-event-blocknumber.ts` to get the
+  block numbers for different events. Make sure to get sufficient
+  number of blockNumbers to cover all possible cases for the event
+  mutations.
+
+  2. Complete the implementation for fetchPoolState function. The
+  function should fetch the on-chain state of the event subscriber
+  using just the blocknumber.
+
+  The template tests only include the test for a single event
+  subscriber. There can be cases where multiple event subscribers
+  exist for a single DEX. In such cases additional tests should be
+  added.
+
+  You can run this individual test script by running:
+  `npx jest src/dex/virtuswap/virtuswap-events.test.ts`
+
+  (This comment should be removed from the final implementation)
+*/
+
+jest.setTimeout(50 * 1000);
+
+async function fetchPoolState(
+  virtuswapPool: VirtuSwapEventPool,
+  blockNumber: number,
+): Promise<DeepReadonly<PoolState>> {
+  return await virtuswapPool.generateState(blockNumber);
+}
+
+// eventName -> blockNumbers
+type EventMappings = Record<string, number[]>;
+
+type PoolEventsInfo = {
+  poolAddress: Address;
+  token0Address: Address;
+  token1Address: Address;
+  eventsMap: EventMappings;
+};
+
+//TODO: add tests for vPairFactory events
+describe('VirtuSwap EventPool', function () {
+  const dexKey = 'VirtuSwap';
+
+  // networkId -> PoolEventsInfo[]
+  const eventsToTest: Partial<Record<Network, PoolEventsInfo[]>> = {
+    [Network.POLYGON]: [
+      // VRSW-WETH
+      {
+        poolAddress: '0x68BfaE97d4970ba6f542c2a93Ed2e6eDBBf96c3b',
+        token0Address: '0x57999936fC9A9EC0751a8D146CcE11901Be8beD0',
+        token1Address: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
+        eventsMap: {
+          ReserveSync: [55283344, 55373346],
+          vSync: [55395552, 55402173, 55430710, 55433860],
+        },
+      },
+      // WMATIC-USDC.e
+      {
+        poolAddress: '0x61e7Af17bA4F3C41D0d30D15133C02E1Eb6a160b',
+        token0Address: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+        token1Address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+        eventsMap: {
+          ReserveSync: [55323873],
+          vSync: [55419625, 55432335],
+        },
+      },
+      // WMATIC-DECATS
+      {
+        poolAddress: '0x3EF0458a06b7507112fC67cD2aaa636e93C29d91',
+        token0Address: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+        token1Address: '0x198f1D316aad1C0Bfd36a79bd1A8e9dba92DAa18',
+        eventsMap: {
+          ReserveSync: [50556813], // Liquidate Reserve
+          AllowListChanged: [52799588, 52799593, 52799696], // Set Allow List
+        },
+      },
+      // USDC.e-USDT
+      {
+        poolAddress: '0x718C2A6A8F60026E13f406aF077B0D84D075d222',
+        token0Address: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
+        token1Address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+        eventsMap: {
+          AllowListChanged: [52799297, 52799705],
+          ReserveSync: [55467619, 55468496],
+        },
+      },
+    ],
+    [Network.ARBITRUM]: [
+      // VRSW-USDC.e
+      {
+        poolAddress: '0xD7d90067A07620EdEc49665B5703E539811aeb17',
+        token0Address: '0xd1E094CabC5aCB9D3b0599C3F76f2D01fF8d3563',
+        token1Address: '0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8',
+        eventsMap: {
+          ReserveSync: [196701768, 196876948],
+          vSync: [197478498],
+        },
+      },
+    ],
+  };
+
+  Object.entries(eventsToTest).forEach(([networkId, eventsInfos]) => {
+    describe(`Network id: ${networkId}`, () => {
+      const network = parseInt(networkId) as Network;
+      const params = VirtuSwapConfig[dexKey][network];
+      const dexHelper = new DummyDexHelper(network);
+      const logger = dexHelper.getLogger(dexKey);
+      eventsInfos.forEach(eventsInfo => {
+        describe(`Events for ${eventsInfo.poolAddress}`, () => {
+          const virtuswapPool = new VirtuSwapEventPool(
+            dexKey,
+            network,
+            dexHelper,
+            logger,
+            params.isTimestampBased,
+            eventsInfo.token0Address,
+            eventsInfo.token1Address,
+            eventsInfo.poolAddress,
+          );
+          Object.entries(eventsInfo.eventsMap).forEach(
+            ([eventName, blockNumbers]: [string, number[]]) => {
+              describe(`${eventName}`, () => {
+                blockNumbers.forEach((blockNumber: number) => {
+                  it(`State after ${blockNumber}`, async function () {
+                    await testEventSubscriber(
+                      virtuswapPool,
+                      virtuswapPool.addressesSubscribed,
+                      (_blockNumber: number) =>
+                        fetchPoolState(virtuswapPool, _blockNumber),
+                      blockNumber,
+                      `${dexKey}_${networkId}_${eventsInfo.poolAddress}`,
+                      dexHelper.provider,
+                    );
+                  });
+                });
+              });
+            },
+          );
+        });
+      });
+    });
+  });
+});

--- a/src/dex/virtuswap/virtuswap-events.test.ts
+++ b/src/dex/virtuswap/virtuswap-events.test.ts
@@ -35,21 +35,25 @@ describe('VirtuSwap EventPool', function () {
         '0x68BfaE97d4970ba6f542c2a93Ed2e6eDBBf96c3b': {
           ReserveSync: [55283344, 55373346],
           vSync: [55395552, 55402173, 55430710, 55433860],
+          SwapReserve: [55283344, 55373346],
         },
         // WMATIC-USDC.e
         '0x61e7Af17bA4F3C41D0d30D15133C02E1Eb6a160b': {
           ReserveSync: [55323873],
           vSync: [55419625, 55432335],
+          SwapReserve: [55323873],
         },
         // WMATIC-DECATS
         '0x3EF0458a06b7507112fC67cD2aaa636e93C29d91': {
           ReserveSync: [50556813], // Liquidate Reserve
           AllowListChanged: [52799588, 52799593, 52799696], // Set Allow List
+          SwapReserve: [55735576],
         },
         // USDC.e-USDT
         '0x718C2A6A8F60026E13f406aF077B0D84D075d222': {
           AllowListChanged: [52799297, 52799705],
           ReserveSync: [55467619, 55468496],
+          SwapReserve: [55467619, 55468496],
         },
       },
       [Network.ARBITRUM]: {
@@ -57,6 +61,13 @@ describe('VirtuSwap EventPool', function () {
         '0xD7d90067A07620EdEc49665B5703E539811aeb17': {
           ReserveSync: [196701768, 196876948],
           vSync: [197478498],
+          SwapReserve: [188252077, 196701768, 196876948],
+        },
+        // USDT-USDC.e
+        '0xd7fA852E4af17255f219503940d3468A5a42a14d': {
+          ReserveSync: [196876948],
+          vSync: [199601613],
+          SwapReserve: [188252077, 196876948],
         },
       },
     };
@@ -66,6 +77,7 @@ describe('VirtuSwap EventPool', function () {
       const network = parseInt(networkId) as Network;
       const params = VirtuSwapConfig[dexKey][network];
       const dexHelper = new DummyDexHelper(network);
+      dexHelper.web3Provider.eth.handleRevert = true; // we need revert strings to test errors
       const logger = dexHelper.getLogger(dexKey);
       Object.entries(eventsInfos).forEach(([poolAddress, eventsMap]) => {
         describe(`Events for ${poolAddress}`, () => {
@@ -79,6 +91,7 @@ describe('VirtuSwap EventPool', function () {
           );
           Object.entries(eventsMap).forEach(
             ([eventName, blockNumbers]: [string, number[]]) => {
+              if (eventName === 'SwapReserve') return; // SwapReserve is handled separately, see below
               describe(`${eventName}`, () => {
                 blockNumbers.forEach((blockNumber: number) => {
                   it(`State after ${blockNumber}`, async function () {
@@ -96,6 +109,80 @@ describe('VirtuSwap EventPool', function () {
               });
             },
           );
+          describe('SwapReserve', () => {
+            const restoringFromPrevVirtuswapPool = new VirtuSwapEventPool(
+              dexKey,
+              network,
+              dexHelper,
+              logger,
+              params.isTimestampBased,
+              poolAddress,
+              (secondPoolAddress: Address, blockNumber: number) => {
+                // test purpose only, should be replaced with getting state from cache
+                return new VirtuSwapEventPool(
+                  dexKey,
+                  network,
+                  dexHelper,
+                  logger,
+                  params.isTimestampBased,
+                  secondPoolAddress,
+                ).generateState(blockNumber - 1);
+              },
+            );
+            const restoringFromCurrentVirtuswapPool = new VirtuSwapEventPool(
+              dexKey,
+              network,
+              dexHelper,
+              logger,
+              params.isTimestampBased,
+              poolAddress,
+              (secondPoolAddress: Address, blockNumber: number) => {
+                // test purpose only, should be replaced with getting state from cache
+                return new VirtuSwapEventPool(
+                  dexKey,
+                  network,
+                  dexHelper,
+                  logger,
+                  params.isTimestampBased,
+                  secondPoolAddress,
+                ).generateState(blockNumber);
+              },
+            );
+            eventsMap.SwapReserve?.forEach((blockNumber: number) => {
+              // current pool should restore reserves from another pool when
+              // another pool state is already updated and when it isn't
+              it(`State after ${blockNumber}, restoring reserves from ${
+                blockNumber - 1
+              }`, async function () {
+                await testEventSubscriber(
+                  restoringFromPrevVirtuswapPool,
+                  restoringFromPrevVirtuswapPool.addressesSubscribed,
+                  (_blockNumber: number) =>
+                    fetchEventSubscriberState(
+                      restoringFromPrevVirtuswapPool,
+                      _blockNumber,
+                    ),
+                  blockNumber,
+                  `${dexKey}_${networkId}_${poolAddress}_RS_PREV`,
+                  dexHelper.provider,
+                );
+              });
+              it(`State after ${blockNumber}, restoring reserves from ${blockNumber}`, async function () {
+                await testEventSubscriber(
+                  restoringFromCurrentVirtuswapPool,
+                  restoringFromCurrentVirtuswapPool.addressesSubscribed,
+                  (_blockNumber: number) =>
+                    fetchEventSubscriberState(
+                      restoringFromCurrentVirtuswapPool,
+                      _blockNumber,
+                    ),
+                  blockNumber,
+                  `${dexKey}_${networkId}_${poolAddress}_RS_CURRENT`,
+                  dexHelper.provider,
+                );
+              });
+            });
+          });
         });
       });
     });

--- a/src/dex/virtuswap/virtuswap-factory.ts
+++ b/src/dex/virtuswap/virtuswap-factory.ts
@@ -1,0 +1,152 @@
+import { Interface } from '@ethersproject/abi';
+import { AsyncOrSync, DeepReadonly } from 'ts-essentials';
+import { Address, Log, Logger } from '../../types';
+import { MultiCallParams } from '../../lib/multi-wrapper';
+import { catchParseLogError, normalizeAddress, stringify } from '../../utils';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
+import { IDexHelper } from '../../dex-helper';
+import { FactoryState, OnPoolCreatedCallback } from './types';
+import vPairFactoryABI from '../../abi/virtuswap/vPairFactory.json';
+import { abiCoderParsers } from './utils';
+
+export class VirtuSwapFactory extends StatefulEventSubscriber<FactoryState> {
+  static readonly vPairFactoryInterface = new Interface(vPairFactoryABI);
+  static readonly contractPairsLengthParser = abiCoderParsers.Int.create(
+    'allPairsLength',
+    'uint256',
+  );
+  static readonly contractAllPairsParser = abiCoderParsers.Address.create(
+    'allPairs',
+    'address',
+  );
+
+  handlers: {
+    [event: string]: (
+      event: any,
+      state: DeepReadonly<FactoryState>,
+      log: Readonly<Log>,
+    ) => AsyncOrSync<DeepReadonly<FactoryState> | null>;
+  } = {};
+
+  logDecoder: (log: Log) => any;
+
+  addressesSubscribed: string[];
+
+  constructor(
+    readonly parentName: string,
+    protected network: number,
+    protected dexHelper: IDexHelper,
+    logger: Logger,
+    protected onPoolCreatedCallback: OnPoolCreatedCallback,
+    protected factoryAddress: Address,
+    protected vPairFactoryIface: Interface = VirtuSwapFactory.vPairFactoryInterface,
+  ) {
+    super(
+      parentName,
+      `${parentName}_${network}_factory_${factoryAddress}`,
+      dexHelper,
+      logger,
+      true,
+    );
+
+    this.logDecoder = (log: Log) => this.vPairFactoryIface.parseLog(log);
+    this.addressesSubscribed = [factoryAddress];
+
+    this.handlers['PairCreated'] = this.handlePairCreated.bind(this); // 0x70084adbff44be952e8bb87558f46235532635d476e79e29558665fa7d6c12ce
+  }
+
+  /**
+   * The function is called every time any of the subscribed
+   * addresses release log. The function accepts the current
+   * state, updates the state according to the log, and returns
+   * the updated state.
+   * @param state - Current state of event subscriber
+   * @param log - Log released by one of the subscribed addresses
+   * @returns Updates state of the event subscriber after the log
+   */
+  protected async processLog(
+    state: DeepReadonly<FactoryState>,
+    log: Readonly<Log>,
+  ): Promise<DeepReadonly<FactoryState> | null> {
+    try {
+      const event = this.logDecoder(log);
+      if (event.name in this.handlers) {
+        return await this.handlers[event.name](event, state, log);
+      }
+    } catch (e) {
+      catchParseLogError(e, this.logger);
+    }
+
+    return null;
+  }
+
+  /**
+   * The function generates state using on-chain calls. This
+   * function is called to regenerate state if the event based
+   * system fails to fetch events and the local state is no
+   * more correct.
+   * @param blockNumber - Blocknumber for which the state
+   * should be generated
+   * @returns state of the event subscriber at blocknumber
+   */
+  async generateState(
+    blockNumber: number,
+  ): Promise<DeepReadonly<FactoryState>> {
+    // Get allPairsLength
+    const lengthMultiCallParams = [
+      VirtuSwapFactory.contractPairsLengthParser,
+    ].map(
+      ({ name, decodeFunction }) =>
+        ({
+          target: this.factoryAddress,
+          callData: this.vPairFactoryIface.encodeFunctionData(name),
+          decodeFunction,
+        } as MultiCallParams<ReturnType<typeof decodeFunction>>),
+    );
+
+    const [allPairsLength] = await this.dexHelper.multiWrapper.aggregate(
+      lengthMultiCallParams,
+      blockNumber,
+    );
+
+    // Get all pairs (addresses of pools)
+    const allPairsMultiCallParams = Array.from(
+      { length: allPairsLength },
+      (_, i) =>
+        ({
+          target: this.factoryAddress,
+          callData: this.vPairFactoryIface.encodeFunctionData('allPairs', [i]),
+          decodeFunction:
+            VirtuSwapFactory.contractAllPairsParser.decodeFunction,
+        } as MultiCallParams<Address>),
+    );
+
+    const pools = await this.dexHelper.multiWrapper.aggregate(
+      allPairsMultiCallParams,
+      blockNumber,
+    );
+
+    await Promise.all(
+      pools.map(pool => this.onPoolCreatedCallback(pool, blockNumber)),
+    );
+
+    return {
+      pools,
+    };
+  }
+
+  async handlePairCreated(
+    event: any,
+    state: DeepReadonly<FactoryState>,
+    log: Readonly<Log>,
+  ): Promise<DeepReadonly<FactoryState> | null> {
+    const pool = normalizeAddress(stringify(event.args.poolAddress));
+
+    await this.onPoolCreatedCallback(pool, log.blockNumber);
+
+    return {
+      ...state,
+      pools: [...state.pools, pool],
+    };
+  }
+}

--- a/src/dex/virtuswap/virtuswap-factory.ts
+++ b/src/dex/virtuswap/virtuswap-factory.ts
@@ -5,7 +5,7 @@ import { MultiCallParams } from '../../lib/multi-wrapper';
 import { catchParseLogError, normalizeAddress, stringify } from '../../utils';
 import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
 import { IDexHelper } from '../../dex-helper';
-import { FactoryState, OnPoolCreatedCallback } from './types';
+import { FactoryState, OnPoolsCreatedCallback } from './types';
 import vPairFactoryABI from '../../abi/virtuswap/vPairFactory.json';
 import { abiCoderParsers } from './utils';
 
@@ -37,7 +37,7 @@ export class VirtuSwapFactory extends StatefulEventSubscriber<FactoryState> {
     protected network: number,
     protected dexHelper: IDexHelper,
     logger: Logger,
-    protected onPoolCreatedCallback: OnPoolCreatedCallback,
+    protected onPoolsCreatedCallback: OnPoolsCreatedCallback,
     protected factoryAddress: Address,
     protected vPairFactoryIface: Interface = VirtuSwapFactory.vPairFactoryInterface,
   ) {
@@ -126,9 +126,7 @@ export class VirtuSwapFactory extends StatefulEventSubscriber<FactoryState> {
       blockNumber,
     );
 
-    await Promise.all(
-      pools.map(pool => this.onPoolCreatedCallback(pool, blockNumber)),
-    );
+    await this.onPoolsCreatedCallback(pools, blockNumber);
 
     return {
       pools,
@@ -142,7 +140,7 @@ export class VirtuSwapFactory extends StatefulEventSubscriber<FactoryState> {
   ): Promise<DeepReadonly<FactoryState> | null> {
     const pool = normalizeAddress(stringify(event.args.poolAddress));
 
-    await this.onPoolCreatedCallback(pool, log.blockNumber);
+    await this.onPoolsCreatedCallback([pool], log.blockNumber);
 
     return {
       ...state,

--- a/src/dex/virtuswap/virtuswap-integration.test.ts
+++ b/src/dex/virtuswap/virtuswap-integration.test.ts
@@ -1,0 +1,280 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Interface, Result } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide } from '../../constants';
+import { PoolPrices, Address } from '../../types';
+import { BI_MAX_UINT256, BI_POWS } from '../../bigint-constants';
+import { VirtuSwap } from './virtuswap';
+import { VirtuSwapData } from './types';
+import {
+  checkPoolPrices,
+  checkPoolsLiquidity,
+  checkConstantPoolPrices,
+} from '../../../tests/utils';
+import { Tokens } from '../../../tests/constants-e2e';
+
+function getReaderCalldata(
+  routerAddress: Address,
+  readerIface: Interface,
+  address1: Address,
+  address2: Address,
+  amounts: bigint[],
+  funcName: string,
+) {
+  return amounts.map(amount => ({
+    target: routerAddress,
+    callData: readerIface.encodeFunctionData(funcName, [
+      address1,
+      address2,
+      amount,
+    ]),
+  }));
+}
+
+function decodeReaderResult(
+  results: Result,
+  readerIface: Interface,
+  funcName: string,
+) {
+  return results.map(result => {
+    const parsed = readerIface.decodeFunctionResult(funcName, result);
+    return BigInt(parsed[0]._hex);
+  });
+}
+
+async function checkOnChainPricing(
+  virtuswap: VirtuSwap,
+  realFuncName: string,
+  virtualFuncName: string,
+  blockNumber: number,
+  poolPrices: PoolPrices<VirtuSwapData>[],
+  amounts: bigint[],
+) {
+  const readerIface = virtuswap.vRouterIface;
+
+  for (const prices of poolPrices) {
+    const routerAddress = prices.data.router;
+
+    let address1: Address;
+    let address2: Address;
+    if (prices.data.isVirtual) {
+      address1 = virtuswap.computePoolAddress({
+        token0: prices.data.tokenOut,
+        token1: prices.data.commonToken,
+      });
+      address2 = prices.data.ikPair;
+    } else {
+      address1 = prices.data.path[0];
+      address2 = prices.data.path[1];
+    }
+
+    const funcName = prices.data.isVirtual ? virtualFuncName : realFuncName;
+
+    const readerCallData = getReaderCalldata(
+      routerAddress,
+      readerIface,
+      address1,
+      address2,
+      amounts.slice(1),
+      funcName,
+    );
+
+    const readerResult = (
+      await virtuswap.dexHelper.multiContract.methods
+        .aggregate(readerCallData)
+        .call({}, blockNumber)
+    ).returnData;
+
+    const expectedPrices = [0n].concat(
+      decodeReaderResult(readerResult, readerIface, funcName),
+    );
+
+    expect(prices.prices).toEqual(expectedPrices);
+  }
+}
+
+async function testPricingOnNetwork(
+  virtuswap: VirtuSwap,
+  network: Network,
+  dexKey: string,
+  blockNumber: number,
+  srcTokenSymbol: string,
+  destTokenSymbol: string,
+  side: SwapSide,
+  amounts: bigint[],
+  realFuncNameToCheck: string,
+  virtualFuncNameToCheck: string,
+) {
+  const networkTokens = Tokens[network];
+
+  const pools = await virtuswap.getPoolIdentifiers(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    side,
+    blockNumber,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Identifiers: `,
+    pools,
+  );
+
+  expect(pools.length).toBeGreaterThan(0);
+
+  const poolPrices = await virtuswap.getPricesVolume(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    amounts,
+    side,
+    blockNumber,
+    pools,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Prices: `,
+    poolPrices,
+  );
+
+  expect(poolPrices).not.toBeNull();
+
+  const pricesToCheck = poolPrices!.filter(
+    ({ prices }) => prices[prices.length - 1] !== BI_MAX_UINT256,
+  );
+
+  expect(pricesToCheck.length).toBeGreaterThan(0);
+
+  // some virtual pools can have very low liquidity and should be skipped from the check
+  const skippedPrices = poolPrices!.filter(
+    ({ prices }) => prices[prices.length - 1] === BI_MAX_UINT256,
+  );
+  if (skippedPrices.length > 0)
+    console.warn(
+      `Some pools had very low liquidity. Skipped Prices: `,
+      skippedPrices,
+    );
+
+  if (virtuswap.hasConstantPriceLargeAmounts) {
+    checkConstantPoolPrices(pricesToCheck!, amounts, dexKey);
+  } else {
+    checkPoolPrices(pricesToCheck!, amounts, side, dexKey);
+  }
+
+  // Check if onchain pricing equals to calculated ones
+  await checkOnChainPricing(
+    virtuswap,
+    realFuncNameToCheck,
+    virtualFuncNameToCheck,
+    blockNumber,
+    pricesToCheck!,
+    amounts,
+  );
+}
+
+describe('VirtuSwap', function () {
+  const dexKey = 'VirtuSwap';
+  const networks = [Network.POLYGON, Network.ARBITRUM];
+  let blockNumber: number;
+  let virtuswap: VirtuSwap;
+
+  for (const network of networks) {
+    describe(`Network id: ${network}`, () => {
+      const dexHelper = new DummyDexHelper(network);
+
+      const tokens = Tokens[network];
+
+      const srcTokenSymbol = tokens['USDCe'] ? 'USDCe' : 'USDC';
+      const destTokenSymbol = 'VRSW';
+
+      const amountsForSell = [
+        0n,
+        1n * BI_POWS[tokens[srcTokenSymbol].decimals],
+        2n * BI_POWS[tokens[srcTokenSymbol].decimals],
+        3n * BI_POWS[tokens[srcTokenSymbol].decimals],
+        4n * BI_POWS[tokens[srcTokenSymbol].decimals],
+        5n * BI_POWS[tokens[srcTokenSymbol].decimals],
+        6n * BI_POWS[tokens[srcTokenSymbol].decimals],
+        7n * BI_POWS[tokens[srcTokenSymbol].decimals],
+        8n * BI_POWS[tokens[srcTokenSymbol].decimals],
+        9n * BI_POWS[tokens[srcTokenSymbol].decimals],
+        10n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      ];
+
+      const amountsForBuy = [
+        0n,
+        1n * BI_POWS[tokens[destTokenSymbol].decimals],
+        2n * BI_POWS[tokens[destTokenSymbol].decimals],
+        3n * BI_POWS[tokens[destTokenSymbol].decimals],
+        4n * BI_POWS[tokens[destTokenSymbol].decimals],
+        5n * BI_POWS[tokens[destTokenSymbol].decimals],
+        6n * BI_POWS[tokens[destTokenSymbol].decimals],
+        7n * BI_POWS[tokens[destTokenSymbol].decimals],
+        8n * BI_POWS[tokens[destTokenSymbol].decimals],
+        9n * BI_POWS[tokens[destTokenSymbol].decimals],
+        10n * BI_POWS[tokens[destTokenSymbol].decimals],
+      ];
+
+      beforeAll(async () => {
+        blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+        virtuswap = new VirtuSwap(network, dexKey, dexHelper);
+        if (virtuswap.initializePricing) {
+          await virtuswap.initializePricing(blockNumber);
+        }
+      });
+
+      it('getPoolIdentifiers and getPricesVolume SELL', async function () {
+        await testPricingOnNetwork(
+          virtuswap,
+          network,
+          dexKey,
+          blockNumber,
+          srcTokenSymbol,
+          destTokenSymbol,
+          SwapSide.SELL,
+          amountsForSell,
+          'getAmountOut',
+          'getVirtualAmountOut',
+        );
+      });
+
+      it('getPoolIdentifiers and getPricesVolume BUY', async function () {
+        await testPricingOnNetwork(
+          virtuswap,
+          network,
+          dexKey,
+          blockNumber,
+          srcTokenSymbol,
+          destTokenSymbol,
+          SwapSide.BUY,
+          amountsForBuy,
+          'getAmountIn',
+          'getVirtualAmountIn',
+        );
+      });
+
+      // TODO: add subgraphURL to set up getTopPoolsForToken
+
+      // it('getTopPoolsForToken', async function () {
+      //   // We have to check without calling initializePricing, because
+      //   // pool-tracker is not calling that function
+      //   const newVirtuSwap = new VirtuSwap(network, dexKey, dexHelper);
+      //   if (newVirtuSwap.updatePoolState) {
+      //     await newVirtuSwap.updatePoolState();
+      //   }
+      //   const poolLiquidity = await newVirtuSwap.getTopPoolsForToken(
+      //     tokens[srcTokenSymbol].address,
+      //     10,
+      //   );
+      //   console.log(`${srcTokenSymbol} Top Pools:`, poolLiquidity);
+      //
+      //   if (!newVirtuSwap.hasConstantPriceLargeAmounts) {
+      //     checkPoolsLiquidity(
+      //       poolLiquidity,
+      //       Tokens[network][srcTokenSymbol].address,
+      //       dexKey,
+      //     );
+      //   }
+      // });
+    });
+  }
+});

--- a/src/dex/virtuswap/virtuswap-integration.test.ts
+++ b/src/dex/virtuswap/virtuswap-integration.test.ts
@@ -188,7 +188,7 @@ describe('VirtuSwap', function () {
 
       const tokens = Tokens[network];
 
-      const srcTokenSymbol = tokens['USDCe'] ? 'USDCe' : 'USDC';
+      const srcTokenSymbol = 'USDCe';
       const destTokenSymbol = 'VRSW';
 
       const amountsForSell = [

--- a/src/dex/virtuswap/virtuswap-integration.test.ts
+++ b/src/dex/virtuswap/virtuswap-integration.test.ts
@@ -16,6 +16,8 @@ import {
 } from '../../../tests/utils';
 import { Tokens } from '../../../tests/constants-e2e';
 
+jest.setTimeout(50 * 1000);
+
 function getReaderCalldata(
   routerAddress: Address,
   readerIface: Interface,
@@ -54,10 +56,9 @@ async function checkOnChainPricing(
   amounts: bigint[],
 ) {
   const readerIface = virtuswap.vRouterIface;
+  const routerAddress = virtuswap.routerAddress;
 
   for (const prices of poolPrices) {
-    const routerAddress = prices.data.router;
-
     let address1: Address;
     let address2: Address;
     if (prices.data.isVirtual) {

--- a/src/dex/virtuswap/virtuswap-integration.test.ts
+++ b/src/dex/virtuswap/virtuswap-integration.test.ts
@@ -257,29 +257,27 @@ describe('VirtuSwap', function () {
         );
       });
 
-      // TODO: add subgraphURL to set up getTopPoolsForToken
+      it('getTopPoolsForToken', async function () {
+        // We have to check without calling initializePricing, because
+        // pool-tracker is not calling that function
+        const newVirtuSwap = new VirtuSwap(network, dexKey, dexHelper);
+        if (newVirtuSwap.updatePoolState) {
+          await newVirtuSwap.updatePoolState();
+        }
+        const poolLiquidity = await newVirtuSwap.getTopPoolsForToken(
+          tokens[srcTokenSymbol].address,
+          10,
+        );
+        console.log(`${srcTokenSymbol} Top Pools:`, poolLiquidity);
 
-      // it('getTopPoolsForToken', async function () {
-      //   // We have to check without calling initializePricing, because
-      //   // pool-tracker is not calling that function
-      //   const newVirtuSwap = new VirtuSwap(network, dexKey, dexHelper);
-      //   if (newVirtuSwap.updatePoolState) {
-      //     await newVirtuSwap.updatePoolState();
-      //   }
-      //   const poolLiquidity = await newVirtuSwap.getTopPoolsForToken(
-      //     tokens[srcTokenSymbol].address,
-      //     10,
-      //   );
-      //   console.log(`${srcTokenSymbol} Top Pools:`, poolLiquidity);
-      //
-      //   if (!newVirtuSwap.hasConstantPriceLargeAmounts) {
-      //     checkPoolsLiquidity(
-      //       poolLiquidity,
-      //       Tokens[network][srcTokenSymbol].address,
-      //       dexKey,
-      //     );
-      //   }
-      // });
+        if (!newVirtuSwap.hasConstantPriceLargeAmounts) {
+          checkPoolsLiquidity(
+            poolLiquidity,
+            Tokens[network][srcTokenSymbol].address,
+            dexKey,
+          );
+        }
+      });
     });
   }
 });

--- a/src/dex/virtuswap/virtuswap-integration.test.ts
+++ b/src/dex/virtuswap/virtuswap-integration.test.ts
@@ -139,14 +139,18 @@ async function testPricingOnNetwork(
   expect(poolPrices).not.toBeNull();
 
   const pricesToCheck = poolPrices!.filter(
-    ({ prices }) => prices[prices.length - 1] !== BI_MAX_UINT256,
+    ({ prices }) =>
+      prices[prices.length - 1] !== BI_MAX_UINT256 &&
+      prices[prices.length - 1] !== 0n,
   );
 
   expect(pricesToCheck.length).toBeGreaterThan(0);
 
   // some virtual pools can have very low liquidity and should be skipped from the check
   const skippedPrices = poolPrices!.filter(
-    ({ prices }) => prices[prices.length - 1] === BI_MAX_UINT256,
+    ({ prices }) =>
+      prices[prices.length - 1] === BI_MAX_UINT256 ||
+      prices[prices.length - 1] === 0n,
   );
   if (skippedPrices.length > 0)
     console.warn(

--- a/src/dex/virtuswap/virtuswap-pool.ts
+++ b/src/dex/virtuswap/virtuswap-pool.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { Interface } from '@ethersproject/abi';
 import { assert, AsyncOrSync, DeepReadonly } from 'ts-essentials';
-import { Address, Log, Logger, Token } from '../../types';
+import { Address, Log, Logger } from '../../types';
 import { MultiCallParams } from '../../lib/multi-wrapper';
 import {
   bigIntify,

--- a/src/dex/virtuswap/virtuswap-pool.ts
+++ b/src/dex/virtuswap/virtuswap-pool.ts
@@ -21,6 +21,8 @@ export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
   static readonly RESERVE_RATIO_FACTOR = VirtuSwapEventPool.BASE_FACTOR * 100n;
   static readonly vPairInterface = new Interface(vPairABI);
   static readonly contractStateFunctionsParsers = [
+    abiCoderParsers.Address.create('token0', 'address'),
+    abiCoderParsers.Address.create('token1', 'address'),
     abiCoderParsers.BigInt.create('pairBalance0', 'uint112'),
     abiCoderParsers.BigInt.create('pairBalance1', 'uint112'),
     abiCoderParsers.Int.create('fee', 'uint16'),
@@ -39,8 +41,6 @@ export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
     'reserves',
     'uint256',
   );
-  protected token0Address: Address;
-  protected token1Address: Address;
 
   handlers: {
     [event: string]: (
@@ -61,8 +61,6 @@ export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
     protected dexHelper: IDexHelper,
     logger: Logger,
     protected isTimestampBased: boolean,
-    _token0Address: Address,
-    _token1Address: Address,
     protected poolAddress: Address,
     protected vPairIface: Interface = VirtuSwapEventPool.vPairInterface,
   ) {
@@ -72,9 +70,6 @@ export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
       dexHelper,
       logger,
     );
-
-    this.token0Address = normalizeAddress(_token0Address);
-    this.token1Address = normalizeAddress(_token1Address);
 
     this.logDecoder = (log: Log) => this.vPairIface.parseLog(log);
     this.addressesSubscribed = [poolAddress];
@@ -218,7 +213,7 @@ export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
       )
     ).filter(
       (address: Address) =>
-        address !== this.token0Address && address !== this.token1Address,
+        address !== initialState.token0 && address !== initialState.token1,
     );
 
     // Get reserves info for each token in allow list
@@ -352,7 +347,7 @@ export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
       .map((token: any) => normalizeAddress(stringify(token)))
       .filter(
         (address: Address) =>
-          address !== this.token0Address && address !== this.token1Address,
+          address !== state.token0 && address !== state.token1,
       );
 
     // we need to fetch reserves for new tokens and recalculate reservesBaseValueSum

--- a/src/dex/virtuswap/virtuswap-pool.ts
+++ b/src/dex/virtuswap/virtuswap-pool.ts
@@ -14,11 +14,10 @@ import { IDexHelper } from '../../dex-helper';
 import { PoolState } from './types';
 import vPairABI from '../../abi/virtuswap/vPair.json';
 import { abiCoderParsers } from './utils';
+import { RESERVE_RATIO_FACTOR } from './constants';
 import { BlockHeader } from 'web3-eth';
 
 export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
-  static readonly BASE_FACTOR = 1000n;
-  static readonly RESERVE_RATIO_FACTOR = VirtuSwapEventPool.BASE_FACTOR * 100n;
   static readonly vPairInterface = new Interface(vPairABI);
   static readonly contractStateFunctionsParsers = [
     abiCoderParsers.Address.create('token0', 'address'),
@@ -292,7 +291,7 @@ export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
 
       // calculate rRatio from local state
       const rRatioRestored =
-        (reservesBaseValueSum * VirtuSwapEventPool.RESERVE_RATIO_FACTOR) /
+        (reservesBaseValueSum * RESERVE_RATIO_FACTOR) /
         (state.pairBalance0 << 1n);
 
       // rRatios must be the same if the pool state is correct

--- a/src/dex/virtuswap/virtuswap-pool.ts
+++ b/src/dex/virtuswap/virtuswap-pool.ts
@@ -551,10 +551,3 @@ export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
     };
   }
 }
-
-export type VirtuSwapPair = {
-  token0: Token;
-  token1: Token;
-  exchange?: Address;
-  pool?: VirtuSwapEventPool;
-};

--- a/src/dex/virtuswap/virtuswap-pool.ts
+++ b/src/dex/virtuswap/virtuswap-pool.ts
@@ -1,0 +1,420 @@
+import _ from 'lodash';
+import { Interface } from '@ethersproject/abi';
+import { assert, AsyncOrSync, DeepReadonly } from 'ts-essentials';
+import { Address, Log, Logger, Token } from '../../types';
+import { MultiCallParams } from '../../lib/multi-wrapper';
+import {
+  bigIntify,
+  catchParseLogError,
+  normalizeAddress,
+  stringify,
+} from '../../utils';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
+import { IDexHelper } from '../../dex-helper';
+import { PoolState } from './types';
+import vPairABI from '../../abi/virtuswap/vPair.json';
+import { abiCoderParsers } from './utils';
+import { BlockHeader } from 'web3-eth';
+
+export class VirtuSwapEventPool extends StatefulEventSubscriber<PoolState> {
+  static readonly BASE_FACTOR = 1000n;
+  static readonly RESERVE_RATIO_FACTOR = VirtuSwapEventPool.BASE_FACTOR * 100n;
+  static readonly vPairInterface = new Interface(vPairABI);
+  static readonly contractStateFunctionsParsers = [
+    abiCoderParsers.BigInt.create('pairBalance0', 'uint112'),
+    abiCoderParsers.BigInt.create('pairBalance1', 'uint112'),
+    abiCoderParsers.Int.create('fee', 'uint16'),
+    abiCoderParsers.Int.create('vFee', 'uint16'),
+    abiCoderParsers.Int.create('lastSwapBlock', 'uint128'),
+    abiCoderParsers.Int.create('blocksDelay', 'uint128'),
+    abiCoderParsers.BigInt.create('reservesBaseValueSum', 'uint256'),
+    abiCoderParsers.BigInt.create('maxReserveRatio', 'uint256'),
+    abiCoderParsers.Int.create('allowListLength', 'uint256'),
+  ] as const;
+  static readonly contractAllowListAddressParser =
+    abiCoderParsers.Address.create('allowList', 'address');
+  static readonly contractReservesBaseValueParser =
+    abiCoderParsers.BigInt.create('reservesBaseValue', 'uint256');
+  static readonly contractReservesParser = abiCoderParsers.BigInt.create(
+    'reserves',
+    'uint256',
+  );
+  protected token0Address: Address;
+  protected token1Address: Address;
+
+  handlers: {
+    [event: string]: (
+      event: any,
+      state: DeepReadonly<PoolState>,
+      log: Readonly<Log>,
+      blockHeader: Readonly<BlockHeader>,
+    ) => AsyncOrSync<DeepReadonly<PoolState> | null>;
+  } = {};
+
+  logDecoder: (log: Log) => any;
+
+  addressesSubscribed: string[];
+
+  constructor(
+    readonly parentName: string,
+    protected network: number,
+    protected dexHelper: IDexHelper,
+    logger: Logger,
+    protected isTimestampBased: boolean,
+    _token0Address: Address,
+    _token1Address: Address,
+    protected poolAddress: Address,
+    protected vPairIface: Interface = VirtuSwapEventPool.vPairInterface,
+  ) {
+    super(
+      parentName,
+      `${parentName}_${network}_${poolAddress}`,
+      dexHelper,
+      logger,
+    );
+
+    this.token0Address = normalizeAddress(_token0Address);
+    this.token1Address = normalizeAddress(_token1Address);
+
+    this.logDecoder = (log: Log) => this.vPairIface.parseLog(log);
+    this.addressesSubscribed = [poolAddress];
+
+    this.handlers['vSync'] = this.handleSync.bind(this); // 0xa74621c1abba1dca03b6708d02443d60ddfd3f4273745060c4355afc9daa52c6
+    this.handlers['ReserveSync'] = this.handleReserveSync.bind(this); // 0x3f78f965596026d67092e66b7de2aaf2c33839a6b15485c4dec57f03e35e8a3e
+    this.handlers['AllowListChanged'] = this.handleAllowListChanged.bind(this); // 0xc2d08e7ae40f88bd169469bbcfa69c8213cb98772e0bab7de792256c59139eec
+    this.handlers['FeeChanged'] = this.handleFeeChanged.bind(this); // 0xaa1ebd1f8841401ae5e1a0f2febc87d5f597ae458fca8277cd0e43b92633183c
+    this.handlers['ReserveThresholdChanged'] =
+      this.handleReserveThresholdChanged.bind(this); // 0x047f24f47d2c93ef7523cb3c84c3b367df61e4899214a2a48784cfa09da91fdf
+    this.handlers['BlocksDelayChanged'] =
+      this.handleBlocksDelayChanged.bind(this); // 0xcaaa7d3acc870fbbecd0fd5b1b5318711a76bc6beee2883e7c8d6bbf3c77b3ad
+  }
+
+  /**
+   * The function is called every time any of the subscribed
+   * addresses release log. The function accepts the current
+   * state, updates the state according to the log, and returns
+   * the updated state.
+   * @param state - Current state of event subscriber
+   * @param log - Log released by one of the subscribed addresses
+   * @param blockHeader - Block header of the block in which the log was released
+   * @returns Updates state of the event subscriber after the log
+   */
+  protected async processLog(
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): Promise<DeepReadonly<PoolState> | null> {
+    try {
+      const event = this.logDecoder(log);
+      if (event.name in this.handlers) {
+        return await this.handlers[event.name](event, state, log, blockHeader);
+      }
+    } catch (e) {
+      catchParseLogError(e, this.logger);
+    }
+
+    return null;
+  }
+
+  /**
+   * The function is called to fetch reserves of the pool
+   * @param addresses - Addresses of the allowed reserve tokens in the pool
+   * @param blockNumber - Blocknumber for which the reserves should be fetched
+   * @returns Reserves of the pool
+   */
+  protected async fetchReserves(
+    addresses: Address[],
+    blockNumber: number,
+  ): Promise<PoolState['reserves']> {
+    const reservesMultiCallParams = addresses.flatMap(
+      address =>
+        [
+          {
+            target: this.poolAddress,
+            callData: this.vPairIface.encodeFunctionData('reservesBaseValue', [
+              address,
+            ]),
+            decodeFunction:
+              VirtuSwapEventPool.contractReservesBaseValueParser.decodeFunction,
+          },
+          {
+            target: this.poolAddress,
+            callData: this.vPairIface.encodeFunctionData('reserves', [address]),
+            decodeFunction:
+              VirtuSwapEventPool.contractReservesParser.decodeFunction,
+          },
+        ] as MultiCallParams<bigint>[],
+    );
+
+    const reservesReturnData = await this.dexHelper.multiWrapper.aggregate(
+      reservesMultiCallParams,
+      blockNumber,
+    );
+
+    return _.fromPairs(
+      _.map(_.chunk(reservesReturnData, 2), ([baseValue, balance], index) => [
+        addresses[index],
+        { baseValue, balance },
+      ]),
+    );
+  }
+
+  /**
+   * The function generates state using on-chain calls. This
+   * function is called to regenerate state if the event based
+   * system fails to fetch events and the local state is no
+   * more correct.
+   * @param blockNumber - Blocknumber for which the state
+   * should be generated
+   * @returns state of the event subscriber at blocknumber
+   */
+  async generateState(blockNumber: number): Promise<DeepReadonly<PoolState>> {
+    // Get initial data and allowListLength
+    const initialMultiCallParams =
+      VirtuSwapEventPool.contractStateFunctionsParsers.map(
+        ({ name, decodeFunction }) =>
+          ({
+            target: this.poolAddress,
+            callData: this.vPairIface.encodeFunctionData(name),
+            decodeFunction,
+          } as MultiCallParams<ReturnType<typeof decodeFunction>>),
+      );
+
+    const initialReturnData = await this.dexHelper.multiWrapper.aggregate(
+      initialMultiCallParams,
+      blockNumber,
+    );
+
+    type stateFunctionParserType =
+      typeof VirtuSwapEventPool.contractStateFunctionsParsers[number];
+
+    const initialState = _.fromPairs(
+      VirtuSwapEventPool.contractStateFunctionsParsers
+        .filter(({ name }) => name !== 'allowListLength')
+        .map(({ name }, i) => [name, initialReturnData[i]]),
+    ) as Pick<
+      PoolState,
+      Exclude<stateFunctionParserType['name'], 'allowListLength'>
+    >;
+
+    const allowListLength = _.last(initialReturnData) as number;
+
+    // Get allow list (addresses of allowed tokens)
+    const allowListMultiCallParams = Array.from(
+      { length: allowListLength },
+      (_, i) =>
+        ({
+          target: this.poolAddress,
+          callData: this.vPairIface.encodeFunctionData('allowList', [i]),
+          decodeFunction:
+            VirtuSwapEventPool.contractAllowListAddressParser.decodeFunction,
+        } as MultiCallParams<Address>),
+    );
+
+    const allowList = (
+      await this.dexHelper.multiWrapper.aggregate(
+        allowListMultiCallParams,
+        blockNumber,
+      )
+    ).filter(
+      (address: Address) =>
+        address !== this.token0Address && address !== this.token1Address,
+    );
+
+    // Get reserves info for each token in allow list
+    const reserves = await this.fetchReserves(allowList, blockNumber);
+
+    return {
+      ...initialState,
+      reserves,
+    };
+  }
+
+  handleSync(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): DeepReadonly<PoolState> | null {
+    const pairBalance0 = bigIntify(event.args.balance0);
+    const pairBalance1 = bigIntify(event.args.balance1);
+    // we use block.timestamp for lastSwapBlock on Arbitrum due to differences in how block.number works there
+    // (see https://docs.arbitrum.io/for-devs/troubleshooting-building#how-do-blocknumber-and-blocktimestamp-work-on-arbitrum)
+    const lastSwapBlock = this.isTimestampBased
+      ? Number(blockHeader.timestamp)
+      : blockHeader.number;
+    return {
+      ...state,
+      lastSwapBlock,
+      pairBalance0,
+      pairBalance1,
+    };
+  }
+
+  async handleReserveSync(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): Promise<DeepReadonly<PoolState> | null> {
+    const reserveToken = normalizeAddress(stringify(event.args.asset));
+    const newReserveBalance = bigIntify(event.args.balance);
+
+    if (newReserveBalance === 0n) {
+      const reservesBaseValueSum =
+        state.reservesBaseValueSum - state.reserves[reserveToken].baseValue;
+      const reserves = {
+        ...state.reserves,
+        [reserveToken]: { balance: 0n, baseValue: 0n },
+      };
+      return {
+        ...state,
+        reserves,
+        reservesBaseValueSum,
+      };
+    } else {
+      const rRatio = bigIntify(event.args.rRatio);
+      // TODO: check if we can use info from SwapReserve event to calculate baseValue
+      /*
+       * we cannot recover the baseValue for reserveToken from rRatio due to
+       * integer division, so we need to re-fetch reserve info for this token
+       * and recalculate reservesBaseValueSum
+       */
+      const tokenReserve = await this.fetchReserves(
+        [reserveToken],
+        blockHeader.number,
+      );
+      const reserves = {
+        ...state.reserves,
+        ...tokenReserve,
+      };
+
+      const reservesBaseValueSum = _.reduce(
+        _.values(reserves),
+        (sum, { baseValue }) => sum + baseValue,
+        0n,
+      );
+
+      // calculate rRatio from local state
+      const rRatioRestored =
+        (reservesBaseValueSum * VirtuSwapEventPool.RESERVE_RATIO_FACTOR) /
+        (state.pairBalance0 << 1n);
+
+      // rRatios must be the same if the pool state is correct
+      assert(
+        rRatio === rRatioRestored,
+        `Pool ${
+          this.poolAddress
+        }: rRatio value is out of sync: rRatio=${rRatio.toString()}; rRatioRestored=${rRatioRestored.toString()}`,
+      );
+
+      return {
+        ...state,
+        reserves,
+        reservesBaseValueSum,
+      };
+
+      // the code below leads to inaccurate calculation of baseValue due to integer division of rRatio in vPair contract
+      /*
+      const reservesBaseValueSum =
+        (rRatio * (state.pairBalance0 << 1n)) /
+        VirtuSwapEventPool.RESERVE_RATIO_FACTOR;
+
+      const newReserveBaseValue =
+        reservesBaseValueSum -
+        state.reservesBaseValueSum +
+        state.reserves[reserveToken].baseValue;
+
+      const reserves = {
+        ...state.reserves,
+        [reserveToken]: {
+          balance: newReserveBalance,
+          baseValue: newReserveBaseValue,
+        },
+      };
+
+      return {
+        ...state,
+        reserves,
+        reservesBaseValueSum,
+      };
+      */
+    }
+  }
+
+  async handleAllowListChanged(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): Promise<DeepReadonly<PoolState> | null> {
+    const allowList = event.args.tokens
+      .map((token: any) => normalizeAddress(stringify(token)))
+      .filter(
+        (address: Address) =>
+          address !== this.token0Address && address !== this.token1Address,
+      );
+
+    // we need to fetch reserves for new tokens and recalculate reservesBaseValueSum
+    const reserves = await this.fetchReserves(allowList, blockHeader.number);
+    const reservesBaseValueSum = _.reduce(
+      _.values(reserves),
+      (sum, { baseValue }) => sum + baseValue,
+      0n,
+    );
+
+    return {
+      ...state,
+      reserves,
+      reservesBaseValueSum,
+    };
+  }
+
+  handleFeeChanged(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): DeepReadonly<PoolState> | null {
+    const fee = Number(event.args.fee);
+    const vFee = Number(event.args.vFee);
+    return {
+      ...state,
+      fee,
+      vFee,
+    };
+  }
+
+  handleReserveThresholdChanged(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): DeepReadonly<PoolState> | null {
+    const maxReserveRatio = bigIntify(event.args.newThreshold);
+    return {
+      ...state,
+      maxReserveRatio,
+    };
+  }
+
+  handleBlocksDelayChanged(
+    event: any,
+    state: DeepReadonly<PoolState>,
+    log: Readonly<Log>,
+    blockHeader: Readonly<BlockHeader>,
+  ): DeepReadonly<PoolState> | null {
+    const blocksDelay = Number(event.args._newBlocksDelay);
+    return {
+      ...state,
+      blocksDelay,
+    };
+  }
+}
+
+export type VirtuSwapPair = {
+  token0: Token;
+  token1: Token;
+  exchange?: Address;
+  pool?: VirtuSwapEventPool;
+};

--- a/src/dex/virtuswap/virtuswap-virtual-pool-manager.ts
+++ b/src/dex/virtuswap/virtuswap-virtual-pool-manager.ts
@@ -1,4 +1,4 @@
-import _, { parseInt } from 'lodash';
+import { parseInt } from 'lodash';
 import { AbiItem } from 'web3-utils';
 import { Contract } from 'web3-eth-contract';
 import { PlainVirtualPoolState } from './types';

--- a/src/dex/virtuswap/virtuswap-virtual-pool-manager.ts
+++ b/src/dex/virtuswap/virtuswap-virtual-pool-manager.ts
@@ -1,0 +1,68 @@
+import _, { parseInt } from 'lodash';
+import { AbiItem } from 'web3-utils';
+import { Contract } from 'web3-eth-contract';
+import { PlainVirtualPoolState } from './types';
+import { Address, Logger } from '../../types';
+import vPoolManagerABI from '../../abi/virtuswap/vPoolManager.json';
+import { bigIntify, normalizeAddress, stringify } from '../../utils';
+import { IDexHelper } from '../../dex-helper';
+
+export class VirtuSwapVirtualPoolManager {
+  vPoolManagerContract: Contract;
+
+  constructor(
+    protected dexHelper: IDexHelper,
+    protected logger: Logger,
+    protected vPoolManagerAddress: Address,
+  ) {
+    this.vPoolManagerContract = new dexHelper.web3Provider.eth.Contract(
+      vPoolManagerABI as AbiItem[],
+      vPoolManagerAddress,
+    );
+  }
+
+  async getVirtualPoolFromChain(
+    jkPair: Address,
+    ikPair: Address,
+    blockNumber?: number | string,
+  ): Promise<PlainVirtualPoolState> {
+    const virtualPool: Record<keyof PlainVirtualPoolState, any> =
+      await this.vPoolManagerContract.methods
+        .getVirtualPool(jkPair, ikPair)
+        .call(undefined, blockNumber);
+
+    return {
+      fee: parseInt(virtualPool.fee),
+      token0: normalizeAddress(stringify(virtualPool.token0)),
+      token1: normalizeAddress(stringify(virtualPool.token1)),
+      balance0: bigIntify(virtualPool.balance0),
+      balance1: bigIntify(virtualPool.balance1),
+      commonToken: normalizeAddress(stringify(virtualPool.commonToken)),
+      jkPair: normalizeAddress(stringify(virtualPool.jkPair)),
+      ikPair: normalizeAddress(stringify(virtualPool.ikPair)),
+    };
+  }
+
+  async getVirtualPoolsFromChain(
+    token0: Address,
+    token1: Address,
+    blockNumber?: number | string,
+  ): Promise<PlainVirtualPoolState[]> {
+    const virtualPools = await this.vPoolManagerContract.methods
+      .getVirtualPools(token0, token1)
+      .call(undefined, blockNumber);
+
+    return virtualPools.map(
+      (virtualPool: Record<keyof PlainVirtualPoolState, any>) => ({
+        fee: parseInt(virtualPool.fee),
+        token0: normalizeAddress(stringify(virtualPool.token0)),
+        token1: normalizeAddress(stringify(virtualPool.token1)),
+        balance0: bigIntify(virtualPool.balance0),
+        balance1: bigIntify(virtualPool.balance1),
+        commonToken: normalizeAddress(stringify(virtualPool.commonToken)),
+        jkPair: normalizeAddress(stringify(virtualPool.jkPair)),
+        ikPair: normalizeAddress(stringify(virtualPool.ikPair)),
+      }),
+    );
+  }
+}

--- a/src/dex/virtuswap/virtuswap-virtual-pools-state.test.ts
+++ b/src/dex/virtuswap/virtuswap-virtual-pools-state.test.ts
@@ -1,0 +1,328 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Network } from '../../constants';
+import { Address } from '../../types';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { VirtuSwapConfig } from './config';
+import { PlainVirtualPoolState } from './types';
+import { getVirtualPool, getVirtualPools } from './lib/vSwapLibrary';
+import { computeAddress } from './lib/PoolAddress';
+import { VirtuSwapVirtualPoolManager } from './virtuswap-virtual-pool-manager';
+import { VirtuSwapEventPool } from './virtuswap-pool';
+import { normalizeAddress } from '../../utils';
+
+jest.setTimeout(50 * 1000);
+
+type PairOfPools = {
+  jkPair: Address;
+  ikPair: Address;
+  validBlockNumbers: number[];
+  invalidBlockNumbers: { [reason: string]: number[] };
+};
+
+type PairOfTokens = {
+  token0: Address;
+  token1: Address;
+  validBlockNumbers: number[];
+};
+
+const dexKey = 'VirtuSwap';
+
+describe('VirtuSwap Virtual Pools by Pairs', function () {
+  const poolsToTest: Partial<Record<Network, PairOfPools[]>> = {
+    [Network.POLYGON]: [
+      {
+        jkPair: '0x68BfaE97d4970ba6f542c2a93Ed2e6eDBBf96c3b', // VRSW-WETH
+        ikPair: '0xa28AA39A9F3A46b20026b80F73fc8ae05290f6DA', // USDC.e-VRSW
+        validBlockNumbers: [
+          55672577 - 1,
+          55674148 - 1,
+          55843818 - 1,
+          55847147 - 1,
+        ], // -1 as we need to check state before events
+        invalidBlockNumbers: {
+          'VSWAP: LOCKED_VPOOL': [55843818, 55847147, 55847147 + 1],
+        },
+      },
+      {
+        jkPair: '0x68BfaE97d4970ba6f542c2a93Ed2e6eDBBf96c3b', // VRSW-WETH
+        ikPair: '0x0298BAa90C7a8d13037276C4D0c7422dB13D206e', // WBTC-WETH
+        validBlockNumbers: [
+          55672577 - 1,
+          55674148 - 1,
+          55739830 - 1,
+          55846513 - 1,
+        ], // -1 as we need to check state before events
+        invalidBlockNumbers: {},
+      },
+      {
+        jkPair: '0x0298BAa90C7a8d13037276C4D0c7422dB13D206e', // WBTC-WETH
+        ikPair: '0x5C4281D26bE6853A132794429CDfAbaC6F652Ad6', // DECATS-VRSW
+        validBlockNumbers: [],
+        invalidBlockNumbers: {
+          'VSWAP: INVALID_VPOOL': [55854967],
+        },
+      },
+      {
+        jkPair: '0x68BfaE97d4970ba6f542c2a93Ed2e6eDBBf96c3b', // VRSW-WETH
+        ikPair: '0x5C4281D26bE6853A132794429CDfAbaC6F652Ad6', // DECATS-VRSW
+        validBlockNumbers: [],
+        invalidBlockNumbers: {
+          'VSWAP: NOT_ALLOWED': [55854967],
+        },
+      },
+    ],
+    [Network.ARBITRUM]: [
+      {
+        jkPair: '0x8431aAaa1bB7BD11d4740F19a0306e00b7eDB817', // WETH-VRSW
+        ikPair: '0xD7d90067A07620EdEc49665B5703E539811aeb17', // VRSW-USDC.e
+        validBlockNumbers: [
+          196701768 - 1,
+          199497388 - 1,
+          199819683 - 1,
+          201211164 - 1,
+          201254592 - 1,
+        ], // -1 as we need to check state before events
+        invalidBlockNumbers: {
+          'VSWAP: LOCKED_VPOOL': [199819683, 199819683 + 1],
+        },
+      },
+      {
+        jkPair: '0xD7d90067A07620EdEc49665B5703E539811aeb17', // VRSW-USDC.e
+        ikPair: '0x05f95b911A4C3CD571d9A8b05e86f3FBbE10593A', // wstETH-WETH
+        validBlockNumbers: [],
+        invalidBlockNumbers: {
+          'VSWAP: INVALID_VPOOL': [201309231],
+        },
+      },
+      {
+        jkPair: '0x8431aAaa1bB7BD11d4740F19a0306e00b7eDB817', // WETH-VRSW
+        ikPair: '0x05f95b911A4C3CD571d9A8b05e86f3FBbE10593A', // wstETH-WETH
+        validBlockNumbers: [],
+        invalidBlockNumbers: {
+          'VSWAP: NOT_ALLOWED': [201309231],
+        },
+      },
+    ],
+  };
+
+  Object.entries(poolsToTest).forEach(([networkId, pairsOfPools]) => {
+    describe(`Network id: ${networkId}`, () => {
+      const network = parseInt(networkId) as Network;
+      const params = VirtuSwapConfig[dexKey][network];
+      const dexHelper = new DummyDexHelper(network);
+      dexHelper.web3Provider.eth.handleRevert = true; // we need revert strings to test errors
+      const logger = dexHelper.getLogger(dexKey);
+      const poolManager = new VirtuSwapVirtualPoolManager(
+        dexHelper,
+        logger,
+        params.vPoolManagerAddress,
+      );
+      pairsOfPools.forEach(pairOfPools => {
+        describe(`Virtual pool between jkPair=${pairOfPools.jkPair}, ikPair=${pairOfPools.ikPair}`, () => {
+          const jkPool = new VirtuSwapEventPool(
+            dexKey,
+            network,
+            dexHelper,
+            logger,
+            params.isTimestampBased,
+            pairOfPools.jkPair,
+          );
+          const ikPool = new VirtuSwapEventPool(
+            dexKey,
+            network,
+            dexHelper,
+            logger,
+            params.isTimestampBased,
+            pairOfPools.ikPair,
+          );
+          pairOfPools.validBlockNumbers.forEach((blockNumber: number) => {
+            it(`State after ${blockNumber}`, async function () {
+              const onChainData = await poolManager.getVirtualPoolFromChain(
+                pairOfPools.jkPair,
+                pairOfPools.ikPair,
+                blockNumber,
+              );
+
+              const jkPoolData = await jkPool.generateState(blockNumber);
+              const ikPoolData = await ikPool.generateState(blockNumber);
+
+              const block = await dexHelper.provider.getBlock(blockNumber);
+              const blockTimestamp = block.timestamp;
+
+              const computedData = getVirtualPool(
+                jkPoolData,
+                ikPoolData,
+                params.isTimestampBased ? blockTimestamp : blockNumber,
+              );
+
+              const plainComputedData = {
+                ...computedData,
+                jkPair: normalizeAddress(pairOfPools.jkPair),
+                ikPair: normalizeAddress(pairOfPools.ikPair),
+              } as PlainVirtualPoolState;
+
+              expect(plainComputedData).toEqual(onChainData);
+            });
+          });
+          Object.entries(pairOfPools.invalidBlockNumbers).forEach(
+            ([reason, blockNumbers]) => {
+              describe(`Error reason: ${reason}`, () => {
+                blockNumbers.forEach((blockNumber: number) => {
+                  it(`State after ${blockNumber}`, async function () {
+                    const onChainError = await poolManager
+                      .getVirtualPoolFromChain(
+                        pairOfPools.jkPair,
+                        pairOfPools.ikPair,
+                        blockNumber,
+                      )
+                      .catch((e: Error) => e);
+
+                    expect(onChainError).toBeInstanceOf(Error);
+                    expect((onChainError as Error).message).toEqual(
+                      expect.stringContaining(reason),
+                    );
+
+                    const jkPoolData = await jkPool.generateState(blockNumber);
+                    const ikPoolData = await ikPool.generateState(blockNumber);
+
+                    const block = await dexHelper.provider.getBlock(
+                      blockNumber,
+                    );
+                    const blockTimestamp = block.timestamp;
+
+                    let wasErrorThrown = false;
+
+                    try {
+                      getVirtualPool(
+                        jkPoolData,
+                        ikPoolData,
+                        params.isTimestampBased ? blockTimestamp : blockNumber,
+                      );
+                    } catch (calculationError: any) {
+                      wasErrorThrown = true;
+                      expect(calculationError).toBeInstanceOf(Error);
+                      expect((calculationError as Error).message).toEqual(
+                        expect.stringContaining(reason),
+                      );
+                    }
+                    expect(wasErrorThrown).toBeTruthy();
+                  });
+                });
+              });
+            },
+          );
+        });
+      });
+    });
+  });
+});
+
+describe('VirtuSwap Virtual Pools by Tokens', function () {
+  const poolsToTest: Partial<Record<Network, PairOfTokens[]>> = {
+    [Network.POLYGON]: [
+      {
+        token0: '0x57999936fC9A9EC0751a8D146CcE11901Be8beD0', // VRSW
+        token1: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619', // WETH
+        validBlockNumbers: [55854967],
+      },
+      {
+        token0: '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174', // USDC.e
+        token1: '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619', // WETH
+        validBlockNumbers: [55861452],
+      },
+    ],
+    [Network.ARBITRUM]: [
+      {
+        token0: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1', // WETH
+        token1: '0xd1E094CabC5aCB9D3b0599C3F76f2D01fF8d3563', // VRSW
+        validBlockNumbers: [201309231],
+      },
+    ],
+  };
+
+  Object.entries(poolsToTest).forEach(([networkId, pairsOfPools]) => {
+    describe(`Network id: ${networkId}`, () => {
+      const network = parseInt(networkId) as Network;
+      const params = VirtuSwapConfig[dexKey][network];
+      const dexHelper = new DummyDexHelper(network);
+      dexHelper.web3Provider.eth.handleRevert = true; // we need revert strings to test errors
+      const logger = dexHelper.getLogger(dexKey);
+      const poolManager = new VirtuSwapVirtualPoolManager(
+        dexHelper,
+        logger,
+        params.vPoolManagerAddress,
+      );
+      pairsOfPools.forEach(pairOfTokens => {
+        describe(`Virtual pool with token0=${pairOfTokens.token0}, token1=${pairOfTokens.token1}`, () => {
+          pairOfTokens.validBlockNumbers.forEach((blockNumber: number) => {
+            it(`State after ${blockNumber}`, async function () {
+              const onChainData = await poolManager.getVirtualPoolsFromChain(
+                pairOfTokens.token0,
+                pairOfTokens.token1,
+                blockNumber,
+              );
+
+              const poolsAddressesSet = new Set(
+                onChainData.flatMap(pool => [pool.jkPair, pool.ikPair]),
+              );
+              const poolsAddresses = Array.from(poolsAddressesSet);
+              const pools = poolsAddresses.map(
+                poolAddress =>
+                  new VirtuSwapEventPool(
+                    dexKey,
+                    network,
+                    dexHelper,
+                    logger,
+                    params.isTimestampBased,
+                    poolAddress,
+                  ),
+              );
+
+              const poolsData = await Promise.all(
+                pools.map(pool => pool.generateState(blockNumber)),
+              );
+
+              const block = await dexHelper.provider.getBlock(blockNumber);
+              const blockTimestamp = block.timestamp;
+
+              const computedData = getVirtualPools(
+                poolsData,
+                params.isTimestampBased ? blockTimestamp : blockNumber,
+                normalizeAddress(pairOfTokens.token0),
+                normalizeAddress(pairOfTokens.token1),
+              );
+
+              const plainComputedData = computedData.map(
+                data =>
+                  ({
+                    ...data,
+                    jkPair: normalizeAddress(
+                      computeAddress(
+                        params.factoryAddress,
+                        data.jkPair.token0,
+                        data.jkPair.token1,
+                        params.initCode,
+                      ),
+                    ),
+                    ikPair: normalizeAddress(
+                      computeAddress(
+                        params.factoryAddress,
+                        data.ikPair.token0,
+                        data.ikPair.token1,
+                        params.initCode,
+                      ),
+                    ),
+                  } as PlainVirtualPoolState),
+              );
+
+              expect(plainComputedData).toEqual(onChainData);
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/dex/virtuswap/virtuswap-virtual-pools-state.test.ts
+++ b/src/dex/virtuswap/virtuswap-virtual-pools-state.test.ts
@@ -299,21 +299,17 @@ describe('VirtuSwap Virtual Pools by Tokens', function () {
                 data =>
                   ({
                     ...data,
-                    jkPair: normalizeAddress(
-                      computeAddress(
-                        params.factoryAddress,
-                        data.jkPair.token0,
-                        data.jkPair.token1,
-                        params.initCode,
-                      ),
+                    jkPair: computeAddress(
+                      params.factoryAddress,
+                      data.jkPair.token0,
+                      data.jkPair.token1,
+                      params.initCode,
                     ),
-                    ikPair: normalizeAddress(
-                      computeAddress(
-                        params.factoryAddress,
-                        data.ikPair.token0,
-                        data.ikPair.token1,
-                        params.initCode,
-                      ),
+                    ikPair: computeAddress(
+                      params.factoryAddress,
+                      data.ikPair.token0,
+                      data.ikPair.token1,
+                      params.initCode,
                     ),
                   } as PlainVirtualPoolState),
               );

--- a/src/dex/virtuswap/virtuswap.ts
+++ b/src/dex/virtuswap/virtuswap.ts
@@ -1,4 +1,4 @@
-import { AsyncOrSync, assert } from 'ts-essentials';
+import { assert } from 'ts-essentials';
 import { Interface } from '@ethersproject/abi';
 import {
   Token,
@@ -358,7 +358,6 @@ export class VirtuSwap extends SimpleExchange implements IDex<VirtuSwapData> {
 
   // Encode params required by the exchange adapter
   // Used for multiSwap, buy & megaSwap
-  // Hint: abiCoder.encodeParameter() could be useful
   getAdapterParam(
     srcToken: Address,
     destToken: Address,
@@ -493,15 +492,6 @@ export class VirtuSwap extends SimpleExchange implements IDex<VirtuSwapData> {
     );
   }
 
-  // This is called once before getTopPoolsForToken is
-  // called for multiple tokens. This can be helpful to
-  // update common state required for calculating
-  // getTopPoolsForToken. It is optional for a DEX
-  // to implement this
-  async updatePoolState(): Promise<void> {
-    // TODO: complete me!
-  }
-
   // Returns list of top pools based on liquidity. Max
   // limit number pools should be returned.
   async getTopPoolsForToken(
@@ -511,11 +501,5 @@ export class VirtuSwap extends SimpleExchange implements IDex<VirtuSwapData> {
     // virtual pools have smaller liquidity than real pools, so only real pools should be returned
     //TODO: complete me!
     return [];
-  }
-
-  // This is optional function in case if your implementation has acquired any resources
-  // you need to release for graceful shutdown. For example, it may be any interval timer
-  releaseResources(): AsyncOrSync<void> {
-    // TODO: complete me!
   }
 }

--- a/src/dex/virtuswap/virtuswap.ts
+++ b/src/dex/virtuswap/virtuswap.ts
@@ -1,0 +1,363 @@
+import { AsyncOrSync, assert } from 'ts-essentials';
+import { Interface } from '@ethersproject/abi';
+import {
+  Token,
+  Address,
+  ExchangePrices,
+  PoolPrices,
+  AdapterExchangeParam,
+  SimpleExchangeParam,
+  PoolLiquidity,
+  Logger,
+} from '../../types';
+import { SwapSide, Network } from '../../constants';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+import { getBigIntPow, getDexKeysWithNetwork } from '../../utils';
+import { IDex } from '../../dex/idex';
+import { IDexHelper } from '../../dex-helper';
+import { PoolState, VirtuSwapData } from './types';
+import { SimpleExchange } from '../simple-exchange';
+import { VirtuSwapConfig, Adapters } from './config';
+import { VirtuSwapFactory } from './virtuswap-factory';
+import { VirtuSwapEventPool } from './virtuswap-pool';
+import vRouterABI from '../../abi/virtuswap/vRouter.json';
+import { computeAddress } from './lib/PoolAddress';
+import {
+  getAmountIn,
+  getAmountOut,
+  getVirtualPool,
+  getVirtualPools,
+  sortBalances,
+} from './lib/vSwapLibrary';
+
+export class VirtuSwap extends SimpleExchange implements IDex<VirtuSwapData> {
+  static readonly vRouterInterface = new Interface(vRouterABI);
+  protected factory: VirtuSwapFactory;
+  protected pools: { [poolAddress: string]: VirtuSwapEventPool } = {};
+
+  readonly hasConstantPriceLargeAmounts = false;
+  // TODO: set true here if protocols works only with wrapped asset
+  readonly needWrapNative = false;
+
+  readonly isFeeOnTransferSupported = false;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(VirtuSwapConfig);
+
+  logger: Logger;
+
+  constructor(
+    readonly network: Network,
+    readonly dexKey: string,
+    readonly dexHelper: IDexHelper,
+    protected adapters = Adapters[network] || {},
+    readonly vRouterIface: Interface = VirtuSwap.vRouterInterface,
+    readonly vPairFactoryIface: Interface = VirtuSwapFactory.vPairFactoryInterface,
+    readonly vPairIface: Interface = VirtuSwapEventPool.vPairInterface,
+    protected config = VirtuSwapConfig[dexKey][network],
+  ) {
+    super(dexHelper, dexKey);
+    this.logger = dexHelper.getLogger(dexKey);
+
+    this.factory = new VirtuSwapFactory(
+      dexKey,
+      network,
+      dexHelper,
+      this.logger,
+      this.addPool.bind(this),
+      config.factoryAddress,
+      vPairFactoryIface,
+    );
+  }
+
+  async initialize(blockNumber: number) {
+    if (!this.factory.isInitialized) {
+      await this.factory.initialize(blockNumber);
+    }
+  }
+
+  // Initialize pricing is called once in the start of
+  // pricing service. It is intended to setup the integration
+  // for pricing requests. It is optional for a DEX to
+  // implement this function
+  async initializePricing(blockNumber: number) {
+    await this.initialize(blockNumber);
+
+    assert(
+      !!this.factory.getState(blockNumber),
+      'initializePricing: factory state is not initialized',
+    );
+  }
+
+  getPoolState(pool: Address, blockNumber: number) {
+    return this.pools[pool]?.getState(blockNumber - 1) ?? null;
+  }
+
+  async addPool(pool: Address, blockNumber: number) {
+    if (!this.pools[pool]) {
+      this.pools[pool] = new VirtuSwapEventPool(
+        this.dexKey,
+        this.network,
+        this.dexHelper,
+        this.logger,
+        this.config.isTimestampBased,
+        pool,
+        this.getPoolState.bind(this),
+        this.vPairIface,
+      );
+      await this.pools[pool].initialize(blockNumber);
+    }
+  }
+
+  // Returns the list of contract adapters (name and index)
+  // for a buy/sell. Return null if there are no adapters.
+  getAdapters(side: SwapSide): { name: string; index: number }[] | null {
+    return this.adapters[side] ? this.adapters[side] : null;
+  }
+
+  computePoolAddress({ token0, token1 }: { token0: Address; token1: Address }) {
+    return computeAddress(
+      this.config.factoryAddress,
+      token0,
+      token1,
+      this.config.initCode,
+    );
+  }
+
+  // Returns list of pool identifiers that can be used
+  // for a given swap. poolIdentifiers must be unique
+  // across DEXes. `${dexKey}_${poolAddress}` for real,
+  // `${dexKey}_${jkPair}_${ikPair}` for virtual pools.
+  async getPoolIdentifiers(
+    srcToken: Token,
+    destToken: Token,
+    side: SwapSide,
+    blockNumber: number,
+  ): Promise<string[]> {
+    const from = this.dexHelper.config.wrapETH(srcToken);
+    const to = this.dexHelper.config.wrapETH(destToken);
+    const [token0, token1] = [from, to].map(token =>
+      token.address.toLowerCase(),
+    );
+    if (token0 === token1) return [];
+
+    const poolAddress = this.computePoolAddress({ token0, token1 });
+
+    const block = await this.dexHelper.provider.getBlock(blockNumber);
+    const blockTimestamp = block.timestamp;
+
+    const allPoolsStates = Object.values(this.pools)
+      .map(pool => pool.getState(blockNumber))
+      .filter(state => !!state) as PoolState[];
+
+    try {
+      const virtualPools = getVirtualPools(
+        allPoolsStates,
+        this.config.isTimestampBased ? blockTimestamp : blockNumber,
+        token0,
+        token1,
+      ).map(
+        vPool =>
+          `${this.dexKey}_${this.computePoolAddress(
+            vPool.jkPair,
+          )}_${this.computePoolAddress(vPool.ikPair)}`,
+      );
+
+      return poolAddress
+        ? [`${this.dexKey}_${poolAddress}`, ...virtualPools]
+        : virtualPools;
+    } catch (e: any) {
+      this.logger.warn('getPoolIdentifiers: error on getVirtualPools', e);
+
+      return poolAddress ? [`${this.dexKey}_${poolAddress}`] : [];
+    }
+  }
+
+  // Returns pool prices for amounts.
+  // If limitPools is defined only pools in limitPools
+  // should be used. If limitPools is undefined then
+  // any pools can be used.
+  async getPricesVolume(
+    srcToken: Token,
+    destToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    limitPools?: string[],
+  ): Promise<null | ExchangePrices<VirtuSwapData>> {
+    const from = this.dexHelper.config.wrapETH(srcToken);
+    const to = this.dexHelper.config.wrapETH(destToken);
+    if (from.address.toLowerCase() === to.address.toLowerCase()) return null;
+
+    const isSell = side === SwapSide.SELL;
+    const unitAmount = getBigIntPow(isSell ? from.decimals : to.decimals);
+    const getAmount = isSell ? getAmountOut : getAmountIn;
+
+    const identifiers =
+      limitPools?.filter(id => id.startsWith(this.dexKey)) ??
+      (await this.getPoolIdentifiers(srcToken, destToken, side, blockNumber));
+
+    return identifiers
+      .map(id => {
+        const splittedId = id.split('_');
+        switch (splittedId.length) {
+          // poolAddress from `${dexKey}_${poolAddress}` for real pools
+          case 2: {
+            const poolAddress = splittedId[1];
+            const poolState = this.getPoolState(poolAddress, blockNumber);
+            if (!poolState) return null;
+
+            const fee = poolState.fee;
+            const [balance0, balance1] = sortBalances(
+              from.address.toLowerCase(),
+              poolState.token0.toLowerCase(),
+              poolState.pairBalance0,
+              poolState.pairBalance1,
+            );
+
+            return {
+              prices: amounts.map(amount =>
+                getAmount(amount, balance0, balance1, fee),
+              ),
+              unit: getAmount(unitAmount, balance0, balance1, fee),
+              data: {
+                router: this.config.router,
+                isVirtual: false,
+                path: [from.address, to.address],
+              },
+              poolIdentifier: id,
+              poolAddresses: [poolAddress],
+              exchange: this.dexKey,
+              gasCost: this.config.realPoolGasCost,
+            };
+          }
+          // jkPair, ikPair from `${dexKey}_${jkPair}_${ikPair}` for virtual pools
+          case 3: {
+            const jkPair = splittedId[1];
+            const ikPair = splittedId[2];
+            const jkState = this.getPoolState(jkPair, blockNumber);
+            if (!jkState) return null;
+
+            const ikState = this.getPoolState(ikPair, blockNumber);
+            if (!ikState) return null;
+
+            try {
+              const vPool = getVirtualPool(jkState, ikState, blockNumber);
+              const { balance0, balance1, fee } = vPool;
+
+              return {
+                prices: amounts.map(amount =>
+                  getAmount(amount, balance0, balance1, fee),
+                ),
+                unit: getAmount(unitAmount, balance0, balance1, fee),
+                data: {
+                  router: this.config.router,
+                  isVirtual: true,
+                  tokenOut: to.address,
+                  commonToken: vPool.commonToken,
+                  ikPair: ikPair,
+                },
+                poolIdentifier: id,
+                poolAddresses: [jkPair, ikPair],
+                exchange: this.dexKey,
+                gasCost: this.config.virtualPoolGasCost,
+              };
+            } catch (e) {
+              this.logger.debug(
+                `getPricesVolume: error on getVirtualPool, jkPair=${jkPair}, ikPair=${ikPair}`,
+                e,
+              );
+              return null;
+            }
+          }
+          default:
+            return null;
+        }
+      })
+      .filter(prices => !!prices) as PoolPrices<VirtuSwapData>[];
+  }
+
+  // Returns estimated gas cost of calldata for this DEX in multiSwap
+  getCalldataGasCost(poolPrices: PoolPrices<VirtuSwapData>): number | number[] {
+    // TODO: update if there is any payload in getAdapterParam
+    return CALLDATA_GAS_COST.DEX_NO_PAYLOAD;
+  }
+
+  // Encode params required by the exchange adapter
+  // Used for multiSwap, buy & megaSwap
+  // Hint: abiCoder.encodeParameter() could be useful
+  getAdapterParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: VirtuSwapData,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    // TODO: complete me!
+    const { router } = data;
+
+    // Encode here the payload for adapter
+    const payload = '';
+
+    return {
+      targetExchange: router,
+      payload,
+      networkFee: '0',
+    };
+  }
+
+  // Encode call data used by simpleSwap like routers
+  // Used for simpleSwap & simpleBuy
+  // Hint: this.buildSimpleParamWithoutWETHConversion
+  // could be useful
+  async getSimpleParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: VirtuSwapData,
+    side: SwapSide,
+  ): Promise<SimpleExchangeParam> {
+    // TODO: complete me!
+    const { router } = data;
+
+    // Encode here the transaction arguments
+    const swapData = '';
+
+    return this.buildSimpleParamWithoutWETHConversion(
+      srcToken,
+      srcAmount,
+      destToken,
+      destAmount,
+      swapData,
+      router,
+    );
+  }
+
+  // This is called once before getTopPoolsForToken is
+  // called for multiple tokens. This can be helpful to
+  // update common state required for calculating
+  // getTopPoolsForToken. It is optional for a DEX
+  // to implement this
+  async updatePoolState(): Promise<void> {
+    // TODO: complete me!
+  }
+
+  // Returns list of top pools based on liquidity. Max
+  // limit number pools should be returned.
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    limit: number,
+  ): Promise<PoolLiquidity[]> {
+    // virtual pools have smaller liquidity than real pools, so only real pools should be returned
+    //TODO: complete me!
+    return [];
+  }
+
+  // This is optional function in case if your implementation has acquired any resources
+  // you need to release for graceful shutdown. For example, it may be any interval timer
+  releaseResources(): AsyncOrSync<void> {
+    // TODO: complete me!
+  }
+}

--- a/src/dex/virtuswap/virtuswap.ts
+++ b/src/dex/virtuswap/virtuswap.ts
@@ -428,11 +428,6 @@ export class VirtuSwap extends SimpleExchange implements IDex<VirtuSwapData> {
 
     const functionSelector = this.vRouterIface.getSighash(functionName);
 
-    this.logger.debug('getAdapterParam:', {
-      functionName,
-      functionSelector,
-    });
-
     const payload = data.isVirtual
       ? this.abiCoder.encodeParameter(
           {

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -351,6 +351,10 @@ export const Tokens: {
       address: '0xe07f9d810a48ab5c3c914ba3ca53af14e4491e8a',
       decimals: 18,
     },
+    VRSW: {
+      address: '0x99A01A4d6a4D621094983050D9A2F10B2912e53D',
+      decimals: 18,
+    },
   },
   [Network.ROPSTEN]: {
     DAI: {
@@ -503,6 +507,10 @@ export const Tokens: {
     },
     MATICX: {
       address: '0xfa68fb4628dff1028cfec22b4162fccd0d45efb6',
+      decimals: 18,
+    },
+    VRSW: {
+      address: '0x57999936fC9A9EC0751a8D146CcE11901Be8beD0',
       decimals: 18,
     },
   },
@@ -953,6 +961,10 @@ export const Tokens: {
       address: '0xabD587f2607542723b17f14d00d99b987C29b074',
       decimals: 18,
     },
+    VRSW: {
+      address: '0xd1E094CabC5aCB9D3b0599C3F76f2D01fF8d3563',
+      decimals: 18,
+    },
   },
   [Network.OPTIMISM]: {
     DAI: {
@@ -1152,6 +1164,7 @@ export const Holders: {
     SDEX: '0xB0470cF15B22a6A32c49a7C20E3821B944A76058',
     frxETH: '0x9df2322bdAEC46627100C999E6dDdD27837fec6e',
     USDe: '0x74e6c48e667d698a4cf90665b6960a5bae39e603',
+    VRSW: '0x6af9225d8F5bAA4d1442f49f705226f9abd66143',
   },
   [Network.ROPSTEN]: {
     ETH: '0x43262A12d8610AA70C15DbaeAC321d51613c9071',
@@ -1190,6 +1203,7 @@ export const Holders: {
     MAI: '0x9a8cf02f3e56c664ce75e395d0e4f3dc3dafe138',
     SDEX: '0xB0470cF15B22a6A32c49a7C20E3821B944A76058',
     crvUSD: '0x9D3a22A71C2bddFEF006f1c207C06B0A5f42f95F',
+    VRSW: '0xD0f7bcF2863E8a76BAe4294Fa3febF9826166AE9',
   },
   [Network.FANTOM]: {
     DAI: '0x370f4b2dcf75c94d8d4450b493661a9c6170d0b5',
@@ -1303,6 +1317,7 @@ export const Holders: {
     SDEX: '0xb0470cf15b22a6a32c49a7c20e3821b944a76058',
     wstETH: '0x916792f7734089470de27297903bed8a4630b26d',
     crvUSD: '0x171c53d55b1bcb725f660677d9e8bad7fd084282',
+    VRSW: '0x88362801574A9a61c93e8376C5e33e12d5D86597',
   },
   [Network.OPTIMISM]: {
     ETH: '0x9ef21bE1C270AA1c3c3d750F458442397fBFFCB6',


### PR DESCRIPTION
This PR adds support for a new DEX: [VirtuSwap](https://virtuswap.io/).

**VirtuSwap**
VirtuSwap mitigates the problem of high trading costs in pairs for which liquidity pools are small or inexistent. VirtuSwap solution relies on virtual liquidity pools, trades on which are executed by creating limited (in size and time) reserves of tokens that are not native to a pool. This novel pool architecture allows each pool to serve multiple trading pairs, increasing the returns to liquidity provision, and solving the problem of triangular trading costs.
A more detailed description is available in the whitepaper: https://virtuswap.io/docs/whitepaper.pdf

**Deployment Addresses**
VirtuSwap DEX contracts deployed on Polygon and Arbitrum, addresses can be found here: https://docs.virtuswap.io/virtuswap-documentation/technical-reference/deployment-addresses

**Contract Code and Documentation**
The contract code can be found in this repository: https://github.com/Virtuswap/v1-core
The documentation can be found on GitBook: https://docs.virtuswap.io/virtuswap-documentation

**Integration**
Since VirtuSwap is not a fork of another protocol, we had to develop our own adapter to support virtual pools: [VirtuSwapAdapter.sol](https://github.com/Virtuswap/v1-core/blob/paraswap/contracts/paraswap/VirtuSwapAdapter.sol). This contract implements both interfaces: `IAdapter` and `IBuyAdapter`, and contains `swapOnVirtuSwap` and `buyOnVirtuSwap` functions for easier integration.
