### PR TITLE
feat/BACK 1558

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "3.8.28",
+  "version": "3.8.29-user-address-rfq.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "3.8.29-user-address-rfq.0",
+  "version": "3.8.29",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/dexalot/dexalot.ts
+++ b/src/dex/dexalot/dexalot.ts
@@ -598,7 +598,7 @@ export class Dexalot extends SimpleExchange implements IDex<DexalotData> {
         takerAsset: ethers.utils.getAddress(takerToken.address),
         makerAmount: isBuy ? optimalSwapExchange.destAmount : undefined,
         takerAmount: isSell ? optimalSwapExchange.srcAmount : undefined,
-        userAddress: options.txOrigin,
+        userAddress: options.userAddress,
         chainid: this.network,
         executor: options.executionContractAddress,
         partner: options.partner,
@@ -725,11 +725,11 @@ export class Dexalot extends SimpleExchange implements IDex<DexalotData> {
         const errorData = e.response.data as RFQResponseError;
         if (errorData.ReasonCode === 'FQ-009') {
           this.logger.warn(
-            `${this.dexKey}-${this.network}: Encountered rate limited user=${options.txOrigin}. Adding to local rate limit cache`,
+            `${this.dexKey}-${this.network}: Encountered rate limited user=${options.userAddress}. Adding to local rate limit cache`,
           );
-          await this.setRateLimited(options.txOrigin, errorData.RetryAfter);
+          await this.setRateLimited(options.userAddress, errorData.RetryAfter);
         } else {
-          await this.setBlacklist(options.txOrigin);
+          await this.setBlacklist(options.userAddress);
           this.logger.error(
             `${this.dexKey}-${this.network}: Failed to fetch RFQ for ${swapIdentifier}: ${errorData.Reason}`,
           );

--- a/src/dex/generic-rfq/generic-rfq.ts
+++ b/src/dex/generic-rfq/generic-rfq.ts
@@ -329,9 +329,19 @@ export class GenericRFQ extends ParaSwapLimitOrders {
         `${this.dexKey}-${this.network}: blacklisted TX Origin address '${options.txOrigin}' trying to build a transaction. Bailing...`,
       );
       throw new Error(
-        `${this.dexKey}-${
-          this.network
-        }: user=${options.txOrigin.toLowerCase()} is blacklisted`,
+        `${this.dexKey}-${this.network}: user=${options.txOrigin} is blacklisted`,
+      );
+    }
+
+    if (
+      options.userAddress !== options.txOrigin &&
+      (await this.isBlacklisted(options.userAddress))
+    ) {
+      this.logger.warn(
+        `${this.dexKey}-${this.network}: blacklisted user address '${options.userAddress}' trying to build a transaction. Bailing...`,
+      );
+      throw new Error(
+        `${this.dexKey}-${this.network}: user=${options.userAddress} is blacklisted`,
       );
     }
 

--- a/src/dex/generic-rfq/generic-rfq.ts
+++ b/src/dex/generic-rfq/generic-rfq.ts
@@ -324,6 +324,17 @@ export class GenericRFQ extends ParaSwapLimitOrders {
     side: SwapSide,
     options: PreprocessTransactionOptions,
   ): Promise<[OptimalSwapExchange<ParaSwapLimitOrdersData>, ExchangeTxInfo]> {
+    if (await this.isBlacklisted(options.txOrigin)) {
+      this.logger.warn(
+        `${this.dexKey}-${this.network}: blacklisted TX Origin address '${options.txOrigin}' trying to build a transaction. Bailing...`,
+      );
+      throw new Error(
+        `${this.dexKey}-${
+          this.network
+        }: user=${options.txOrigin.toLowerCase()} is blacklisted`,
+      );
+    }
+
     const isSell = side === SwapSide.SELL;
 
     const order = await this.rateFetcher.getFirmRate(
@@ -334,7 +345,7 @@ export class GenericRFQ extends ParaSwapLimitOrders {
         : overOrder(optimalSwapExchange.destAmount, 1),
       side,
       options.executionContractAddress,
-      options.txOrigin,
+      options.userAddress,
       options.partner,
       options.special,
     );

--- a/src/dex/hashflow/hashflow.ts
+++ b/src/dex/hashflow/hashflow.ts
@@ -597,7 +597,7 @@ export class Hashflow extends SimpleExchange implements IDex<HashflowData> {
           : { quoteTokenAmount: optimalSwapExchange.destAmount }),
         // receiver address
         wallet: options.recipient.toLowerCase(),
-        effectiveTrader: options.txOrigin.toLowerCase(),
+        effectiveTrader: options.userAddress.toLowerCase(),
         marketMakers: [mm],
       });
 
@@ -731,9 +731,9 @@ export class Hashflow extends SimpleExchange implements IDex<HashflowData> {
         e.message?.toLowerCase().includes('user is restricted')
       ) {
         this.logger.warn(
-          `${this.dexKey}-${this.network}: Encountered restricted user=${options.txOrigin}. Adding to local blacklist cache`,
+          `${this.dexKey}-${this.network}: Encountered restricted user=${options.userAddress}. Adding to local blacklist cache`,
         );
-        await this.setBlacklist(options.txOrigin);
+        await this.setBlacklist(options.userAddress);
       } else {
         if (e instanceof TooStrictSlippageCheckError) {
           this.logger.warn(

--- a/src/dex/swaap-v2/swaap-v2.ts
+++ b/src/dex/swaap-v2/swaap-v2.ts
@@ -524,7 +524,7 @@ export class SwaapV2 extends SimpleExchange implements IDex<SwaapV2Data> {
         normalizedDestToken,
         isSell ? optimalSwapExchange.srcAmount : optimalSwapExchange.destAmount,
         isSell ? SWAAP_ORDER_TYPE_SELL : SWAAP_ORDER_TYPE_BUY,
-        options.txOrigin,
+        options.userAddress,
         options.executionContractAddress,
         options.recipient,
         tolerance,
@@ -636,14 +636,14 @@ export class SwaapV2 extends SimpleExchange implements IDex<SwaapV2Data> {
       ];
     } catch (e) {
       if (isAxiosError(e) && e.response?.status === 403) {
-        await this.setBlacklist(options.txOrigin, SWAAP_403_TTL_S);
+        await this.setBlacklist(options.userAddress, SWAAP_403_TTL_S);
         this.logger.warn(
-          `${this.dexKey}-${this.network}: Encountered blacklisted user=${options.txOrigin}. Adding to local blacklist cache`,
+          `${this.dexKey}-${this.network}: Encountered blacklisted user=${options.userAddress}. Adding to local blacklist cache`,
         );
       } else if (isAxiosError(e) && e.response?.status === 429) {
-        await this.setBlacklist(options.txOrigin, SWAAP_429_TTL_S);
+        await this.setBlacklist(options.userAddress, SWAAP_429_TTL_S);
         this.logger.warn(
-          `${this.dexKey}-${this.network}: Encountered restricted user=${options.txOrigin}. Adding to local blacklist cache`,
+          `${this.dexKey}-${this.network}: Encountered restricted user=${options.userAddress}. Adding to local blacklist cache`,
         );
       } else {
         if (e instanceof TooStrictSlippageCheckError) {

--- a/src/implementations/local-paraswap-sdk.ts
+++ b/src/implementations/local-paraswap-sdk.ts
@@ -282,6 +282,7 @@ export class LocalParaswapSDK implements IParaSwapSDK {
                         {
                           slippageFactor,
                           txOrigin: userAddress,
+                          userAddress,
                           executionContractAddress,
                           isDirectMethod: DirectContractMethods.includes(
                             contractMethod as ContractMethod,

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,6 +318,7 @@ export type ExchangeTxInfo = {
 export type PreprocessTransactionOptions = {
   slippageFactor: BigNumber;
   txOrigin: Address;
+  userAddress: Address;
   executionContractAddress: Address;
   hmac?: string;
   mockRfqAndLO?: boolean;


### PR DESCRIPTION
feat: use userAddress instead of tx.origin for RFQ orders

Mostly because to be compatible with adapters/executors (as we insert msg.sender in orders for all RFQs)