### PR TITLE
Integrate Fluid DEX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@ tests/configs.json
 .idea/
 local-scripts
 tests/debug-price-route.json
+tests/constants-e2e.d.ts
+tests/constants-e2e.js
+tests/constants-e2e.js.map
+tests/smart-tokens.d.ts
+tests/smart-tokens.js
+tests/smart-tokens.js.map

--- a/src/abi/fluid-dex/dexFactory.abi.json
+++ b/src/abi/fluid-dex/dexFactory.abi.json
@@ -1,0 +1,506 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "errorId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "errorId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexFactoryError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexLiquidityOutput",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexPerfectLiquidityOutput",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenAmt",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexSingleTokenOutput",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexSwapResult",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "dex",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "dexId",
+        "type": "uint256"
+      }
+    ],
+    "name": "DexDeployed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "deployer",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "LogSetDeployer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "dexAuth",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "dex",
+        "type": "address"
+      }
+    ],
+    "name": "LogSetDexAuth",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "dexDeploymentLogic",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "LogSetDexDeploymentLogic",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "globalAuth",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bool",
+        "name": "allowed",
+        "type": "bool"
+      }
+    ],
+    "name": "LogSetGlobalAuth",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dexDeploymentLogic_",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "dexDeploymentData_",
+        "type": "bytes"
+      }
+    ],
+    "name": "deployDex",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "dexId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getDexAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "deployer_",
+        "type": "address"
+      }
+    ],
+    "name": "isDeployer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      }
+    ],
+    "name": "isDex",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "dexAuth_",
+        "type": "address"
+      }
+    ],
+    "name": "isDexAuth",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dexDeploymentLogic_",
+        "type": "address"
+      }
+    ],
+    "name": "isDexDeploymentLogic",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "globalAuth_",
+        "type": "address"
+      }
+    ],
+    "name": "isGlobalAuth",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "slot_",
+        "type": "bytes32"
+      }
+    ],
+    "name": "readFromStorage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "result_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "deployer_",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "allowed_",
+        "type": "bool"
+      }
+    ],
+    "name": "setDeployer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "dexAuth_",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "allowed_",
+        "type": "bool"
+      }
+    ],
+    "name": "setDexAuth",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "deploymentLogic_",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "allowed_",
+        "type": "bool"
+      }
+    ],
+    "name": "setDexDeploymentLogic",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "globalAuth_",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "allowed_",
+        "type": "bool"
+      }
+    ],
+    "name": "setGlobalAuth",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target_",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data_",
+        "type": "bytes"
+      }
+    ],
+    "name": "spell",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "response_",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalDexes",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/abi/fluid-dex/fluid-dex.abi.json
+++ b/src/abi/fluid-dex/fluid-dex.abi.json
@@ -1,0 +1,922 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "errorId",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexLiquidityOutput",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexPerfectLiquidityOutput",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lastStoredPrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "centerPrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "upperRange",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lowerRange",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "geometricMean",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "supplyToken0ExchangePrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowToken0ExchangePrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "supplyToken1ExchangePrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowToken1ExchangePrice",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.PricesAndExchangePrice",
+        "name": "pex_",
+        "type": "tuple"
+      }
+    ],
+    "name": "FluidDexPricesAndExchangeRates",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenAmt",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexSingleTokenOutput",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidDexSwapResult",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DEX_ID",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxSharesAmt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "borrow",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minToken0Borrow_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minToken1Borrow_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "borrowPerfect",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "constantsView",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "dexId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "liquidity",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "factory",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "shift",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "admin",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "colOperations",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "debtOperations",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "perfectOperationsAndOracle",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct IFluidDexT1.Implementations",
+            "name": "implementations",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "deployerContract",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "supplyToken0Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "borrowToken0Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "supplyToken1Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "borrowToken1Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "exchangePriceToken0Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "exchangePriceToken1Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "oracleMapping",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.ConstantViews",
+        "name": "constantsView_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "constantsView2",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "token0NumeratorPrecision",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token0DenominatorPrecision",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1NumeratorPrecision",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1DenominatorPrecision",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.ConstantViews2",
+        "name": "constantsView2_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minSharesAmt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxToken0Deposit_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxToken1Deposit_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "depositPerfect",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "geometricMean_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "upperRange_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lowerRange_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token0SupplyExchangePrice_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1SupplyExchangePrice_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getCollateralReserves",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "token0RealReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1RealReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token0ImaginaryReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1ImaginaryReserves",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.CollateralReserves",
+        "name": "c_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "geometricMean_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "upperRange_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "lowerRange_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token0BorrowExchangePrice_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1BorrowExchangePrice_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getDebtReserves",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "token0Debt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1Debt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token0RealReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1RealReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token0ImaginaryReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1ImaginaryReserves",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.DebtReserves",
+        "name": "d_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getPricesAndExchangePrices",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "secondsAgos_",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "oraclePrice",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "twap1by0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lowestPrice1by0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "highestPrice1by0",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "twap0by1",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lowestPrice0by1",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "highestPrice0by1",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.Oracle[]",
+        "name": "twaps_",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "currentPrice_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minSharesAmt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "payback",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxToken0Payback_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxToken1Payback_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "paybackPerfect",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxToken0_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxToken1_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "paybackPerfectInOneToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "paybackAmt_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "slot_",
+        "type": "bytes32"
+      }
+    ],
+    "name": "readFromStorage",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "result_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "swap0to1_",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOutMin_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to_",
+        "type": "address"
+      }
+    ],
+    "name": "swapIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "swap0to1_",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountInMax_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "to_",
+        "type": "address"
+      }
+    ],
+    "name": "swapOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxSharesAmt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minToken0Withdraw_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minToken1Withdraw_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "withdrawPerfect",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "token0Amt_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "token1Amt_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "shares_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minToken0_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "minToken1_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "estimate_",
+        "type": "bool"
+      }
+    ],
+    "name": "withdrawPerfectInOneToken",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "withdrawAmt_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/abi/fluid-dex/liquidityUserModule.abi.json
+++ b/src/abi/fluid-dex/liquidityUserModule.abi.json
@@ -1,0 +1,145 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "errorId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidLiquidityCalcsError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "errorId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidLiquidityError",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "errorId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "FluidSafeTransferError",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "BorrowRateMaxCap",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "supplyAmount",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "borrowAmount",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "withdrawTo",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "borrowTo",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalAmounts",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "exchangePricesAndConfig",
+        "type": "uint256"
+      }
+    ],
+    "name": "LogOperate",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "token_",
+        "type": "address"
+      },
+      {
+        "internalType": "int256",
+        "name": "supplyAmount_",
+        "type": "int256"
+      },
+      {
+        "internalType": "int256",
+        "name": "borrowAmount_",
+        "type": "int256"
+      },
+      {
+        "internalType": "address",
+        "name": "withdrawTo_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "borrowTo_",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callbackData_",
+        "type": "bytes"
+      }
+    ],
+    "name": "operate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "memVar3_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "memVar4_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/src/abi/fluid-dex/resolver.abi.json
+++ b/src/abi/fluid-dex/resolver.abi.json
@@ -1,0 +1,884 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "factory_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "FACTORY",
+    "outputs": [
+      {
+        "internalType": "contract IFluidDexFactory",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "swap0to1_",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountIn_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOutMin_",
+        "type": "uint256"
+      }
+    ],
+    "name": "estimateSwapIn",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "swap0to1_",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountOut_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountInMax_",
+        "type": "uint256"
+      }
+    ],
+    "name": "estimateSwapOut",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountIn_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllPoolAddresses",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "pools_",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllPools",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fee",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Structs.Pool[]",
+        "name": "pools_",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllPoolsReserves",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fee",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "token0RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token0ImaginaryReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1ImaginaryReserves",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IFluidDexT1.CollateralReserves",
+            "name": "collateralReserves",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "token0Debt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1Debt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token0RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token0ImaginaryReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1ImaginaryReserves",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IFluidDexT1.DebtReserves",
+            "name": "debtReserves",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct Structs.PoolWithReserves[]",
+        "name": "poolsReserves_",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      }
+    ],
+    "name": "getDexCollateralReserves",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "token0RealReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1RealReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token0ImaginaryReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1ImaginaryReserves",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.CollateralReserves",
+        "name": "reserves_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      }
+    ],
+    "name": "getDexDebtReserves",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "token0Debt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1Debt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token0RealReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1RealReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token0ImaginaryReserves",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1ImaginaryReserves",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.DebtReserves",
+        "name": "reserves_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "dex_",
+        "type": "address"
+      }
+    ],
+    "name": "getDexPricesAndExchangePrices",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "lastStoredPrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "centerPrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "upperRange",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "lowerRange",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "geometricMean",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "supplyToken0ExchangePrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowToken0ExchangePrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "supplyToken1ExchangePrice",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "borrowToken1ExchangePrice",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.PricesAndExchangePrice",
+        "name": "pex_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "poolId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPool",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fee",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct Structs.Pool",
+        "name": "pool_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "poolId_",
+        "type": "uint256"
+      }
+    ],
+    "name": "getPoolAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "pool_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool_",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolConstantsView",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "dexId",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "liquidity",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "factory",
+            "type": "address"
+          },
+          {
+            "components": [
+              {
+                "internalType": "address",
+                "name": "shift",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "admin",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "colOperations",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "debtOperations",
+                "type": "address"
+              },
+              {
+                "internalType": "address",
+                "name": "perfectOperationsAndOracle",
+                "type": "address"
+              }
+            ],
+            "internalType": "struct IFluidDexT1.Implementations",
+            "name": "implementations",
+            "type": "tuple"
+          },
+          {
+            "internalType": "address",
+            "name": "deployerContract",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "supplyToken0Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "borrowToken0Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "supplyToken1Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "borrowToken1Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "exchangePriceToken0Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "exchangePriceToken1Slot",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "oracleMapping",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.ConstantViews",
+        "name": "constantsView_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool_",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolConstantsView2",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "token0NumeratorPrecision",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token0DenominatorPrecision",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1NumeratorPrecision",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "token1DenominatorPrecision",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct IFluidDexT1.ConstantViews2",
+        "name": "constantsView2_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool_",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "fee_",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool_",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolReserves",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fee",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "token0RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token0ImaginaryReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1ImaginaryReserves",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IFluidDexT1.CollateralReserves",
+            "name": "collateralReserves",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "token0Debt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1Debt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token0RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token0ImaginaryReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1ImaginaryReserves",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IFluidDexT1.DebtReserves",
+            "name": "debtReserves",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct Structs.PoolWithReserves",
+        "name": "poolReserves_",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool_",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolTokens",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "token0_",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "token1_",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "pools_",
+        "type": "address[]"
+      }
+    ],
+    "name": "getPoolsReserves",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "pool",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token0",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "token1",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "fee",
+            "type": "uint256"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "token0RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token0ImaginaryReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1ImaginaryReserves",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IFluidDexT1.CollateralReserves",
+            "name": "collateralReserves",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "uint256",
+                "name": "token0Debt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1Debt",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token0RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1RealReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token0ImaginaryReserves",
+                "type": "uint256"
+              },
+              {
+                "internalType": "uint256",
+                "name": "token1ImaginaryReserves",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IFluidDexT1.DebtReserves",
+            "name": "debtReserves",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct Structs.PoolWithReserves[]",
+        "name": "poolsReserves_",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getTotalPools",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/dex/fluid-dex/config.ts
+++ b/src/dex/fluid-dex/config.ts
@@ -1,0 +1,24 @@
+import { DexParams } from './types';
+import { DexConfigMap, AdapterMappings } from '../../types';
+import { Network, SwapSide } from '../../constants';
+
+export const FluidDexConfig: DexConfigMap<DexParams> = {
+  FluidDex: {
+    [Network.MAINNET]: {
+      commonAddresses: {
+        liquidityProxy: '0x52aa899454998be5b000ad077a46bbe360f4e497',
+        resolver: '0x278166a9b88f166eb170d55801be1b1d1e576330',
+        dexFactory: '0x93dd426446b5370f094a1e31f19991aaa6ac0be0',
+      },
+      pools: [],
+    },
+  },
+};
+
+export const FLUID_DEX_GAS_COST = 160_000;
+
+export const Adapters: Record<number, AdapterMappings> = {
+  // TODO: add adapters for each chain
+  // This is an example to copy
+  [Network.MAINNET]: { [SwapSide.SELL]: [{ name: '', index: 0 }] },
+};

--- a/src/dex/fluid-dex/config.ts
+++ b/src/dex/fluid-dex/config.ts
@@ -18,7 +18,8 @@ export const FluidDexConfig: DexConfigMap<DexParams> = {
 export const FLUID_DEX_GAS_COST = 160_000;
 
 export const Adapters: Record<number, AdapterMappings> = {
-  // TODO: add adapters for each chain
-  // This is an example to copy
-  [Network.MAINNET]: { [SwapSide.SELL]: [{ name: '', index: 0 }] },
+  [Network.MAINNET]: {
+    // TODO: set index?
+    [SwapSide.SELL]: [{ name: 'Adapter03', index: 0 }],
+  },
 };

--- a/src/dex/fluid-dex/fluid-dex-e2e.test.ts
+++ b/src/dex/fluid-dex/fluid-dex-e2e.test.ts
@@ -1,0 +1,134 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import {
+  Tokens,
+  Holders,
+  NativeTokenSymbols,
+} from '../../../tests/constants-e2e';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+
+/*
+  README
+  ======
+
+  This test script should add e2e tests for FluidDex. The tests
+  should cover as many cases as possible. Most of the DEXes follow
+  the following test structure:
+    - DexName
+      - ForkName + Network
+        - ContractMethod
+          - ETH -> Token swap
+          - Token -> ETH swap
+          - Token -> Token swap
+
+  The template already enumerates the basic structure which involves
+  testing simpleSwap, multiSwap, megaSwap contract methods for
+  ETH <> TOKEN and TOKEN <> TOKEN swaps. You should replace tokenA and
+  tokenB with any two highly liquid tokens on FluidDex for the tests
+  to work. If the tokens that you would like to use are not defined in
+  Tokens or Holders map, you can update the './tests/constants-e2e'
+
+  Other than the standard cases that are already added by the template
+  it is highly recommended to add test cases which could be specific
+  to testing FluidDex (Eg. Tests based on poolType, special tokens,
+  etc).
+
+  You can run this individual test script by running:
+  `npx jest src/dex/<dex-name>/<dex-name>-e2e.test.ts`
+
+  e2e tests use the Tenderly fork api. Please add the following to your
+  .env file:
+  TENDERLY_TOKEN=Find this under Account>Settings>Authorization.
+  TENDERLY_ACCOUNT_ID=Your Tenderly account name.
+  TENDERLY_PROJECT=Name of a Tenderly project you have created in your
+  dashboard.
+
+  (This comment should be removed from the final implementation)
+*/
+
+function testForNetwork(
+  network: Network,
+  dexKey: string,
+  tokenASymbol: string,
+  tokenBSymbol: string,
+  tokenAAmount: string,
+  tokenBAmount: string,
+  nativeTokenAmount: string,
+) {
+  const provider = new StaticJsonRpcProvider(
+    generateConfig(network).privateHttpProvider,
+    network,
+  );
+  const tokens = Tokens[network];
+  const holders = Holders[network];
+  const nativeTokenSymbol = NativeTokenSymbols[network];
+
+  const sideToContractMethods = new Map([[SwapSide.SELL, ['swapIn']]]);
+
+  describe(`${network}`, () => {
+    sideToContractMethods.forEach((contractMethods, side) =>
+      describe(`${side}`, () => {
+        contractMethods.forEach((contractMethod: string) => {
+          describe(`${contractMethod}`, () => {
+            it(`${nativeTokenSymbol} -> ${tokenASymbol}`, async () => {
+              await testE2E(
+                tokens[nativeTokenSymbol],
+                tokens[tokenASymbol],
+                holders[nativeTokenSymbol],
+                tokenBAmount,
+                SwapSide.SELL,
+                dexKey,
+                contractMethod as ContractMethod,
+                network,
+                provider,
+              );
+            });
+            it(`${tokenASymbol} -> ${nativeTokenSymbol}`, async () => {
+              await testE2E(
+                tokens[tokenASymbol],
+                tokens[nativeTokenSymbol],
+                holders[tokenASymbol],
+                tokenAAmount,
+                SwapSide.SELL,
+                dexKey,
+                contractMethod as ContractMethod,
+                network,
+                provider,
+              );
+            });
+          });
+        });
+      }),
+    );
+  });
+}
+
+describe('FluidDex E2E', () => {
+  const dexKey = 'FluidDex';
+
+  describe('Mainnet', () => {
+    const network = Network.MAINNET;
+
+    const tokenASymbol: string = 'wstETH';
+    const tokenBSymbol: string = 'ETH';
+
+    const tokenAAmount: string = '1000000000000000000';
+    const tokenBAmount: string = '1000000000000000000';
+    const nativeTokenAmount = '1000000000000000000';
+
+    testForNetwork(
+      network,
+      dexKey,
+      tokenASymbol,
+      tokenBSymbol,
+      tokenAAmount,
+      tokenBAmount,
+      nativeTokenAmount,
+    );
+  });
+});

--- a/src/dex/fluid-dex/fluid-dex-events.test.ts
+++ b/src/dex/fluid-dex/fluid-dex-events.test.ts
@@ -9,19 +9,10 @@ import { Network } from '../../constants';
 import { Address } from '../../types';
 import { DummyDexHelper } from '../../dex-helper/index';
 import { testEventSubscriber } from '../../../tests/utils-events';
-import {
-  commonAddresses,
-  FluidDexPool,
-  FluidDexPoolState,
-  Pool,
-} from './types';
+import { CommonAddresses, FluidDexPoolState, Pool } from './types';
 import { FluidDexConfig } from './config';
 import { DeepReadonly } from 'ts-essentials';
-import {
-  EstimateGasSimulation,
-  TenderlySimulation,
-  TransactionSimulator,
-} from '../../../tests/tenderly-simulation';
+import { TenderlySimulation } from '../../../tests/tenderly-simulation';
 
 /*
   README
@@ -108,14 +99,14 @@ describe('FluidDex EventPool Mainnet', function () {
   const network = Network.MAINNET;
   const dexHelper = new DummyDexHelper(network);
   const logger = dexHelper.getLogger(dexKey);
-  const fluidDexCommonAddressStruct: commonAddresses =
+  const fluidDexCommonAddressStruct: CommonAddresses =
     FluidDexConfig[dexKey][network].commonAddresses;
   const liquidityProxy: Address = '0x52aa899454998be5b000ad077a46bbe360f4e497';
   const dexFactory: Address = '0x93dd426446b5370f094a1e31f19991aaa6ac0be0';
 
   const poolFetchEventsToTest: Record<Address, EventMappings> = {
     [dexFactory]: {
-      DexDeployed: [20825862],
+      DexDeployed: [20776998],
     },
   };
 

--- a/src/dex/fluid-dex/fluid-dex-events.test.ts
+++ b/src/dex/fluid-dex/fluid-dex-events.test.ts
@@ -1,0 +1,263 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { FluidDexEventPool } from './fluid-dex-pool';
+import { FluidDexCommonAddresses } from './fluid-dex-generate-pool';
+import { FluidDex } from './fluid-dex';
+import { Network } from '../../constants';
+import { Address } from '../../types';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { testEventSubscriber } from '../../../tests/utils-events';
+import {
+  commonAddresses,
+  FluidDexPool,
+  FluidDexPoolState,
+  Pool,
+} from './types';
+import { FluidDexConfig } from './config';
+import { DeepReadonly } from 'ts-essentials';
+import {
+  EstimateGasSimulation,
+  TenderlySimulation,
+  TransactionSimulator,
+} from '../../../tests/tenderly-simulation';
+
+/*
+  README
+  ======
+
+  This test script adds unit tests for FluidDex event based
+  system. This is done by fetching the state on-chain before the
+  event block, manually pushing the block logs to the event-subscriber,
+  comparing the local state with on-chain state.
+
+  Most of the logic for testing is abstracted by `testEventSubscriber`.
+  You need to do two things to make the tests work:
+
+  1. Fetch the block numbers where certain events were released. You
+  can modify the `./scripts/fetch-event-blocknumber.ts` to get the
+  block numbers for different events. Make sure to get sufficient
+  number of blockNumbers to cover all possible cases for the event
+  mutations.
+
+  2. Complete the implementation for fetchPoolState function. The
+  function should fetch the on-chain state of the event subscriber
+  using just the blocknumber.
+
+  The template tests only include the test for a single event
+  subscriber. There can be cases where multiple event subscribers
+  exist for a single DEX. In such cases additional tests should be
+  added.
+
+  You can run this individual test script by running:
+  `npx jest src/dex/<dex-name>/<dex-name>-events.test.ts`
+
+  (This comment should be removed from the final implementation)
+*/
+
+jest.setTimeout(50 * 1000);
+
+async function fetchPoolState(
+  fluidDexPool: FluidDexEventPool,
+  blockNumber: number,
+): Promise<FluidDexPoolState> {
+  return await fluidDexPool.generateState(blockNumber);
+}
+
+async function fetchTotalPools(
+  fluidCommonAddresses: FluidDexCommonAddresses,
+  blockNumber: number,
+): Promise<DeepReadonly<Pool[]>> {
+  return await fluidCommonAddresses.generateState(blockNumber);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function stringifyCircular(obj: any, space?: number): string {
+  const seen = new WeakSet();
+  return JSON.stringify(
+    obj,
+    (key, value) => {
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) {
+          return '[Circular]';
+        }
+        seen.add(value);
+      }
+      return value;
+    },
+    space,
+  );
+}
+
+function replacer(key: string, value: any) {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  return value;
+}
+
+// eventName -> blockNumbers
+type EventMappings = Record<string, number[]>;
+
+describe('FluidDex EventPool Mainnet', function () {
+  const dexKey = 'FluidDex';
+  const network = Network.MAINNET;
+  const dexHelper = new DummyDexHelper(network);
+  const logger = dexHelper.getLogger(dexKey);
+  const fluidDexCommonAddressStruct: commonAddresses =
+    FluidDexConfig[dexKey][network].commonAddresses;
+  const liquidityProxy: Address = '0x52aa899454998be5b000ad077a46bbe360f4e497';
+  const dexFactory: Address = '0x93dd426446b5370f094a1e31f19991aaa6ac0be0';
+
+  const poolFetchEventsToTest: Record<Address, EventMappings> = {
+    [dexFactory]: {
+      DexDeployed: [20825862],
+    },
+  };
+
+  // poolAddress -> EventMappings
+  const poolUpdateEventsToTest: Record<Address, EventMappings> = {
+    [dexFactory]: {
+      LogOperate: [20825862],
+    },
+  };
+
+  let fluidDexEventPool: FluidDexEventPool;
+  let fluidDexCommonAddress: FluidDexCommonAddresses;
+
+  Object.entries(poolUpdateEventsToTest).forEach(
+    ([poolAddress, events]: [string, EventMappings]) => {
+      describe(`Events for ${poolAddress}`, () => {
+        Object.entries(events).forEach(
+          ([eventName, blockNumbers]: [string, number[]]) => {
+            describe(`${eventName}`, () => {
+              blockNumbers.forEach((blockNumber: number) => {
+                it(`State after ${blockNumber}`, async function () {
+                  const fluidDex = new FluidDex(network, dexKey, dexHelper);
+
+                  await fluidDex.initializePricing(blockNumber);
+
+                  const ts: TenderlySimulation = new TenderlySimulation(
+                    network,
+                  );
+
+                  await ts.setup();
+
+                  const forkId = ts.forkId;
+                  dexHelper.replaceProviderWithRPC(
+                    `https://rpc.tenderly.co/fork/${forkId}`,
+                  );
+
+                  console.log(forkId);
+
+                  fluidDexEventPool =
+                    fluidDex.eventPools[
+                      'FluidDex_0x6d83f60eeac0e50a1250760151e81db2a278e03a'
+                    ];
+
+                  console.log(fluidDexEventPool.dexHelper.provider);
+
+                  console.log(
+                    'eth balance before : ' +
+                      (await dexHelper.provider.getBalance(
+                        '0x3c22ec75ea5d745c78fc84762f7f1e6d82a2c5bf',
+                      )),
+                  );
+
+                  const allowanceTxn = await ts.simulate({
+                    from: '0x3c22ec75ea5d745c78fc84762f7f1e6d82a2c5bf',
+                    to: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0', // undefined in case of contract deployment
+                    value: '0',
+                    data: '0x095ea7b30000000000000000000000006a000f20005980200259b80c51020030400010680000000000000000000000000000000000000000000000056bc75e2d63100000',
+                  });
+
+                  console.log(
+                    'allowance txn (isSuccess?) : ' + allowanceTxn.success,
+                  );
+
+                  const swapTxn = await ts.simulate({
+                    from: '0x3c22ec75ea5d745c78fc84762f7f1e6d82a2c5bf',
+                    to: '0x6a000f20005980200259b80c5102003040001068', // undefined in case of contract deployment
+                    value: '0',
+                    data: '0xe3ead59e000000000000000000000000a600910b670804230e00a100000d28000ae005c00000000000000000000000007f39c581f595b53c5cb19bd0b3f8da6c935e2ca0000000000000000000000000eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee0000000000000000000000000000000000000000000000000de0b6b3a7640000000000000000000000000000000000000000000000000000103ab964e9ceb0100000000000000000000000000000000000000000000000001064b0ec65b454c0ae160924eed54e7abfa6d4ced59c2447000000000000000000000000013f7447000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000160000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000180000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000001807f39c581f595b53c5cb19bd0b3f8da6c935e2ca00000006000000044ff00000000000000000000000000000000000000000000000000000000000000095ea7b30000000000000000000000006d83f60eeac0e50a1250760151e81db2a278e03affffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff6d83f60eeac0e50a1250760151e81db2a278e03a000000a00024000000000007000000000000000000000000000000000000000000000000000000002668dfaa00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000006a000f20005980200259b80c5102003040001068',
+                  });
+
+                  console.log('swap txn (isSuccess?) : ' + swapTxn.success);
+
+                  console.log(
+                    'eth balance after : ' +
+                      (await dexHelper.provider.getBalance(
+                        '0x3c22ec75ea5d745c78fc84762f7f1e6d82a2c5bf',
+                      )),
+                  );
+
+                  const txnBlockNumber = swapTxn.transaction.block_number;
+
+                  await delay(30000);
+                  console.log(
+                    'state 1 block after : ' +
+                      JSON.stringify(
+                        await fluidDexEventPool.generateState(
+                          txnBlockNumber - 2,
+                        ),
+                        replacer,
+                        2,
+                      ),
+                  );
+                  console.log(
+                    'state 1 block after : ' +
+                      JSON.stringify(
+                        await fluidDexEventPool.generateState(
+                          await dexHelper.provider.getBlockNumber(),
+                        ),
+                        replacer,
+                        2,
+                      ),
+                  );
+                });
+              });
+            });
+          },
+        );
+      });
+    },
+  );
+
+  Object.entries(poolFetchEventsToTest).forEach(
+    ([poolAddress, events]: [string, EventMappings]) => {
+      describe(`Events for ${poolAddress}`, () => {
+        Object.entries(events).forEach(
+          ([eventName, blockNumbers]: [string, number[]]) => {
+            describe(`${eventName}`, () => {
+              blockNumbers.forEach((blockNumber: number) => {
+                it(`State after ${blockNumber}`, async function () {
+                  fluidDexCommonAddress = new FluidDexCommonAddresses(
+                    'FluidDex',
+                    fluidDexCommonAddressStruct,
+                    network,
+                    dexHelper,
+                    logger,
+                  );
+
+                  await testEventSubscriber(
+                    fluidDexCommonAddress,
+                    fluidDexCommonAddress.addressesSubscribed,
+                    (_blockNumber: number) =>
+                      fetchTotalPools(fluidDexCommonAddress, _blockNumber),
+                    blockNumber,
+                    `${dexKey}_${poolAddress}`,
+                    dexHelper.provider,
+                  );
+                });
+              });
+            });
+          },
+        );
+      });
+    },
+  );
+});

--- a/src/dex/fluid-dex/fluid-dex-events.test.ts
+++ b/src/dex/fluid-dex/fluid-dex-events.test.ts
@@ -106,7 +106,7 @@ describe('FluidDex EventPool Mainnet', function () {
 
   const poolFetchEventsToTest: Record<Address, EventMappings> = {
     [dexFactory]: {
-      DexDeployed: [20776998],
+      DexDeployed: [20825862],
     },
   };
 

--- a/src/dex/fluid-dex/fluid-dex-generate-pool.ts
+++ b/src/dex/fluid-dex/fluid-dex-generate-pool.ts
@@ -1,0 +1,198 @@
+import { Interface } from '@ethersproject/abi';
+import { DeepReadonly } from 'ts-essentials';
+import { Log, Logger } from '../../types';
+import { catchParseLogError } from '../../utils';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import ResolverABI from '../../abi/fluid-dex/resolver.abi.json';
+import DexFactoryABI from '../../abi/fluid-dex/liquidityUserModule.abi.json';
+import {
+  commonAddresses,
+  FluidDexPool,
+  FluidDexPoolState,
+  PoolWithReserves,
+  Pool,
+} from './types';
+import { ethers } from 'ethers';
+import { eachOfSeries } from 'async';
+import { MultiResult, MultiCallParams } from '../../lib/multi-wrapper';
+import { BytesLike } from 'ethers/lib/utils';
+import { Address } from '../../types';
+import { generalDecoder, extractSuccessAndValue } from '../../lib/decoders';
+
+export class FluidDexCommonAddresses extends StatefulEventSubscriber<Pool[]> {
+  handlers: {
+    [event: string]: (
+      event: any,
+      state: DeepReadonly<Pool[]>,
+      log: Readonly<Log>,
+    ) => Promise<DeepReadonly<Pool[]> | null>;
+  } = {};
+
+  logDecoder: (log: Log) => any;
+
+  addressesSubscribed: Address[];
+  protected dexFactoryIface = new Interface(DexFactoryABI);
+
+  constructor(
+    readonly parentName: string,
+    // readonly pool: FluidDexPool,
+    readonly commonAddresses: commonAddresses,
+    protected network: number,
+    protected dexHelper: IDexHelper,
+    logger: Logger,
+  ) {
+    super(parentName, 'getAllPools', dexHelper, logger);
+
+    this.logDecoder = (log: Log) => this.dexFactoryIface.parseLog(log);
+    this.addressesSubscribed = [commonAddresses.dexFactory];
+
+    // Add handlers
+    this.handlers['DexDeployed'] = this.handleDexDeployed.bind(this);
+  }
+
+  /**
+   * Handle a trade rate change on the pool.
+   */
+  async handleDexDeployed(
+    event: any,
+    state: DeepReadonly<Pool[]>,
+    log: Readonly<Log>,
+  ): Promise<DeepReadonly<Pool[]> | null> {
+    const blockNumber_ = await this.dexHelper.web3Provider.eth.getBlockNumber();
+    const resolverAbi = new Interface(ResolverABI);
+    const callData: MultiCallParams<Pool>[] = [
+      {
+        target: this.commonAddresses.resolver,
+        callData: resolverAbi.encodeFunctionData('getPool', [event.args.dexId]),
+        decodeFunction: await this.decodePool,
+      },
+    ];
+
+    const results: Pool[] = await this.dexHelper.multiWrapper.aggregate<Pool>(
+      callData,
+      blockNumber_,
+      this.dexHelper.multiWrapper.defaultBatchSize,
+    );
+
+    const generatedPool = {
+      address: results[0].address,
+      token0: results[0].token0,
+      token1: results[0].token1,
+    };
+
+    let currentPool = this.getState(0);
+    currentPool = currentPool == null ? [] : currentPool;
+    currentPool = [...currentPool, generatedPool];
+
+    this.setState(currentPool, blockNumber_);
+
+    return currentPool;
+  }
+
+  decodePool = (result: MultiResult<BytesLike> | BytesLike): Pool => {
+    return generalDecoder(
+      result,
+      ['tuple(address pool, address token0, address token1, uint256 fee)'],
+      undefined,
+      decoded => {
+        return {
+          address: decoded[0].toLowerCase(),
+          token0: decoded[1].toLowerCase(),
+          token1: decoded[2].toLowerCase(),
+        };
+      },
+    );
+  };
+
+  /**
+   * The function is called every time any of the subscribed
+   * addresses release log. The function accepts the current
+   * state, updates the state according to the log, and returns
+   * the updated state.
+   * @param state - Current state of event subscriber
+   * @param log - Log released by one of the subscribed addresses
+   * @returns Updates state of the event subscriber after the log
+   */
+  async processLog(
+    state: DeepReadonly<Pool[]>,
+    log: Readonly<Log>,
+  ): Promise<DeepReadonly<Pool[]> | null> {
+    try {
+      const event = this.logDecoder(log);
+      if (event.name in this.handlers) {
+        return await this.handlers[event.name](event, state, log);
+      }
+    } catch (e) {
+      catchParseLogError(e, this.logger);
+    }
+
+    return null;
+  }
+
+  async getStateOrGenerate(
+    blockNumber: number,
+    readonly: boolean = false,
+  ): Promise<DeepReadonly<Pool[]>> {
+    let state = this.getState(blockNumber);
+    if (!state) {
+      state = await this.generateState(blockNumber);
+      if (!readonly) this.setState(state, blockNumber);
+    }
+    return state;
+  }
+
+  /**
+   * The function generates state using on-chain calls. This
+   * function is called to regenerate state if the event based
+   * system fails to fetch events and the local state is no
+   * more correct.
+   * @param blockNumber - Blocknumber for which the state should
+   * should be generated
+   * @returns state of the event subscriber at blocknumber
+   */
+  async generateState(blockNumber: number): Promise<DeepReadonly<Pool[]>> {
+    // Flatten the array of arrays into a single array
+    const flattenedResults: Pool[] = (
+      await this.getPoolsFromResolver(blockNumber)
+    ).flat();
+
+    // Cast the result to DeepReadonly<Pool[]>
+    return flattenedResults as DeepReadonly<Pool[]>;
+  }
+
+  async getPoolsFromResolver(blockNumber: number): Promise<Pool[]> {
+    const resolverAbi = new Interface(ResolverABI);
+    const callData: MultiCallParams<Pool[]>[] = [
+      {
+        target: this.commonAddresses.resolver,
+        callData: resolverAbi.encodeFunctionData('getAllPools', []),
+        decodeFunction: this.decodePools,
+      },
+    ];
+
+    const results: Pool[][] = await this.dexHelper.multiWrapper.aggregate<
+      Pool[]
+    >(callData, blockNumber, this.dexHelper.multiWrapper.defaultBatchSize);
+
+    return results[0];
+  }
+
+  decodePools = (result: MultiResult<BytesLike> | BytesLike): Pool[] => {
+    if (result === '0x') {
+      return []; // Return an empty array since there are no pools to decode
+    }
+    return generalDecoder(
+      result,
+      ['tuple(address pool, address token0, address token1)[]'],
+      undefined,
+      decoded => {
+        return decoded.map((decodedPool: any) => ({
+          address: decodedPool[0][0].toLowerCase(),
+          token0: decodedPool[0][1].toLowerCase(),
+          token1: decodedPool[0][2].toLowerCase(),
+        }));
+      },
+    );
+  };
+}

--- a/src/dex/fluid-dex/fluid-dex-integration.test.ts
+++ b/src/dex/fluid-dex/fluid-dex-integration.test.ts
@@ -170,22 +170,8 @@ describe('FluidDex', function () {
       10n * BI_POWS[tokens[srcTokenSymbol].decimals],
     ];
 
-    // const amountsForBuy = [
-    //   0n,
-    //   1n * BI_POWS[tokens[destTokenSymbol].decimals],
-    //   2n * BI_POWS[tokens[destTokenSymbol].decimals],
-    //   3n * BI_POWS[tokens[destTokenSymbol].decimals],
-    //   4n * BI_POWS[tokens[destTokenSymbol].decimals],
-    //   // 5n * BI_POWS[tokens[destTokenSymbol].decimals],
-    //   // 6n * BI_POWS[tokens[destTokenSymbol].decimals],
-    //   // 7n * BI_POWS[tokens[destTokenSymbol].decimals],
-    //   // 8n * BI_POWS[tokens[destTokenSymbol].decimals],
-    //   // 9n * BI_POWS[tokens[destTokenSymbol].decimals],
-    //   // 10n * BI_POWS[tokens[destTokenSymbol].decimals],
-    // ];
-
     beforeAll(async () => {
-      blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      blockNumber = await dexHelper.provider.getBlockNumber();
       fluidDex = new FluidDex(network, dexKey, dexHelper);
       if (fluidDex.initializePricing) {
         await fluidDex.initializePricing(blockNumber);
@@ -205,20 +191,6 @@ describe('FluidDex', function () {
         'estimateSwapIn',
       );
     });
-
-    // it('getPoolIdentifiers and getPricesVolume BUY', async function () {
-    //   await testPricingOnNetwork(
-    //     fluidDex,
-    //     network,
-    //     dexKey,
-    //     blockNumber,
-    //     srcTokenSymbol,
-    //     destTokenSymbol,
-    //     SwapSide.BUY,
-    //     amountsForBuy,
-    //     'estimateSwapOut',
-    //   );
-    // });
 
     it('getTopPoolsForToken', async function () {
       // We have to check without calling initializePricing, because

--- a/src/dex/fluid-dex/fluid-dex-integration.test.ts
+++ b/src/dex/fluid-dex/fluid-dex-integration.test.ts
@@ -1,0 +1,245 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Interface, Result } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide } from '../../constants';
+import { BI_POWS } from '../../bigint-constants';
+import { FluidDex } from './fluid-dex';
+import {
+  checkPoolPrices,
+  checkPoolsLiquidity,
+  checkConstantPoolPrices,
+} from '../../../tests/utils';
+import { Tokens } from '../../../tests/constants-e2e';
+import ResolverABI from '../../abi/fluid-dex/resolver.abi.json';
+
+/*
+  README
+  ======
+
+  This test script adds tests for FluidDex general integration
+  with the DEX interface. The test cases below are example tests.
+  It is recommended to add tests which cover FluidDex specific
+  logic.
+
+  You can run this individual test script by running:
+  `npx jest src/dex/<dex-name>/<dex-name>-integration.test.ts`
+
+  (This comment should be removed from the final implementation)
+*/
+
+function getReaderCalldata(
+  exchangeAddress: string,
+  readerIface: Interface,
+  amounts: bigint[],
+  funcName: string,
+) {
+  return amounts.map(amount => ({
+    target: exchangeAddress,
+    callData: readerIface.encodeFunctionData(funcName, [
+      '0x6d83f60eeac0e50a1250760151e81db2a278e03a',
+      funcName == 'estimateSwapIn' ? true : false,
+      amount,
+      funcName == 'estimateSwapIn' ? 0 : 2n * amount,
+    ]),
+  }));
+}
+
+function decodeReaderResult(
+  results: Result,
+  readerIface: Interface,
+  funcName: string,
+) {
+  return results.map(result => {
+    return BigInt(result);
+  });
+}
+
+async function checkOnChainPricing(
+  fluidDex: FluidDex,
+  funcName: string,
+  blockNumber: number,
+  prices: bigint[],
+  amounts: bigint[],
+) {
+  const resolverAddress = '0x278166a9b88f166eb170d55801be1b1d1e576330';
+
+  const readerIface = new Interface(ResolverABI);
+
+  const readerCallData = getReaderCalldata(
+    resolverAddress,
+    readerIface,
+    amounts.slice(1),
+    funcName,
+  );
+  const readerResult = (
+    await fluidDex.dexHelper.multiContract.methods
+      .aggregate(readerCallData)
+      .call({}, blockNumber)
+  ).returnData;
+
+  const expectedPrices = [0n].concat(
+    decodeReaderResult(readerResult, readerIface, funcName),
+  );
+}
+
+async function testPricingOnNetwork(
+  fluidDex: FluidDex,
+  network: Network,
+  dexKey: string,
+  blockNumber: number,
+  srcTokenSymbol: string,
+  destTokenSymbol: string,
+  side: SwapSide,
+  amounts: bigint[],
+  funcNameToCheck: string,
+) {
+  const networkTokens = Tokens[network];
+
+  const pools = await fluidDex.getPoolIdentifiers(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    side,
+    blockNumber,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Identifiers: `,
+    pools,
+  );
+
+  expect(pools.length).toBeGreaterThan(0);
+
+  const poolPrices = await fluidDex.getPricesVolume(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    amounts,
+    side,
+    blockNumber,
+    pools,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Prices: `,
+    poolPrices,
+  );
+
+  expect(poolPrices).not.toBeNull();
+  if (fluidDex.hasConstantPriceLargeAmounts) {
+    checkConstantPoolPrices(poolPrices!, amounts, dexKey);
+  } else {
+    checkPoolPrices(poolPrices!, amounts, side, dexKey);
+  }
+
+  // Check if onchain pricing equals to calculated ones
+  await checkOnChainPricing(
+    fluidDex,
+    funcNameToCheck,
+    blockNumber,
+    poolPrices![0].prices,
+    amounts,
+  );
+}
+
+describe('FluidDex', function () {
+  const dexKey = 'FluidDex';
+  let blockNumber: number;
+  let fluidDex: FluidDex;
+
+  describe('Mainnet', () => {
+    const network = Network.MAINNET;
+    const dexHelper = new DummyDexHelper(network);
+
+    const tokens = Tokens[network];
+
+    // Don't forget to update relevant tokens in constant-e2e.ts
+    const srcTokenSymbol = 'wstETH';
+    const destTokenSymbol = 'ETH';
+
+    const amountsForSell = [
+      0n,
+      1n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      2n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      3n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      4n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      5n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      6n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      7n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      8n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      9n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      10n * BI_POWS[tokens[srcTokenSymbol].decimals],
+    ];
+
+    // const amountsForBuy = [
+    //   0n,
+    //   1n * BI_POWS[tokens[destTokenSymbol].decimals],
+    //   2n * BI_POWS[tokens[destTokenSymbol].decimals],
+    //   3n * BI_POWS[tokens[destTokenSymbol].decimals],
+    //   4n * BI_POWS[tokens[destTokenSymbol].decimals],
+    //   // 5n * BI_POWS[tokens[destTokenSymbol].decimals],
+    //   // 6n * BI_POWS[tokens[destTokenSymbol].decimals],
+    //   // 7n * BI_POWS[tokens[destTokenSymbol].decimals],
+    //   // 8n * BI_POWS[tokens[destTokenSymbol].decimals],
+    //   // 9n * BI_POWS[tokens[destTokenSymbol].decimals],
+    //   // 10n * BI_POWS[tokens[destTokenSymbol].decimals],
+    // ];
+
+    beforeAll(async () => {
+      blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      fluidDex = new FluidDex(network, dexKey, dexHelper);
+      if (fluidDex.initializePricing) {
+        await fluidDex.initializePricing(blockNumber);
+      }
+    });
+
+    it('getPoolIdentifiers and getPricesVolume SELL', async function () {
+      await testPricingOnNetwork(
+        fluidDex,
+        network,
+        dexKey,
+        blockNumber,
+        srcTokenSymbol,
+        destTokenSymbol,
+        SwapSide.SELL,
+        amountsForSell,
+        'estimateSwapIn',
+      );
+    });
+
+    // it('getPoolIdentifiers and getPricesVolume BUY', async function () {
+    //   await testPricingOnNetwork(
+    //     fluidDex,
+    //     network,
+    //     dexKey,
+    //     blockNumber,
+    //     srcTokenSymbol,
+    //     destTokenSymbol,
+    //     SwapSide.BUY,
+    //     amountsForBuy,
+    //     'estimateSwapOut',
+    //   );
+    // });
+
+    it('getTopPoolsForToken', async function () {
+      // We have to check without calling initializePricing, because
+      // pool-tracker is not calling that function
+      const newFluidDex = new FluidDex(network, dexKey, dexHelper);
+      await newFluidDex.initializePricing(blockNumber);
+      if (newFluidDex.updatePoolState) {
+        await newFluidDex.updatePoolState();
+      }
+      const poolLiquidity = await newFluidDex.getTopPoolsForToken(
+        tokens[srcTokenSymbol].address,
+        1,
+      );
+
+      if (!newFluidDex.hasConstantPriceLargeAmounts) {
+        checkPoolsLiquidity(
+          poolLiquidity,
+          Tokens[network][srcTokenSymbol].address,
+          dexKey,
+        );
+      }
+    });
+  });
+});

--- a/src/dex/fluid-dex/fluid-dex-pool.ts
+++ b/src/dex/fluid-dex/fluid-dex-pool.ts
@@ -1,0 +1,244 @@
+import { Interface } from '@ethersproject/abi';
+import { DeepReadonly } from 'ts-essentials';
+import { Log, Logger } from '../../types';
+import { catchParseLogError } from '../../utils';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import ResolverABI from '../../abi/fluid-dex/resolver.abi.json';
+import LiquidityABI from '../../abi/fluid-dex/liquidityUserModule.abi.json';
+import {
+  commonAddresses,
+  FluidDexPoolState,
+  PoolWithReserves,
+  CollateralReserves,
+  DebtReserves,
+} from './types';
+import { MultiResult, MultiCallParams } from '../../lib/multi-wrapper';
+import { BytesLike } from 'ethers/lib/utils';
+import { Address } from '../../types';
+import { generalDecoder } from '../../lib/decoders';
+import { Contract } from 'ethers';
+
+export class FluidDexEventPool extends StatefulEventSubscriber<FluidDexPoolState> {
+  handlers: {
+    [event: string]: (
+      event: any,
+      state: DeepReadonly<FluidDexPoolState>,
+      log: Readonly<Log>,
+    ) => Promise<DeepReadonly<FluidDexPoolState> | null>;
+  } = {};
+
+  logDecoder: (log: Log) => any;
+
+  addressesSubscribed: Address[];
+  protected liquidityIface = new Interface(LiquidityABI);
+
+  constructor(
+    readonly parentName: string,
+    readonly pool: Address,
+    readonly commonAddresses: commonAddresses,
+    protected network: number,
+    readonly dexHelper: IDexHelper,
+    logger: Logger,
+  ) {
+    super(parentName, 'FluidDex_' + pool, dexHelper, logger);
+
+    this.logDecoder = (log: Log) => this.liquidityIface.parseLog(log);
+    this.addressesSubscribed = [commonAddresses.liquidityProxy];
+
+    // Add handlers
+    this.handlers['LogOperate'] = this.handleOperate.bind(this);
+  }
+
+  /**
+   * Handle a trade rate change on the pool.
+   */
+  async handleOperate(
+    event: any,
+    state: DeepReadonly<FluidDexPoolState>,
+    log: Readonly<Log>,
+  ): Promise<DeepReadonly<FluidDexPoolState> | null> {
+    const resolverAbi = new Interface(ResolverABI);
+    if (!(event.args.user in [this.pool])) {
+      return null;
+    }
+    const resolverContract = new Contract(
+      this.commonAddresses.resolver,
+      ResolverABI,
+      this.dexHelper.provider,
+    );
+    const rawResult = await resolverContract.callStatic.getPoolReserves(
+      this.pool,
+      {
+        blockTag: await this.dexHelper.provider,
+      },
+    );
+
+    const generatedState = this.convertToFluidDexPoolState(rawResult);
+
+    this.setState(
+      generatedState,
+      await this.dexHelper.provider.getBlockNumber(),
+    );
+
+    return generatedState;
+  }
+
+  decodePoolWithReserves = (
+    result: MultiResult<BytesLike> | BytesLike,
+  ): PoolWithReserves => {
+    return generalDecoder(
+      result,
+      [
+        'tuple(address pool, address token0_, address token1_, uint256 fee,' +
+          'tuple(uint256 token0RealReserves, uint256 token1RealReserves, uint256 token0ImaginaryReserves, uint256 token1ImaginaryReserves) collateralReserves, ' +
+          'tuple(uint256 token0Debt, uint256 token1Debt, uint256 token0RealReserves, uint256 token1RealReserves, uint256 token0ImaginaryReserves, uint256 token1ImaginaryReserves) debtReserves)',
+      ],
+      undefined,
+      decoded => {
+        const [decodedResult] = decoded;
+        return {
+          pool: decodedResult.pool,
+          token0_: decodedResult.token0_,
+          token1_: decodedResult.token1_,
+          fee: decodedResult.fee,
+          collateralReserves: {
+            token0RealReserves: BigInt(
+              decodedResult.collateralReserves.token0RealReserves,
+            ),
+            token1RealReserves: BigInt(
+              decodedResult.collateralReserves.token1RealReserves,
+            ),
+            token0ImaginaryReserves: BigInt(
+              decodedResult.collateralReserves.token0ImaginaryReserves,
+            ),
+            token1ImaginaryReserves: BigInt(
+              decodedResult.collateralReserves.token1ImaginaryReserves,
+            ),
+          },
+          debtReserves: {
+            token0Debt: BigInt(decodedResult.debtReserves.token0Debt),
+            token1Debt: BigInt(decodedResult.debtReserves.token1Debt),
+            token0RealReserves: BigInt(
+              decodedResult.debtReserves.token0RealReserves,
+            ),
+            token1RealReserves: BigInt(
+              decodedResult.debtReserves.token1RealReserves,
+            ),
+            token0ImaginaryReserves: BigInt(
+              decodedResult.debtReserves.token0ImaginaryReserves,
+            ),
+            token1ImaginaryReserves: BigInt(
+              decodedResult.debtReserves.token1ImaginaryReserves,
+            ),
+          },
+        };
+      },
+    );
+  };
+
+  /**
+   * The function is called every time any of the subscribed
+   * addresses release log. The function accepts the current
+   * state, updates the state according to the log, and returns
+   * the updated state.
+   * @param state - Current state of event subscriber
+   * @param log - Log released by one of the subscribed addresses
+   * @returns Updates state of the event subscriber after the log
+   */
+  async processLog(
+    state: DeepReadonly<FluidDexPoolState>,
+    log: Readonly<Log>,
+  ): Promise<DeepReadonly<FluidDexPoolState> | null> {
+    try {
+      const event = this.logDecoder(log);
+      if (event.name in this.handlers) {
+        return await this.handlers[event.name](event, state, log);
+      }
+    } catch (e) {
+      catchParseLogError(e, this.logger);
+    }
+
+    return null;
+  }
+
+  async getStateOrGenerate(
+    blockNumber: number,
+    readonly: boolean = false,
+  ): Promise<FluidDexPoolState> {
+    let state = this.getState(blockNumber);
+    if (!state) {
+      state = await this.generateState(blockNumber);
+      if (!readonly) this.setState(state, blockNumber);
+    }
+    return state;
+  }
+
+  replacer(key: string, value: any) {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+    return value;
+  }
+
+  /**
+   * The function generates state using on-chain calls. This
+   * function is called to regenerate state if the event based
+   * system fails to fetch events and the local state is no
+   * more correct.
+   * @param blockNumber - Blocknumber for which the state should
+   * should be generated
+   * @returns state of the event subscriber at blocknumber
+   */
+  async generateState(
+    blockNumber: number,
+  ): Promise<DeepReadonly<FluidDexPoolState>> {
+    const resolverContract = new Contract(
+      this.commonAddresses.resolver,
+      ResolverABI,
+      this.dexHelper.provider,
+    );
+    const rawResult = await resolverContract.callStatic.getPoolReserves(
+      this.pool,
+      {
+        blockTag: blockNumber,
+      },
+    );
+
+    const convertedResult = this.convertToFluidDexPoolState(rawResult);
+
+    return convertedResult;
+  }
+
+  convertToFluidDexPoolState(input: any[]): FluidDexPoolState {
+    // Ignore the first three addresses
+    const [, , , feeHex, collateralReservesHex, debtReservesHex] = input;
+    //   // Convert fee from hex to number
+    const fee = feeHex;
+    //   console.log("converted fee : " + fee);
+
+    // Convert collateral reserves
+    const collateralReserves: CollateralReserves = {
+      token0RealReserves: collateralReservesHex[0],
+      token1RealReserves: collateralReservesHex[1],
+      token0ImaginaryReserves: collateralReservesHex[2],
+      token1ImaginaryReserves: collateralReservesHex[3],
+    };
+
+    // Convert debt reserves
+    const debtReserves: DebtReserves = {
+      token0Debt: debtReservesHex[0],
+      token1Debt: debtReservesHex[1],
+      token0RealReserves: debtReservesHex[2],
+      token1RealReserves: debtReservesHex[3],
+      token0ImaginaryReserves: debtReservesHex[4],
+      token1ImaginaryReserves: debtReservesHex[5],
+    };
+
+    return {
+      collateralReserves,
+      debtReserves,
+      fee,
+    };
+  }
+}

--- a/src/dex/fluid-dex/fluid-dex-pool.ts
+++ b/src/dex/fluid-dex/fluid-dex-pool.ts
@@ -1,6 +1,5 @@
 import { Interface } from '@ethersproject/abi';
 import { DeepReadonly } from 'ts-essentials';
-import { BytesLike } from 'ethers/lib/utils';
 import { Log, Logger } from '../../types';
 import { catchParseLogError } from '../../utils';
 import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
@@ -10,13 +9,10 @@ import LiquidityABI from '../../abi/fluid-dex/liquidityUserModule.abi.json';
 import {
   CommonAddresses,
   FluidDexPoolState,
-  PoolWithReserves,
   CollateralReserves,
   DebtReserves,
 } from './types';
-import { MultiResult } from '../../lib/multi-wrapper';
 import { Address } from '../../types';
-import { generalDecoder } from '../../lib/decoders';
 import { Contract } from 'ethers';
 
 export class FluidDexEventPool extends StatefulEventSubscriber<FluidDexPoolState> {
@@ -152,25 +148,25 @@ export class FluidDexEventPool extends StatefulEventSubscriber<FluidDexPoolState
   private convertToFluidDexPoolState(input: any[]): FluidDexPoolState {
     // Ignore the first three addresses
     const [, , , feeHex, collateralReservesHex, debtReservesHex] = input;
-    //  Convert fee from hex to number
-    const fee = feeHex;
+    // Convert fee from hex to number
+    const fee = Number(feeHex.toString());
 
     // Convert collateral reserves
     const collateralReserves: CollateralReserves = {
-      token0RealReserves: collateralReservesHex[0],
-      token1RealReserves: collateralReservesHex[1],
-      token0ImaginaryReserves: collateralReservesHex[2],
-      token1ImaginaryReserves: collateralReservesHex[3],
+      token0RealReserves: BigInt(collateralReservesHex[0].toString()),
+      token1RealReserves: BigInt(collateralReservesHex[1].toString()),
+      token0ImaginaryReserves: BigInt(collateralReservesHex[2].toString()),
+      token1ImaginaryReserves: BigInt(collateralReservesHex[3].toString()),
     };
 
     // Convert debt reserves
     const debtReserves: DebtReserves = {
-      token0Debt: debtReservesHex[0],
-      token1Debt: debtReservesHex[1],
-      token0RealReserves: debtReservesHex[2],
-      token1RealReserves: debtReservesHex[3],
-      token0ImaginaryReserves: debtReservesHex[4],
-      token1ImaginaryReserves: debtReservesHex[5],
+      token0Debt: BigInt(debtReservesHex[0].toString()),
+      token1Debt: BigInt(debtReservesHex[1].toString()),
+      token0RealReserves: BigInt(debtReservesHex[2].toString()),
+      token1RealReserves: BigInt(debtReservesHex[3].toString()),
+      token0ImaginaryReserves: BigInt(debtReservesHex[4].toString()),
+      token1ImaginaryReserves: BigInt(debtReservesHex[5].toString()),
     };
 
     return {

--- a/src/dex/fluid-dex/fluid-dex.ts
+++ b/src/dex/fluid-dex/fluid-dex.ts
@@ -1,0 +1,881 @@
+import { AsyncOrSync } from 'ts-essentials';
+import { Interface } from '@ethersproject/abi';
+import {
+  Token,
+  Address,
+  ExchangePrices,
+  PoolPrices,
+  AdapterExchangeParam,
+  SimpleExchangeParam,
+  PoolLiquidity,
+  DexExchangeParam,
+  Logger,
+} from '../../types';
+import { SwapSide, Network } from '../../constants';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+import { Context, IDex } from '../../dex/idex';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import {
+  CollateralReserves,
+  DebtReserves,
+  DexParams,
+  FluidDexData,
+  FluidDexPool,
+  FluidDexPoolState,
+  Pool,
+  commonAddresses,
+} from './types';
+import {
+  SimpleExchange,
+  getLocalDeadlineAsFriendlyPlaceholder,
+} from '../simple-exchange';
+import FluidDexPoolABI from '../../abi/fluid-dex/fluid-dex.abi.json';
+import { FluidDexConfig, Adapters, FLUID_DEX_GAS_COST } from './config';
+import { FluidDexEventPool } from './fluid-dex-pool';
+import { FluidDexCommonAddresses } from './fluid-dex-generate-pool';
+import { applyTransferFee } from '../../lib/token-transfer-fee';
+import { getDexKeysWithNetwork, getBigIntPow } from '../../utils';
+import { extractReturnAmountPosition } from '../../executor/utils';
+import ResolverABI from '../../abi/fluid-dex/resolver.abi.json';
+import { MultiResult, MultiCallParams } from '../../lib/multi-wrapper';
+import { BytesLike } from 'ethers/lib/utils';
+import {
+  generalDecoder,
+  extractSuccessAndValue,
+  addressDecode,
+} from '../../lib/decoders';
+// @ts-ignore
+import { Tokens } from '../../../tests/constants-e2e';
+
+export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
+  readonly eventPools: { [id: string]: FluidDexEventPool } = {};
+  readonly hasConstantPriceLargeAmounts = false;
+  readonly needWrapNative = false;
+  readonly isFeeOnTransferSupported = false;
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(FluidDexConfig);
+
+  logger: Logger;
+
+  pools: FluidDexPool[];
+
+  readonly FluidCommonAddresses: FluidDexCommonAddresses;
+
+  readonly iFluidDexPool: Interface;
+
+  protected adapters;
+
+  FEE_100_PERCENT = BigInt(1000000);
+
+  constructor(
+    readonly network: Network,
+    readonly dexKey: string,
+    readonly dexHelper: IDexHelper,
+  ) {
+    super(dexHelper, dexKey);
+    this.logger = dexHelper.getLogger(dexKey);
+    this.FluidCommonAddresses = new FluidDexCommonAddresses(
+      'FluidDex',
+      FluidDexConfig['FluidDex'][network].commonAddresses,
+      network,
+      dexHelper,
+      this.logger,
+    );
+    this.pools = FluidDexConfig['FluidDex'][network].pools;
+    this.adapters = Adapters[network] || {};
+    this.iFluidDexPool = new Interface(FluidDexPoolABI);
+  }
+
+  async fetchFluidDexPools(blockNumber: number): Promise<FluidDexPool[]> {
+    const poolsFromResolver =
+      await this.FluidCommonAddresses.getStateOrGenerate(blockNumber, false);
+
+    return poolsFromResolver.map(pool => ({
+      id: `FluidDex_${pool.address}`,
+      address: pool.address,
+      token0: pool.token0,
+      token1: pool.token1,
+    }));
+  }
+
+  async updatePoolAndEventPool(blockNumber: number) {
+    this.pools = await this.fetchFluidDexPools(blockNumber);
+    for (const pool of this.pools) {
+      if (!this.eventPools[pool.id]) {
+        this.eventPools[pool.id] = new FluidDexEventPool(
+          'FluidDex',
+          pool.address,
+          this.FluidCommonAddresses.commonAddresses,
+          this.network,
+          this.dexHelper,
+          this.logger,
+        );
+      }
+    }
+  }
+
+  // Initialize pricing is called once in the start of
+  // pricing service. It is intended to setup the integration
+  // for pricing requests. It is optional for a DEX to
+  // implement this function
+  async initializePricing(blockNumber: number) {
+    Object.entries(this.eventPools).forEach(([id, eventPool]) => {
+      eventPool.getStateOrGenerate(blockNumber, false);
+    });
+    await this.updatePoolAndEventPool(blockNumber);
+  }
+
+  // Returns the list of contract adapters (name and index)
+  // for a buy/sell. Return null if there are no adapters.
+  getAdapters(side: SwapSide): { name: string; index: number }[] | null {
+    return this.adapters[side] ? this.adapters[side] : null;
+  }
+
+  decodePools = (result: MultiResult<BytesLike> | BytesLike): Pool[] => {
+    return generalDecoder(
+      result,
+      ['tuple(address pool, address token0, address token1)[]'],
+      undefined,
+      decoded => {
+        return decoded.map((decodedPool: any) => ({
+          address: decodedPool[0][0].toLowerCase(),
+          token0: decodedPool[0][1].toLowerCase(),
+          token1: decodedPool[0][2].toLowerCase(),
+        }));
+      },
+    );
+  };
+
+  // Returns list of pool identifiers that can be used
+  // for a given swap. poolIdentifiers must be unique
+  // across DEXes. It is recommended to use
+  // ${dexKey}_${poolAddress} as a poolIdentifier
+  async getPoolIdentifiers(
+    srcToken: Token,
+    destToken: Token,
+    side: SwapSide,
+    blockNumber: number,
+  ): Promise<string[]> {
+    await this.updatePoolAndEventPool(blockNumber);
+    const pool = await this.getPoolByTokenPair(
+      srcToken.address,
+      destToken.address,
+    );
+    return pool ? [pool.id] : [];
+  }
+
+  async getPoolByTokenPair(
+    srcToken: Address,
+    destToken: Address,
+  ): Promise<FluidDexPool | null> {
+    const srcAddress = srcToken.toLowerCase();
+    const destAddress = destToken.toLowerCase();
+
+    // A pair must have 2 different tokens.
+    if (srcAddress === destAddress) return null;
+
+    for (const pool of this.pools) {
+      if (
+        (srcAddress === pool.token0 && destAddress === pool.token1) ||
+        (srcAddress === pool.token1 && destAddress === pool.token0)
+      ) {
+        return pool;
+      }
+    }
+    return null;
+  }
+
+  // Returns pool prices for amounts.
+  // If limitPools is defined only pools in limitPools
+  // should be used. If limitPools is undefined then
+  // any pools can be used.
+  async getPricesVolume(
+    srcToken: Token,
+    destToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    limitPools?: string[],
+  ): Promise<null | ExchangePrices<FluidDexData>> {
+    await this.updatePoolAndEventPool(blockNumber);
+    try {
+      if (side === SwapSide.BUY) throw new Error(`Buy not supported`);
+      // Get the pool to use.
+      const pool = await this.getPoolByTokenPair(
+        srcToken.address,
+        destToken.address,
+      );
+      if (!pool) return null;
+
+      // Make sure the pool meets the optional limitPools filter.
+      if (limitPools && !limitPools.includes(pool.id)) return null;
+
+      const eventPool = this.eventPools[pool.id];
+
+      if (!eventPool) {
+        this.logger.error(`fluid-dex pool ${pool.id}: No EventPool found.`);
+
+        return null;
+      }
+
+      // const state = await eventPool.generateState(blockNumber);
+      const state = await eventPool.getStateOrGenerate(blockNumber);
+
+      const swap0To1: boolean = side === SwapSide.SELL;
+
+      const prices = amounts.map(amount => {
+        if (side === SwapSide.SELL) {
+          return this.swapIn(
+            srcToken.address.toLowerCase() === pool.token0.toLowerCase(),
+            amount,
+            state.collateralReserves,
+            state.debtReserves,
+            srcToken.decimals,
+            destToken.decimals,
+            BigInt(state.fee),
+          );
+        } else {
+          return this.swapOut(
+            !(srcToken.address.toLowerCase() === pool.token0.toLowerCase()),
+            amount,
+            state.collateralReserves,
+            state.debtReserves,
+            srcToken.decimals,
+            destToken.decimals,
+            BigInt(state.fee),
+          );
+        }
+      });
+
+      return [
+        {
+          prices: prices.filter((price): price is bigint => price !== null), // to be done
+          unit: getBigIntPow(
+            (side === SwapSide.SELL ? destToken : srcToken).decimals,
+          ), // to be done
+          data: {
+            colReserves: state.collateralReserves,
+            debtReserves: state.debtReserves,
+            exchange: this.dexKey,
+          },
+          exchange: this.dexKey,
+          poolIdentifier: pool.id,
+          gasCost: FLUID_DEX_GAS_COST, // to be done
+          poolAddresses: [pool.address],
+        },
+      ];
+    } catch (e) {
+      this.logger.error(
+        `Error_getPricesVolume ${srcToken.address || srcToken.symbol}, ${
+          destToken.address || destToken.symbol
+        }, ${side}:`,
+        e,
+      );
+
+      return null;
+    }
+  }
+
+  // Returns estimated gas cost of calldata for this DEX in multiSwap
+  getCalldataGasCost(poolPrices: PoolPrices<FluidDexData>): number | number[] {
+    return CALLDATA_GAS_COST.DEX_NO_PAYLOAD;
+  }
+
+  // Encode params required by the exchange adapter
+  // V5: Used for multiSwap, buy & megaSwap
+  // V6: Not used, can be left blank
+  // Hint: abiCoder.encodeParameter() could be useful
+  getAdapterParam(
+    srcToken: string,
+    destToken: string,
+    srcAmount: string,
+    destAmount: string,
+    data: FluidDexData,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    if (side === SwapSide.BUY) throw new Error(`Buy not supported`);
+    const { exchange } = data;
+
+    // Encode here the payload for adapter
+    const payload = '';
+
+    return {
+      targetExchange: exchange,
+      payload,
+      networkFee: '0',
+    };
+  }
+
+  // This is called once before getTopPoolsForToken is
+  // called for multiple tokens. This can be helpful to
+  // update common state required for calculating
+  // getTopPoolsForToken. It is optional for a DEX
+  // to implement this
+  async updatePoolState(): Promise<void> {
+    this.initializePricing(
+      await this.dexHelper.web3Provider.eth.getBlockNumber(),
+    );
+  }
+
+  // Returns list of top pools based on liquidity. Max
+  // limit number pools should be returned.
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    limit: number,
+  ): Promise<PoolLiquidity[]> {
+    const latestBlockNumber_ =
+      await this.dexHelper.web3Provider.eth.getBlockNumber();
+    let liquidityAmounts: { [id: string]: bigint } = {};
+    for (const pool of this.pools) {
+      if (
+        pool.token0 === tokenAddress.toLowerCase() ||
+        pool.token1 === tokenAddress.toLowerCase()
+      ) {
+        const state: FluidDexPoolState = await this.eventPools[
+          pool.id
+        ].getStateOrGenerate(latestBlockNumber_, false);
+
+        liquidityAmounts[pool.id] =
+          pool.token0 === tokenAddress
+            ? state.collateralReserves.token0RealReserves +
+              state.debtReserves.token0RealReserves
+            : state.collateralReserves.token1RealReserves +
+              state.debtReserves.token1RealReserves;
+      }
+    }
+
+    const entries = Object.entries(liquidityAmounts);
+
+    // Sort the entries based on the values in descending order
+    entries.sort((a, b) => {
+      if (b[1] > a[1]) return 1;
+      if (b[1] < a[1]) return -1;
+      return 0;
+    });
+
+    // Take the top k entries
+    const topKEntries = entries.slice(0, limit);
+
+    // Convert the array back to an object
+    const sortedAmounts = Object.fromEntries(topKEntries);
+
+    const poolLiquidities: PoolLiquidity[] = [];
+
+    for (const [id, amount] of Object.entries(sortedAmounts)) {
+      const pool = this.pools.find(p => p.id === id);
+      if (!pool) continue; // Skip if pool not found
+
+      const state: FluidDexPoolState = await this.eventPools[
+        pool.id
+      ].getStateOrGenerate(latestBlockNumber_, false);
+
+      let token0decimals: number;
+      for (const [networkStr, symbolMapping] of Object.entries(Tokens)) {
+        let found = false;
+        for (const [symbol, tokenParams] of Object.entries(symbolMapping)) {
+          if (tokenParams.address.toLowerCase() === pool.token0.toLowerCase()) {
+            token0decimals = tokenParams.decimals;
+            found = true;
+            break;
+          }
+          if (found) break;
+        }
+      }
+
+      let token1decimals: number;
+      for (const [networkStr, symbolMapping] of Object.entries(Tokens)) {
+        let found = false;
+        for (const [symbol, tokenParams] of Object.entries(symbolMapping)) {
+          if (tokenParams.address.toLowerCase() === pool.token1.toLowerCase()) {
+            token1decimals = tokenParams.decimals;
+            found = true;
+            break;
+          }
+          if (found) break;
+        }
+      }
+
+      const usd0 = await this.dexHelper.getTokenUSDPrice(
+        { address: pool.token0, decimals: token0decimals! },
+        state.collateralReserves.token0RealReserves +
+          state.debtReserves.token0RealReserves,
+      );
+      const usd1 = await this.dexHelper.getTokenUSDPrice(
+        { address: pool.token1, decimals: token1decimals! },
+        state.collateralReserves.token1RealReserves +
+          state.debtReserves.token1RealReserves,
+      );
+
+      poolLiquidities.push({
+        exchange: 'FluidDex',
+        address: pool.address,
+        connectorTokens: [],
+        liquidityUSD: Number(usd0 + usd1), // converted to number
+      });
+    }
+    return poolLiquidities;
+  }
+
+  async getDexParam(
+    srcToken: Address,
+    destToken: Address,
+    srcAmount: string,
+    destAmount: string,
+    recipient: Address,
+    data: FluidDexData,
+    side: SwapSide,
+    context: Context,
+    executorAddress: Address,
+  ): Promise<DexExchangeParam> {
+    const latestBlockNumber_ =
+      await this.dexHelper.web3Provider.eth.getBlockNumber();
+    await this.updatePoolAndEventPool(latestBlockNumber_);
+
+    if (side === SwapSide.BUY) throw new Error(`Buy not supported`);
+
+    let method: string;
+    let args: any;
+    let returnAmountPos: number | undefined = undefined;
+
+    const deadline = getLocalDeadlineAsFriendlyPlaceholder();
+
+    method = side == SwapSide.SELL ? 'swapIn' : 'swapOut';
+
+    returnAmountPos = extractReturnAmountPosition(
+      this.iFluidDexPool,
+      method,
+      side == SwapSide.SELL ? 'amountOut_' : 'amountIn_',
+      1,
+    );
+
+    const pool = await this.getPoolByTokenPair(srcToken, destToken);
+
+    if (side == SwapSide.SELL) {
+      if (pool!.token0.toLowerCase() != srcToken.toLowerCase()) {
+        args = [false, BigInt(srcAmount), BigInt(destAmount), recipient];
+      } else {
+        args = [true, BigInt(srcAmount), BigInt(destAmount), recipient];
+      }
+    } else {
+      if (pool!.token0.toLowerCase() != srcToken.toLowerCase()) {
+        args = [true, BigInt(srcAmount), 2n * BigInt(srcAmount), recipient];
+      } else {
+        args = [false, BigInt(srcAmount), 2n * BigInt(srcAmount), recipient];
+      }
+    }
+
+    const swapData = this.iFluidDexPool.encodeFunctionData(method, args);
+
+    return {
+      needWrapNative: this.needWrapNative,
+      dexFuncHasRecipient: true,
+      exchangeData: swapData,
+      targetExchange: pool!.address,
+      returnAmountPos,
+    };
+  }
+
+  /**
+   * Calculates the output amount for a given input amount in a swap operation.
+   * @param swap0To1 - Direction of the swap. True if swapping token0 for token1, false otherwise.
+   * @param amountIn - The amount of input token to be swapped (as a BigInt).
+   * @param colReserves - The reserves of the collateral pool.
+   * @param debtReserves - The reserves of the debt pool.
+   * @param inDecimals - The number of decimals for the input token.
+   * @param outDecimals - The number of decimals for the output token.
+   * @returns The calculated output amount (as a BigInt).
+   */
+  swapIn(
+    swap0To1: boolean,
+    amountIn: bigint,
+    colReserves: CollateralReserves,
+    debtReserves: DebtReserves,
+    inDecimals: number,
+    outDecimals: number,
+    fee: bigint,
+  ): bigint {
+    if (amountIn === 0n) {
+      return 0n; // Return 0 if input amount is 0
+    }
+    const amountInAdjusted =
+      (((amountIn * (this.FEE_100_PERCENT - fee)) / this.FEE_100_PERCENT) *
+        BigInt(10 ** 12)) /
+      BigInt(10 ** inDecimals);
+
+    const amountOut = this.swapInAdjusted(
+      swap0To1,
+      amountInAdjusted, // Convert back to number for internal calculations
+      colReserves,
+      debtReserves,
+    );
+    const result = (amountOut * BigInt(10 ** outDecimals)) / BigInt(10 ** 12);
+    return result;
+  }
+
+  /**
+   * Calculates the output amount for a given input amount in a swap operation.
+   * @param swap0To1 - Direction of the swap. True if swapping token0 for token1, false otherwise.
+   * @param amountToSwap - The amount of input token to be swapped.
+   * @param colReserves - The reserves of the collateral pool.
+   * @param debtReserves - The reserves of the debt pool.
+   * @returns The calculated output amount.
+   */
+  private swapInAdjusted(
+    swap0To1: boolean,
+    amountToSwap: bigint,
+    colReserves: CollateralReserves,
+    debtReserves: DebtReserves,
+  ): bigint {
+    const {
+      token0RealReserves,
+      token1RealReserves,
+      token0ImaginaryReserves,
+      token1ImaginaryReserves,
+    } = colReserves;
+
+    const {
+      token0RealReserves: debtToken0RealReserves,
+      token1RealReserves: debtToken1RealReserves,
+      token0ImaginaryReserves: debtToken0ImaginaryReserves,
+      token1ImaginaryReserves: debtToken1ImaginaryReserves,
+    } = debtReserves;
+
+    // Check if all reserves of collateral pool are greater than 0
+    const colPoolEnabled =
+      token0RealReserves > BigInt(0) &&
+      token1RealReserves > BigInt(0) &&
+      token0ImaginaryReserves > BigInt(0) &&
+      token1ImaginaryReserves > BigInt(0);
+
+    // Check if all reserves of debt pool are greater than 0
+    const debtPoolEnabled =
+      debtToken0RealReserves > BigInt(0) &&
+      debtToken1RealReserves > BigInt(0) &&
+      debtToken0ImaginaryReserves > BigInt(0) &&
+      debtToken1ImaginaryReserves > BigInt(0);
+
+    let colIReserveIn: bigint,
+      colIReserveOut: bigint,
+      debtIReserveIn: bigint,
+      debtIReserveOut: bigint;
+
+    if (swap0To1) {
+      colIReserveIn = token0ImaginaryReserves;
+      colIReserveOut = token1ImaginaryReserves;
+      debtIReserveIn = debtToken0ImaginaryReserves;
+      debtIReserveOut = debtToken1ImaginaryReserves;
+    } else {
+      colIReserveIn = token1ImaginaryReserves;
+      colIReserveOut = token0ImaginaryReserves;
+      debtIReserveIn = debtToken1ImaginaryReserves;
+      debtIReserveOut = debtToken0ImaginaryReserves;
+    }
+
+    let a: bigint;
+    if (colPoolEnabled && debtPoolEnabled) {
+      a = this.swapRoutingIn(
+        amountToSwap,
+        colIReserveOut,
+        colIReserveIn,
+        debtIReserveOut,
+        debtIReserveIn,
+      );
+    } else if (debtPoolEnabled) {
+      a = BigInt(-1); // Route from debt pool
+    } else if (colPoolEnabled) {
+      a = amountToSwap + BigInt(1); // Route from collateral pool
+    } else {
+      throw new Error('No pools are enabled');
+    }
+
+    let amountOutCollateral = BigInt(0);
+    let amountOutDebt = BigInt(0);
+
+    if (a <= BigInt(0)) {
+      // Entire trade routes through debt pool
+      amountOutDebt = this.getAmountOut(
+        amountToSwap,
+        debtIReserveIn,
+        debtIReserveOut,
+      );
+    } else if (a >= amountToSwap) {
+      // Entire trade routes through collateral pool
+      amountOutCollateral = this.getAmountOut(
+        amountToSwap,
+        colIReserveIn,
+        colIReserveOut,
+      );
+    } else {
+      // Trade routes through both pools
+      amountOutCollateral = this.getAmountOut(a, colIReserveIn, colIReserveOut);
+      amountOutDebt = this.getAmountOut(
+        amountToSwap - a,
+        debtIReserveIn,
+        debtIReserveOut,
+      );
+    }
+    const totalAmountOut = amountOutCollateral + amountOutDebt;
+
+    return totalAmountOut;
+  }
+
+  /**
+   * Given an input amount of asset and pair reserves, returns the maximum output amount of the other asset.
+   * @param amountIn - The amount of input asset.
+   * @param iReserveIn - Imaginary token reserve with input amount.
+   * @param iReserveOut - Imaginary token reserve of output amount.
+   * @returns The maximum output amount of the other asset.
+   */
+  private getAmountOut(
+    amountIn: bigint,
+    iReserveIn: bigint,
+    iReserveOut: bigint,
+  ): bigint {
+    // Both numerator and denominator are scaled to 1e6 to factor in fee scaling.
+    const numerator = amountIn * iReserveOut;
+    const denominator = iReserveIn + amountIn;
+
+    // Using the swap formula: (AmountIn * iReserveY) / (iReserveX + AmountIn)
+    // We use division with rounding down, which is the default for bigint division
+
+    return numerator / denominator;
+  }
+
+  /**
+   * Given an output amount of asset and pair reserves, returns the input amount of the other asset
+   * @param amountOut - Desired output amount of the asset.
+   * @param iReserveIn - Imaginary token reserve of input amount.
+   * @param iReserveOut - Imaginary token reserve of output amount.
+   * @returns The input amount of the other asset.
+   */
+  private getAmountIn(
+    amountOut: bigint,
+    iReserveIn: bigint,
+    iReserveOut: bigint,
+  ): bigint {
+    // Both numerator and denominator are scaled to 1e6 to factor in fee scaling.
+    const numerator = amountOut * iReserveIn;
+    const denominator = iReserveOut - amountOut;
+
+    // Using the swap formula: (AmountOut * iReserveX) / (iReserveY - AmountOut)
+    return numerator / denominator;
+  }
+
+  /**
+   * Calculates how much of a swap should go through the collateral pool for output amount.
+   * @param t - Total amount out.
+   * @param x - Imaginary reserves of token in of collateral.
+   * @param y - Imaginary reserves of token out of collateral.
+   * @param x2 - Imaginary reserves of token in of debt.
+   * @param y2 - Imaginary reserves of token out of debt.
+   * @returns How much swap should go through collateral pool. Remaining will go from debt.
+   * @note If a < 0 then entire trade route through debt pool and debt pool arbitrage with col pool.
+   * @note If a > t then entire trade route through col pool and col pool arbitrage with debt pool.
+   * @note If a > 0 & a < t then swap will route through both pools.
+   */
+  private swapRoutingOut(
+    t: bigint,
+    x: bigint,
+    y: bigint,
+    x2: bigint,
+    y2: bigint,
+  ): bigint {
+    // Adding 1e18 precision
+    const xyRoot = BigInt(
+      Math.floor(Math.sqrt(Number(x * y * BigInt(10n ** 18n)))),
+    );
+    const x2y2Root = BigInt(
+      Math.floor(Math.sqrt(Number(x2 * y2 * BigInt(10n ** 18n)))),
+    );
+
+    // 1e18 precision gets cancelled out in division
+    const numerator = t * xyRoot + y * x2y2Root - y2 * xyRoot;
+    const denominator = xyRoot + x2y2Root;
+
+    // Use integer division (rounds down)
+    const a = numerator / denominator;
+
+    return a;
+  }
+
+  /**
+   * Calculates how much of a swap should go through the collateral pool.
+   * @param t - Total amount in.
+   * @param x - Imaginary reserves of token out of collateral.
+   * @param y - Imaginary reserves of token in of collateral.
+   * @param x2 - Imaginary reserves of token out of debt.
+   * @param y2 - Imaginary reserves of token in of debt.
+   * @returns How much swap should go through collateral pool. Remaining will go from debt.
+   * @note If a < 0 then entire trade route through debt pool and debt pool arbitrage with col pool.
+   * @note If a > t then entire trade route through col pool and col pool arbitrage with debt pool.
+   * @note If a > 0 & a < t then swap will route through both pools.
+   */
+  swapRoutingIn(
+    t: bigint,
+    x: bigint,
+    y: bigint,
+    x2: bigint,
+    y2: bigint,
+  ): bigint {
+    // Adding 1e18 precision
+
+    const xyRoot = BigInt(Math.floor(Math.sqrt(Number(x * y * BigInt(1e18)))));
+    const x2y2Root = BigInt(
+      Math.floor(Math.sqrt(Number(x2 * y2 * BigInt(1e18)))),
+    );
+
+    // Calculating 'a' using the given formula
+    const a =
+      (Number(y2) * Number(xyRoot) +
+        Number(t) * Number(xyRoot) -
+        Number(y) * Number(x2y2Root)) /
+      (Number(xyRoot) + Number(x2y2Root));
+    return BigInt(Math.floor(a));
+  }
+
+  /**
+   * Calculates the input amount for a given output amount in a swap operation.
+   * @param {boolean} swap0to1 - Direction of the swap. True if swapping token0 for token1, false otherwise.
+   * @param {bigint} amountOut - The amount of output token to be swapped.
+   * @param {Reserves} colReserves - The reserves of the collateral pool.
+   * @param {Reserves} debtReserves - The reserves of the debt pool.
+   * @param {number} inDecimals - The number of decimals for the input token.
+   * @param {number} outDecimals - The number of decimals for the output token.
+   * @param {number} fee - The fee for the swap. 1e4 = 1%
+   * @returns {bigint} amountIn - The calculated input amount required for the swap.
+   */
+  swapOut(
+    swap0to1: boolean,
+    amountOut: bigint,
+    colReserves: CollateralReserves,
+    debtReserves: DebtReserves,
+    inDecimals: number,
+    outDecimals: number,
+    fee: bigint,
+  ): bigint {
+    const amountOutAdjusted =
+      (amountOut * BigInt(10 ** 12)) / BigInt(10 ** outDecimals);
+    const amountIn = this.swapOutAdjusted(
+      swap0to1,
+      amountOutAdjusted,
+      colReserves,
+      debtReserves,
+    );
+
+    const FEE_100_PERCENT = BigInt(1e6); // Assuming this constant is defined elsewhere
+
+    const result =
+      ((amountIn * FEE_100_PERCENT) / (FEE_100_PERCENT - fee)) *
+      BigInt(10 ** (inDecimals - 12));
+
+    return result;
+  }
+
+  /**
+   * Calculates the input amount for a given output amount in a swap operation.
+   * @param {boolean} swap0to1 - Direction of the swap. True if swapping token0 for token1, false otherwise.
+   * @param {bigint} amountOut - The amount of output token to be swapped.
+   * @param {CollateralReserves} colReserves - The reserves of the collateral pool.
+   * @param {DebtReserves} debtReserves - The reserves of the debt pool.
+   * @returns {bigint} The calculated input amount required for the swap.
+   */
+  swapOutAdjusted(
+    swap0to1: boolean,
+    amountOut: bigint,
+    colReserves: CollateralReserves,
+    debtReserves: DebtReserves,
+  ): bigint {
+    const {
+      token0RealReserves,
+      token1RealReserves,
+      token0ImaginaryReserves,
+      token1ImaginaryReserves,
+    } = colReserves;
+
+    const {
+      token0RealReserves: debtToken0RealReserves,
+      token1RealReserves: debtToken1RealReserves,
+      token0ImaginaryReserves: debtToken0ImaginaryReserves,
+      token1ImaginaryReserves: debtToken1ImaginaryReserves,
+    } = debtReserves;
+
+    // Check if all reserves of collateral pool are greater than 0
+    const colPoolEnabled =
+      token0RealReserves > 0n &&
+      token1RealReserves > 0n &&
+      token0ImaginaryReserves > 0n &&
+      token1ImaginaryReserves > 0n;
+
+    // Check if all reserves of debt pool are greater than 0
+    const debtPoolEnabled =
+      debtToken0RealReserves > 0n &&
+      debtToken1RealReserves > 0n &&
+      debtToken0ImaginaryReserves > 0n &&
+      debtToken1ImaginaryReserves > 0n;
+
+    let colIReserveIn: bigint,
+      colIReserveOut: bigint,
+      debtIReserveIn: bigint,
+      debtIReserveOut: bigint;
+
+    if (swap0to1) {
+      colIReserveIn = token0ImaginaryReserves;
+      colIReserveOut = token1ImaginaryReserves;
+      debtIReserveIn = debtToken0ImaginaryReserves;
+      debtIReserveOut = debtToken1ImaginaryReserves;
+    } else {
+      colIReserveIn = token1ImaginaryReserves;
+      colIReserveOut = token0ImaginaryReserves;
+      debtIReserveIn = debtToken1ImaginaryReserves;
+      debtIReserveOut = debtToken0ImaginaryReserves;
+    }
+
+    let a: bigint;
+    if (colPoolEnabled && debtPoolEnabled) {
+      a = this.swapRoutingOut(
+        amountOut,
+        colIReserveIn,
+        colIReserveOut,
+        debtIReserveIn,
+        debtIReserveOut,
+      );
+    } else if (debtPoolEnabled) {
+      a = -1n; // Route from debt pool
+    } else if (colPoolEnabled) {
+      a = amountOut + 1n; // Route from collateral pool
+    } else {
+      throw new Error('No pools are enabled');
+    }
+
+    let amountInCollateral = 0n;
+    let amountInDebt = 0n;
+
+    if (a <= 0n) {
+      // Entire trade routes through debt pool
+      amountInDebt = this.getAmountIn(
+        amountOut,
+        debtIReserveIn,
+        debtIReserveOut,
+      );
+    } else if (a >= amountOut) {
+      // Entire trade routes through collateral pool
+      amountInCollateral = this.getAmountIn(
+        amountOut,
+        colIReserveIn,
+        colIReserveOut,
+      );
+    } else {
+      // Trade routes through both pools
+      amountInCollateral = this.getAmountIn(a, colIReserveIn, colIReserveOut);
+      amountInDebt = this.getAmountIn(
+        amountOut - a,
+        debtIReserveIn,
+        debtIReserveOut,
+      );
+    }
+
+    const totalAmountIn = amountInCollateral + amountInDebt;
+
+    return totalAmountIn;
+  }
+}

--- a/src/dex/fluid-dex/fluid-dex.ts
+++ b/src/dex/fluid-dex/fluid-dex.ts
@@ -1,4 +1,4 @@
-import { AsyncOrSync } from 'ts-essentials';
+import { BytesLike } from 'ethers/lib/utils';
 import { Interface } from '@ethersproject/abi';
 import {
   Token,
@@ -6,7 +6,6 @@ import {
   ExchangePrices,
   PoolPrices,
   AdapterExchangeParam,
-  SimpleExchangeParam,
   PoolLiquidity,
   DexExchangeParam,
   Logger,
@@ -18,32 +17,20 @@ import { IDexHelper } from '../../dex-helper/idex-helper';
 import {
   CollateralReserves,
   DebtReserves,
-  DexParams,
   FluidDexData,
   FluidDexPool,
   FluidDexPoolState,
   Pool,
-  commonAddresses,
 } from './types';
-import {
-  SimpleExchange,
-  getLocalDeadlineAsFriendlyPlaceholder,
-} from '../simple-exchange';
+import { SimpleExchange } from '../simple-exchange';
 import FluidDexPoolABI from '../../abi/fluid-dex/fluid-dex.abi.json';
 import { FluidDexConfig, Adapters, FLUID_DEX_GAS_COST } from './config';
 import { FluidDexEventPool } from './fluid-dex-pool';
 import { FluidDexCommonAddresses } from './fluid-dex-generate-pool';
-import { applyTransferFee } from '../../lib/token-transfer-fee';
 import { getDexKeysWithNetwork, getBigIntPow } from '../../utils';
 import { extractReturnAmountPosition } from '../../executor/utils';
-import ResolverABI from '../../abi/fluid-dex/resolver.abi.json';
-import { MultiResult, MultiCallParams } from '../../lib/multi-wrapper';
-import { BytesLike } from 'ethers/lib/utils';
-import {
-  generalDecoder,
-  extractSuccessAndValue,
-  addressDecode,
-} from '../../lib/decoders';
+import { MultiResult } from '../../lib/multi-wrapper';
+import { generalDecoder } from '../../lib/decoders';
 // @ts-ignore
 import { Tokens } from '../../../tests/constants-e2e';
 
@@ -59,9 +46,9 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
 
   pools: FluidDexPool[];
 
-  readonly FluidCommonAddresses: FluidDexCommonAddresses;
+  readonly fluidCommonAddresses: FluidDexCommonAddresses;
 
-  readonly iFluidDexPool: Interface;
+  readonly fluidDexPoolIface: Interface;
 
   protected adapters;
 
@@ -74,7 +61,7 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
   ) {
     super(dexHelper, dexKey);
     this.logger = dexHelper.getLogger(dexKey);
-    this.FluidCommonAddresses = new FluidDexCommonAddresses(
+    this.fluidCommonAddresses = new FluidDexCommonAddresses(
       'FluidDex',
       FluidDexConfig['FluidDex'][network].commonAddresses,
       network,
@@ -83,12 +70,14 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     );
     this.pools = FluidDexConfig['FluidDex'][network].pools;
     this.adapters = Adapters[network] || {};
-    this.iFluidDexPool = new Interface(FluidDexPoolABI);
+    this.fluidDexPoolIface = new Interface(FluidDexPoolABI);
   }
 
-  async fetchFluidDexPools(blockNumber: number): Promise<FluidDexPool[]> {
+  private async fetchFluidDexPools(
+    blockNumber: number,
+  ): Promise<FluidDexPool[]> {
     const poolsFromResolver =
-      await this.FluidCommonAddresses.getStateOrGenerate(blockNumber, false);
+      await this.fluidCommonAddresses.getStateOrGenerate(blockNumber, false);
 
     return poolsFromResolver.map(pool => ({
       id: `FluidDex_${pool.address}`,
@@ -105,7 +94,7 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
         this.eventPools[pool.id] = new FluidDexEventPool(
           'FluidDex',
           pool.address,
-          this.FluidCommonAddresses.commonAddresses,
+          this.fluidCommonAddresses.commonAddresses,
           this.network,
           this.dexHelper,
           this.logger,
@@ -218,41 +207,24 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
         return null;
       }
 
-      // const state = await eventPool.generateState(blockNumber);
       const state = await eventPool.getStateOrGenerate(blockNumber);
 
-      const swap0To1: boolean = side === SwapSide.SELL;
-
       const prices = amounts.map(amount => {
-        if (side === SwapSide.SELL) {
-          return this.swapIn(
-            srcToken.address.toLowerCase() === pool.token0.toLowerCase(),
-            amount,
-            state.collateralReserves,
-            state.debtReserves,
-            srcToken.decimals,
-            destToken.decimals,
-            BigInt(state.fee),
-          );
-        } else {
-          return this.swapOut(
-            !(srcToken.address.toLowerCase() === pool.token0.toLowerCase()),
-            amount,
-            state.collateralReserves,
-            state.debtReserves,
-            srcToken.decimals,
-            destToken.decimals,
-            BigInt(state.fee),
-          );
-        }
+        return this.swapIn(
+          srcToken.address.toLowerCase() === pool.token0.toLowerCase(),
+          amount,
+          state.collateralReserves,
+          state.debtReserves,
+          srcToken.decimals,
+          destToken.decimals,
+          BigInt(state.fee),
+        );
       });
 
       return [
         {
           prices: prices.filter((price): price is bigint => price !== null), // to be done
-          unit: getBigIntPow(
-            (side === SwapSide.SELL ? destToken : srcToken).decimals,
-          ), // to be done
+          unit: getBigIntPow(destToken.decimals),
           data: {
             colReserves: state.collateralReserves,
             debtReserves: state.debtReserves,
@@ -433,38 +405,27 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
 
     if (side === SwapSide.BUY) throw new Error(`Buy not supported`);
 
-    let method: string;
     let args: any;
     let returnAmountPos: number | undefined = undefined;
 
-    const deadline = getLocalDeadlineAsFriendlyPlaceholder();
-
-    method = side == SwapSide.SELL ? 'swapIn' : 'swapOut';
+    const method = 'swapIn';
 
     returnAmountPos = extractReturnAmountPosition(
-      this.iFluidDexPool,
+      this.fluidDexPoolIface,
       method,
-      side == SwapSide.SELL ? 'amountOut_' : 'amountIn_',
+      'amountOut_',
       1,
     );
 
     const pool = await this.getPoolByTokenPair(srcToken, destToken);
 
-    if (side == SwapSide.SELL) {
-      if (pool!.token0.toLowerCase() != srcToken.toLowerCase()) {
-        args = [false, BigInt(srcAmount), BigInt(destAmount), recipient];
-      } else {
-        args = [true, BigInt(srcAmount), BigInt(destAmount), recipient];
-      }
+    if (pool!.token0.toLowerCase() != srcToken.toLowerCase()) {
+      args = [false, BigInt(srcAmount), BigInt(destAmount), recipient];
     } else {
-      if (pool!.token0.toLowerCase() != srcToken.toLowerCase()) {
-        args = [true, BigInt(srcAmount), 2n * BigInt(srcAmount), recipient];
-      } else {
-        args = [false, BigInt(srcAmount), 2n * BigInt(srcAmount), recipient];
-      }
+      args = [true, BigInt(srcAmount), BigInt(destAmount), recipient];
     }
 
-    const swapData = this.iFluidDexPool.encodeFunctionData(method, args);
+    const swapData = this.fluidDexPoolIface.encodeFunctionData(method, args);
 
     return {
       needWrapNative: this.needWrapNative,
@@ -485,7 +446,7 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
    * @param outDecimals - The number of decimals for the output token.
    * @returns The calculated output amount (as a BigInt).
    */
-  swapIn(
+  private swapIn(
     swap0To1: boolean,
     amountIn: bigint,
     colReserves: CollateralReserves,
@@ -710,7 +671,7 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
    * @note If a > t then entire trade route through col pool and col pool arbitrage with debt pool.
    * @note If a > 0 & a < t then swap will route through both pools.
    */
-  swapRoutingIn(
+  private swapRoutingIn(
     t: bigint,
     x: bigint,
     y: bigint,
@@ -744,7 +705,7 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
    * @param {number} fee - The fee for the swap. 1e4 = 1%
    * @returns {bigint} amountIn - The calculated input amount required for the swap.
    */
-  swapOut(
+  private swapOut(
     swap0to1: boolean,
     amountOut: bigint,
     colReserves: CollateralReserves,
@@ -779,7 +740,7 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
    * @param {DebtReserves} debtReserves - The reserves of the debt pool.
    * @returns {bigint} The calculated input amount required for the swap.
    */
-  swapOutAdjusted(
+  private swapOutAdjusted(
     swap0to1: boolean,
     amountOut: bigint,
     colReserves: CollateralReserves,

--- a/src/dex/fluid-dex/types.ts
+++ b/src/dex/fluid-dex/types.ts
@@ -1,0 +1,66 @@
+import { Address } from '../../types';
+
+export type FluidDexPoolState = {
+  collateralReserves: CollateralReserves;
+  debtReserves: DebtReserves;
+  fee: number;
+};
+
+export type CollateralReserves = {
+  token0RealReserves: bigint; // Changed from uint to bigint
+  token1RealReserves: bigint; // Changed from uint to bigint
+  token0ImaginaryReserves: bigint; // Changed from uint to bigint
+  token1ImaginaryReserves: bigint; // Changed from uint to bigint
+};
+
+export type DebtReserves = {
+  token0Debt: bigint; // Changed from uint to bigint
+  token1Debt: bigint; // Changed from uint to bigint
+  token0RealReserves: bigint; // Changed from uint to bigint
+  token1RealReserves: bigint; // Changed from uint to bigint
+  token0ImaginaryReserves: bigint; // Changed from uint to bigint
+  token1ImaginaryReserves: bigint; // Changed from uint to bigint
+};
+
+export interface PoolWithReserves {
+  pool: string;
+  token0_: string;
+  token1_: string;
+  fee: number;
+  collateralReserves: CollateralReserves;
+  debtReserves: DebtReserves;
+}
+
+export type FluidDexData = {
+  colReserves: CollateralReserves;
+  debtReserves: DebtReserves;
+  exchange: Address;
+};
+
+// Each pool has a contract address and token pairs.
+export type FluidDexPool = {
+  id: string;
+  address: Address;
+  token0: Address;
+  token1: Address;
+};
+
+export type DexParams = {
+  // TODO: DexParams is set of parameters the can
+  // be used to initiate a DEX fork.
+  // Complete me!
+  commonAddresses: commonAddresses;
+  pools: FluidDexPool[];
+};
+
+export type commonAddresses = {
+  liquidityProxy: Address;
+  resolver: Address;
+  dexFactory: Address;
+};
+
+export type Pool = {
+  address: Address;
+  token0: Address;
+  token1: Address;
+};

--- a/src/dex/fluid-dex/types.ts
+++ b/src/dex/fluid-dex/types.ts
@@ -7,25 +7,25 @@ export type FluidDexPoolState = {
 };
 
 export type CollateralReserves = {
-  token0RealReserves: bigint; // Changed from uint to bigint
-  token1RealReserves: bigint; // Changed from uint to bigint
-  token0ImaginaryReserves: bigint; // Changed from uint to bigint
-  token1ImaginaryReserves: bigint; // Changed from uint to bigint
+  token0RealReserves: bigint;
+  token1RealReserves: bigint;
+  token0ImaginaryReserves: bigint;
+  token1ImaginaryReserves: bigint;
 };
 
 export type DebtReserves = {
-  token0Debt: bigint; // Changed from uint to bigint
-  token1Debt: bigint; // Changed from uint to bigint
-  token0RealReserves: bigint; // Changed from uint to bigint
-  token1RealReserves: bigint; // Changed from uint to bigint
-  token0ImaginaryReserves: bigint; // Changed from uint to bigint
-  token1ImaginaryReserves: bigint; // Changed from uint to bigint
+  token0Debt: bigint;
+  token1Debt: bigint;
+  token0RealReserves: bigint;
+  token1RealReserves: bigint;
+  token0ImaginaryReserves: bigint;
+  token1ImaginaryReserves: bigint;
 };
 
 export interface PoolWithReserves {
   pool: string;
-  token0_: string;
-  token1_: string;
+  token0: string;
+  token1: string;
   fee: number;
   collateralReserves: CollateralReserves;
   debtReserves: DebtReserves;
@@ -46,14 +46,11 @@ export type FluidDexPool = {
 };
 
 export type DexParams = {
-  // TODO: DexParams is set of parameters the can
-  // be used to initiate a DEX fork.
-  // Complete me!
-  commonAddresses: commonAddresses;
+  commonAddresses: CommonAddresses;
   pools: FluidDexPool[];
 };
 
-export type commonAddresses = {
+export type CommonAddresses = {
   liquidityProxy: Address;
   resolver: Address;
   dexFactory: Address;

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -85,6 +85,7 @@ import { Spark } from './spark/spark';
 import { VelodromeSlipstream } from './uniswap-v3/forks/velodrome-slipstream/velodrome-slipstream';
 import { AaveV3Stata } from './aave-v3-stata/aave-v3-stata';
 import { OSwap } from './oswap/oswap';
+import { FluidDex } from './fluid-dex/fluid-dex';
 import { ConcentratorArusd } from './concentrator-arusd/concentrator-arusd';
 import { FxProtocolRusd } from './fx-protocol-rusd/fx-protocol-rusd';
 import { AaveGsm } from './aave-gsm/aave-gsm';
@@ -179,6 +180,7 @@ const Dexes = [
   UsualBond,
   StkGHO,
   SkyConverter,
+  FluidDex,
 ];
 
 export type LegacyDexConstructor = new (dexHelper: IDexHelper) => IDexTxBuilder<

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -7,6 +7,7 @@ import {
   allowedFn,
   _balancesFn,
   _allowancesFn,
+  // @ts-ignore
 } from '../tests/smart-tokens';
 import { Address } from '../src/types';
 import { ETHER_ADDRESS, Network } from '../src/constants';
@@ -1584,7 +1585,7 @@ export const Holders: {
     BADGER: '0x34e2741a3f8483dbe5231f61c005110ff4b9f50a',
     STETH: '0x6663613FbD927cE78abBF7F5Ca7e2c3FE0d96d18',
     SUSHI: '0x8a108e4761386c94b8d2f98A5fFe13E472cFE76a',
-    wstETH: '0x5fEC2f34D80ED82370F733043B6A536d7e9D7f8d',
+    wstETH: '0x3c22ec75ea5D745c78fc84762F7F1E6D82a2c5BF',
     WETH: '0x6B44ba0a126a2A1a8aa6cD1AdeeD002e141Bcd44',
     USDT: '0xAf64555DDD61FcF7D094824dd9B4eBea165aFc5b',
     XAUT: '0xc4e161e8d8a4bc4ac762ab33a28bbac5474203d7',
@@ -1836,7 +1837,7 @@ export const Holders: {
     LINK: '0x7f1fa204bb700853d36994da19f830b6ad18455c',
     DMT: '0x40414f138eb2ef938e6c3629897ef99d4464d4e8',
     PENDLE: '0x5bdf85216ec1e38d6458c870992a69e38e03f7ef',
-    wstETH: '0x27edc7700f1820cb38ec3bbb84c542945f21b5a1',
+    wstETH: '0x3c22ec75ea5D745c78fc84762F7F1E6D82a2c5BF',
     EURA: '0x6dd7b830896b56812aa667bdd14b71c8b3252f8e',
     stEUR: '0xE588611e7A2392507879E3be80531654b85C16aA',
     USDA: '0xa86ff337db9107b54862d30d1a598f8be847b05e',


### PR DESCRIPTION
This PR integrates the very soon to be launched Instadapp Fluid Dex.
It uses our on-chain resolvers to fetch all required data. 

It only implements SELL for now, we will add support for BUY in a separate later PR

Todo: 
- Adapters in config.ts: what has to be set here?
- Update addresses in config.ts from Test deployment to final deployment once ready (should be done by ~Oct 18) 
- Update gas cost constant, likely becomes 150k 
