### PR TITLE
fix/BACK 1737

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "3.9.4-aave-v3-approval.0",
+  "version": "3.9.4-aave-v3-maverick-v1-fixes.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "3.9.3",
+  "version": "3.9.4-aave-v3-approval.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "3.9.4-aave-v3-maverick-v1-fixes.0",
+  "version": "3.9.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/aave-v3/aave-v3.ts
+++ b/src/dex/aave-v3/aave-v3.ts
@@ -10,7 +10,12 @@ import {
   Logger,
   DexExchangeParam,
 } from '../../types';
-import { SwapSide, Network, NULL_ADDRESS } from '../../constants';
+import {
+  SwapSide,
+  Network,
+  NULL_ADDRESS,
+  ETHER_ADDRESS,
+} from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { getDexKeysWithNetwork, isETHAddress, getBigIntPow } from '../../utils';
 import { IDex } from '../../dex/idex';
@@ -246,7 +251,8 @@ export class AaveV3 extends SimpleExchange implements IDex<Data, Param> {
       exchangeData,
       targetExchange: swapCallee,
       returnAmountPos: undefined,
-      skipApproval: data.fromAToken,
+      skipApproval:
+        !data.fromAToken && srcToken.toLowerCase() === ETHER_ADDRESS,
     };
   }
 

--- a/src/dex/maverick-v1/maverick-v1-pool.ts
+++ b/src/dex/maverick-v1/maverick-v1-pool.ts
@@ -80,7 +80,7 @@ export class MaverickV1EventPool extends StatefulEventSubscriber<PoolState> {
 
     this.poolMath = new MaverickPoolMath(
       parentName,
-      BigInt(fee * 1e18),
+      BigInt((fee * 1e18).toFixed(0)),
       BigInt(tickSpacing),
       BigInt(protocolFeeRatio),
     );


### PR DESCRIPTION
- **fix: skip approval only for `toAToken && src=ETH` case on AaveV3**
- **3.9.4-aave-v3-approval.0**
- **fix: round fee before converting to BigInt on maverick-v1**
- **3.9.4-aave-v3-maverick-v1-fixes.0**
