### PR TITLE
Docs improvements

### DIFF
--- a/dex-template/__DexName__-e2e.test.ts.template
+++ b/dex-template/__DexName__-e2e.test.ts.template
@@ -34,7 +34,7 @@ import { generateConfig } from '../../config';
   Tokens or Holders map, you can update the './tests/constants-e2e'
 
   Other than the standard cases that are already added by the template
-  it is highly recommended to add test cases which could be specific
+  it is highly recommended to add test cases that could be specific
   to testing __DexName__ (Eg. Tests based on poolType, special tokens,
   etc).
 

--- a/dex-template/__DexName__.ts.template
+++ b/dex-template/__DexName__.ts.template
@@ -148,7 +148,7 @@ export class __DexName__
     return [];
   }
 
-  // This is optional function in case if your implementation has acquired any resources
+  // This is an optional function in case if your implementation has acquired any resources
   // you need to release for graceful shutdown. For example, it may be any interval timer
   releaseResources(): AsyncOrSync<void> {
     // TODO: complete me!

--- a/src/dex-helper/iblock-manager.ts
+++ b/src/dex-helper/iblock-manager.ts
@@ -12,7 +12,7 @@ export interface EventSubscriber {
   //implementers must not present states older than the latest/requested block
   //number to any query.
   //If isTracking() returns true, it is assumed that all logs up to the latest
-  //block have been processed, hence it is fine to return the last calculated
+  //block has been processed, hence it is fine to return the last calculated
   //state.
   isTracking: () => boolean;
 
@@ -32,7 +32,7 @@ export interface EventSubscriber {
     blockNumberForMissingStateRegen?: number,
   ): AsyncOrSync<void>;
 
-  //Will be called on a chain reorganisation prior to updating with new logs.
+  //Will be called on a chain reorganization prior to updating with new logs.
   //All state corresponding to blocks after the given number must be discarded,
   //except for the most recent state, if the invalid flag isn't still set.
   rollback(blockNumber: number): void;

--- a/src/lib/stateful-rpc-poller/state-polling-manager.ts
+++ b/src/lib/stateful-rpc-poller/state-polling-manager.ts
@@ -35,7 +35,7 @@ export class StatePollingManager {
   // This pools will be updated if we see new block and the time has come
   private _poolsToBeUpdated: Set<string> = new Set();
 
-  // This pools wont be updated before we change _isStateToBeUpdated to true
+  // This pools won't be updated before we change _isStateToBeUpdated to true
   private _idlePools: Set<string> = new Set();
 
   private constructor(protected dexHelper: IDexHelper) {

--- a/src/lib/stateful-rpc-poller/stateful-rpc-poller.ts
+++ b/src/lib/stateful-rpc-poller/stateful-rpc-poller.ts
@@ -73,7 +73,7 @@ export abstract class StatefulRpcPoller<State, M>
   // Derived classes should not set these directly, and instead use setState()
   protected _stateWithUpdateInfo?: ObjWithUpdateInfo<State>;
 
-  // This values is used to determine if current pool will participate in update or not
+  // This values is used to determine if the current pool will participate in update or not
   // We don't want to keep track of state for pools without liquidity
   protected _liquidityInUSDWithUpdateInfo: ObjWithUpdateInfo<number> = {
     value: 0,
@@ -142,7 +142,7 @@ export abstract class StatefulRpcPoller<State, M>
     protected liquidityUpdatePeriodMs = DEFAULT_LIQUIDITY_UPDATE_PERIOD_MS,
   ) {
     // Don't make it too custom, like adding poolIdentifier. It will break log suppressor
-    // If we are really need to do that, update log Suppressor to handle that case
+    // If we really need to do that, update log Suppressor to handle that case
     // The idea is to have one entity name per Dex level, not pool level
     this.entityName = `StatefulPoller-${this.dexKey}-${this.dexHelper.config.data.network}`;
 


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.