### PR TITLE
BACK-1754

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "3.11.1-algebra.0",
+  "version": "3.11.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "3.11.0",
+  "version": "3.11.1-algebra.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/algebra/algebra-pool-v1_1.ts
+++ b/src/dex/algebra/algebra-pool-v1_1.ts
@@ -38,7 +38,6 @@ import {
   _reduceTickBitmap,
   _reduceTicks,
 } from '../uniswap-v3/contract-math/utils';
-import { Constants } from './lib/Constants';
 import { Network, NULL_ADDRESS } from '../../constants';
 import { TickTable } from './lib/TickTable';
 import {
@@ -336,7 +335,8 @@ export class AlgebraEventPoolV1_1 extends StatefulEventSubscriber<PoolStateV1_1>
       globalState: { tick },
     } = _stateWithoutTicksAndTickBitmap;
     const currentBitmapIndex = int16(
-      (BigInt(tick) / Constants.TICK_SPACING) >> 8n,
+      (BigInt(tick) / BigInt(_stateWithoutTicksAndTickBitmap.tickSpacing)) >>
+        8n,
     );
 
     const buffer = this.getBitmapRangeToRequest();
@@ -633,7 +633,7 @@ export class AlgebraEventPoolV1_1 extends StatefulEventSubscriber<PoolStateV1_1>
     };
     const currentTick = globalState.tick;
     const startTickBitmap = TickTable.position(
-      BigInt(currentTick) / Constants.TICK_SPACING,
+      BigInt(currentTick) / BigInt(_state.tickSpacing),
     )[0];
 
     return {
@@ -641,8 +641,8 @@ export class AlgebraEventPoolV1_1 extends StatefulEventSubscriber<PoolStateV1_1>
       blockTimestamp: bigIntify(_state.blockTimestamp),
       globalState,
       liquidity: bigIntify(_state.liquidity),
-      tickSpacing: Constants.TICK_SPACING,
-      maxLiquidityPerTick: Constants.MAX_LIQUIDITY_PER_TICK,
+      tickSpacing: bigIntify(_state.tickSpacing),
+      maxLiquidityPerTick: bigIntify(_state.maxLiquidityPerTick),
       tickBitmap,
       ticks,
       startTickBitmap,

--- a/src/dex/algebra/lib/AlgebraMath.ts
+++ b/src/dex/algebra/lib/AlgebraMath.ts
@@ -579,7 +579,11 @@ class AlgebraMathClass {
       tickCount: 0,
     };
     // swap until there is remaining input or output tokens or we reach the price limit
+    let iterationsCount = 0;
     while (true) {
+      iterationsCount++;
+      _require(iterationsCount < 100, 'Max iteration reached on AlgebraMath');
+
       step.stepSqrtPrice = currentPrice;
 
       //equivalent of tickTable.nextTickInTheSameRow(currentTick, zeroToOne);

--- a/src/dex/algebra/lib/AlgebraMath.ts
+++ b/src/dex/algebra/lib/AlgebraMath.ts
@@ -651,11 +651,7 @@ class AlgebraMathClass {
       }
 
       // check stop condition
-      if (
-        amountRequired == 0n ||
-        currentPrice == newSqrtPriceX96 ||
-        currentTick === newTick // deviation from contract
-      ) {
+      if (amountRequired == 0n || currentPrice == newSqrtPriceX96) {
         break;
       }
     }


### PR DESCRIPTION
- **fix: use relevant tickSpacing and maxLiquidityPerTick on ALgebraPoolV1.1**
- **fix: remove currentTick === newTick check (leads to broken event handling)**
- **3.11.1-algebra.0**
