### PR TITLE
fix: pass bebop auth name through env

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "scripts": {
     "init-integration": "ts-node scripts/dex-integration.ts init",
     "test-integration": "ts-node scripts/dex-integration.ts test",
-    "play:bebop": "ts-node src/dex/bebop/play.ts",
     "build": "yarn check:pq && yarn check:es && tsc",
     "watch": "tsc -w",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "init-integration": "ts-node scripts/dex-integration.ts init",
     "test-integration": "ts-node scripts/dex-integration.ts test",
+    "play:bebop": "ts-node src/dex/bebop/play.ts",
     "build": "yarn check:pq && yarn check:es && tsc",
     "watch": "tsc -w",
     "test": "jest",

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,7 @@ type BaseConfig = {
   idleDaoAuthToken?: string;
   swaapV2AuthToken?: string;
   dexalotAuthToken?: string;
+  bebopAuthName?: string;
   bebopAuthToken?: string;
   forceRpcFallbackDexs: string[];
 };
@@ -74,6 +75,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     rpcPollingBlocksBackToTriggerUpdate: 0,
     swaapV2AuthToken: process.env.API_KEY_SWAAP_V2_AUTH_TOKEN || '',
     hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
+    bebopAuthName: process.env.API_KEY_BEBOP_AUTH_NAME || '',
     bebopAuthToken: process.env.API_KEY_BEBOP_AUTH_TOKEN || '',
     idleDaoAuthToken: process.env.API_KEY_IDLEDAO_AUTH_TOKEN || '',
     hashFlowDisabledMMs:
@@ -147,6 +149,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     multicallV2Address: '0xC50F4c1E81c873B2204D7eFf7069Ffec6Fbe136D',
     privateHttpProvider: process.env.HTTP_PROVIDER_56,
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
+    bebopAuthName: process.env.API_KEY_BEBOP_AUTH_NAME || '',
     bebopAuthToken: process.env.API_KEY_BEBOP_AUTH_TOKEN || '',
     executorsAddresses: {
       Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
@@ -301,6 +304,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
       Executor03: '0xe009F00e200A090090fC70e02d70B232000c0802',
     },
     dexalotAuthToken: process.env.API_KEY_DEXALOT_AUTH_TOKEN || '',
+    bebopAuthName: process.env.API_KEY_BEBOP_AUTH_NAME || '',
     bebopAuthToken: process.env.API_KEY_BEBOP_AUTH_TOKEN || '',
     adapterAddresses: {
       ArbitrumAdapter01: '0x369A2FDb910d432f0a07381a5E3d27572c876713',
@@ -348,6 +352,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     uniswapV2ExchangeRouterAddress:
       '0xB41dD984730dAf82f5C41489E21ac79D5e3B61bC',
     uniswapV3EventLoggingSampleRate: 0,
+    bebopAuthName: process.env.API_KEY_BEBOP_AUTH_NAME || '',
     bebopAuthToken: process.env.API_KEY_BEBOP_AUTH_TOKEN || '',
     rfqConfigs: {},
     rpcPollingMaxAllowedStateDelayInBlocks: 5,
@@ -431,6 +436,7 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     multicallV2Address: '0xeDF6D2a16e8081F777eB623EeB4411466556aF3d',
     privateHttpProvider: process.env.HTTP_PROVIDER_8453,
     dexalotAuthToken: process.env.API_KEY_DEXALOT_AUTH_TOKEN || '',
+    bebopAuthName: process.env.API_KEY_BEBOP_AUTH_NAME || '',
     bebopAuthToken: process.env.API_KEY_BEBOP_AUTH_TOKEN || '',
     hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
     swaapV2AuthToken: process.env.API_KEY_SWAAP_V2_AUTH_TOKEN || '',
@@ -528,6 +534,7 @@ export function generateConfig(network: number): Config {
     idleDaoAuthToken: baseConfig.idleDaoAuthToken,
     swaapV2AuthToken: baseConfig.swaapV2AuthToken,
     dexalotAuthToken: baseConfig.dexalotAuthToken,
+    bebopAuthName: baseConfig.bebopAuthName,
     bebopAuthToken: baseConfig.bebopAuthToken,
     hashFlowDisabledMMs: baseConfig.hashFlowDisabledMMs,
     forceRpcFallbackDexs: baseConfig.forceRpcFallbackDexs,

--- a/src/dex/bebop/bebop.ts
+++ b/src/dex/bebop/bebop.ts
@@ -35,7 +35,6 @@ import { Interface } from 'ethers/lib/utils';
 import { RateFetcher } from './rate-fetcher';
 import {
   BEBOP_API_URL,
-  BEBOP_AUTH_NAME,
   BEBOP_ERRORS_CACHE_KEY,
   BEBOP_GAS_COST,
   BEBOP_INIT_TIMEOUT_MS,
@@ -77,6 +76,7 @@ export class Bebop extends SimpleExchange implements IDex<BebopData> {
   private tokensAddrCacheKey: string;
 
   private bebopAuthToken: string;
+  private bebopAuthName: string;
 
   logger: Logger;
 
@@ -94,9 +94,11 @@ export class Bebop extends SimpleExchange implements IDex<BebopData> {
     this.pricesCacheKey = `prices`;
     this.tokensAddrCacheKey = `tokens_addr`;
     const token = this.dexHelper.config.data.bebopAuthToken;
-    if (!token) {
-      throw new Error('Bebop auth token is not set');
+    const name = this.dexHelper.config.data.bebopAuthName;
+    if (!token || !name) {
+      throw new Error('Bebop auth token and name is not set');
     }
+    this.bebopAuthName = name;
     this.bebopAuthToken = token;
 
     this.rateFetcher = new RateFetcher(
@@ -122,7 +124,7 @@ export class Bebop extends SimpleExchange implements IDex<BebopData> {
               BEBOP_WS_API_URL +
               `/pmm/${BebopConfig['Bebop'][network].chainName}/v3/pricing?format=protobuf`,
             headers: {
-              name: BEBOP_AUTH_NAME,
+              name: this.bebopAuthName,
               authorization: this.bebopAuthToken,
             },
           },
@@ -687,7 +689,7 @@ export class Bebop extends SimpleExchange implements IDex<BebopData> {
       receiver_address: utils.getAddress(options.recipient),
       gasless: false,
       skip_validation: true,
-      source: BEBOP_AUTH_NAME,
+      source: this.bebopAuthName,
     };
 
     try {

--- a/src/dex/bebop/constants.ts
+++ b/src/dex/bebop/constants.ts
@@ -5,7 +5,6 @@ export const BEBOP_TOKENS_POLLING_INTERVAL_MS = 30 * 1000;
 export const BEBOP_API_URL = 'https://api.bebop.xyz';
 export const BEBOP_WS_API_URL = 'wss://api.bebop.xyz';
 export const BEBOP_GAS_COST = 120_000;
-export const BEBOP_AUTH_NAME = 'paraswap';
 export const BEBOP_QUOTE_TIMEOUT_MS = 3000;
 export const BEBOP_ERRORS_CACHE_KEY = 'errors';
 export const BEBOP_RESTRICTED_CACHE_KEY = 'restricted';

--- a/src/types.ts
+++ b/src/types.ts
@@ -312,6 +312,7 @@ export type Config = {
   uniswapV3EventLoggingSampleRate?: number;
   swaapV2AuthToken?: string;
   dexalotAuthToken?: string;
+  bebopAuthName: string;
   bebopAuthToken?: string;
   idleDaoAuthToken?: string;
   forceRpcFallbackDexs: string[];


### PR DESCRIPTION
Pass auth name in environment so separate keys can be used for test environments