### PR TITLE
Balancer v3 nested erc4626

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.0.23",
+  "version": "4.0.24-bal-v3-nested-erc4626.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/balancer-v3/getGasCost.ts
+++ b/src/dex/balancer-v3/getGasCost.ts
@@ -14,15 +14,7 @@ const PARTIAL_BOOSTED_SWAP_GAS_COST = 259815;
 const BUFFER_WRAP_UNWRAP_GAS_COST = 155921;
 
 export function getGasCost(steps: Step[]): number {
-  if (steps.length === 2) {
-    // Partial boosted/buffer swap:
-    // token[wrap]wrappedToken[swap]wrappedToken or
-    // wrappedToken[swap]wrappedToken[unwrap]token
-    return PARTIAL_BOOSTED_SWAP_GAS_COST;
-  } else if (steps.length === 3) {
-    // Full boosted/buffer swap: token[wrap]wrappedToken[swap]wrappedToken[unwrap]token
-    return FULL_BOOSTED_SWAP_GAS_COST;
-  } else {
+  if (steps.length === 1) {
     switch (steps[0].poolState.poolType) {
       case 'WEIGHTED':
         return WEIGHTED_GAS_COST;
@@ -33,5 +25,18 @@ export function getGasCost(steps: Step[]): number {
       default:
         return WEIGHTED_GAS_COST;
     }
+  } else if (steps.length === 2) {
+    // Partial boosted/buffer swap:
+    // token[wrap]wrappedToken[swap]wrappedToken or
+    // wrappedToken[swap]wrappedToken[unwrap]token
+    return PARTIAL_BOOSTED_SWAP_GAS_COST;
+  } else if (steps.length === 3) {
+    // Full boosted/buffer swap: token[wrap]wrappedToken[swap]wrappedToken[unwrap]token
+    return FULL_BOOSTED_SWAP_GAS_COST;
+  } else {
+    return (
+      FULL_BOOSTED_SWAP_GAS_COST +
+      (steps.length - 3) * BUFFER_WRAP_UNWRAP_GAS_COST
+    );
   }
 }

--- a/src/dex/balancer-v3/getPoolsApi.ts
+++ b/src/dex/balancer-v3/getPoolsApi.ts
@@ -14,6 +14,7 @@ interface PoolToken {
   isErc4626: boolean;
   underlyingToken: {
     address: string;
+    underlyingTokenAddress: string | null;
   } | null;
 }
 
@@ -67,6 +68,7 @@ function createQuery(
           isErc4626
           underlyingToken {
             address
+            underlyingTokenAddress
           }
         }
       }
@@ -81,6 +83,9 @@ function toImmutablePoolStateMap(pools: Pool[]): ImmutablePoolStateMap {
       tokens: pool.poolTokens.map(t => t.address),
       tokensUnderlying: pool.poolTokens.map(t =>
         t.underlyingToken ? t.underlyingToken.address : null,
+      ),
+      tokensNestedERC4626Underlying: pool.poolTokens.map(t =>
+        t.underlyingToken ? t.underlyingToken.underlyingTokenAddress : null,
       ),
       weights: pool.poolTokens.map(t =>
         t.weight ? parseUnits(t.weight, 18).toBigInt() : 0n,

--- a/src/dex/balancer-v3/getTopPoolsApi.ts
+++ b/src/dex/balancer-v3/getTopPoolsApi.ts
@@ -7,6 +7,7 @@ interface PoolToken {
   underlyingToken?: {
     address: string;
     decimals: number;
+    underlyingTokenAddress: string;
   };
 }
 
@@ -63,6 +64,7 @@ function createQuery(
           underlyingToken {
             address
             decimals
+            underlyingTokenAddress
           }
         }
         dynamicData {

--- a/src/dex/balancer-v3/types.ts
+++ b/src/dex/balancer-v3/types.ts
@@ -9,6 +9,7 @@ export type CommonImmutablePoolState = {
   tokens: string[];
   // For boosted pools underlying is the unwrapped token, e.g. USDC/DAI
   tokensUnderlying: (string | null)[];
+  tokensNestedERC4626Underlying: (string | null)[];
   weights: bigint[];
   // TODO re-introduce this once added to API
   // scalingFactors: bigint[];
@@ -19,6 +20,7 @@ export type CommonImmutablePoolState = {
 export interface CommonMutableState {
   tokenRates: bigint[];
   erc4626Rates: (bigint | null)[];
+  erc4626NestedRates: (bigint | null)[];
   balancesLiveScaled18: bigint[];
   swapFee: bigint;
   aggregateSwapFee: bigint;
@@ -78,10 +80,13 @@ export type DexParams = {
   balancerBatchRouterAddress: string;
 };
 
+export enum TokenType {
+  MainToken = 1,
+  ERC4626,
+  ERC4626Nested,
+}
+
 export type TokenInfo = {
-  isBoosted: boolean;
-  underlyingToken: string | null;
-  mainToken: string;
   index: number;
-  rate: bigint;
+  type: TokenType;
 };

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -581,6 +581,21 @@ export const Tokens: {
       decimals: 6,
       symbol: 'USUALM',
     },
+    USDL: {
+      address: '0xbdC7c08592Ee4aa51D06C27Ee23D5087D65aDbcD',
+      decimals: 18,
+      symbol: 'USDL',
+    },
+    csUSDL: {
+      address: '0xbEeFc011e94f43b8B7b455eBaB290C7Ab4E216f1',
+      decimals: 18,
+      symbol: 'csUSDL',
+    },
+    csUSDC: {
+      address: '0x7204b7dbf9412567835633b6f00c3edc3a8d6330',
+      decimals: 18,
+      symbol: 'csUSDC',
+    },
   },
   [Network.POLYGON]: {
     jGBP: {


### PR DESCRIPTION
Adds support for nested ERC4626 swaps.

It is possible to have nested ERC4626 tokens in Balancer V3 pools, for example this pool:
https://balancer.fi/pools/ethereum/v3/0x10a04efba5b880e169920fd4348527c64fb29d4d
With:
csUSDC: 0x7204b7dbf9412567835633b6f00c3edc3a8d6330 -- ERC4626 Pool token
  - USDC: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48 -- underlying
csUSDL: 0xbeefc011e94f43b8b7b455ebab290c7ab4e216f1 -- ERC4626 Pool token
  - wUSDL: 0x7751e2f4b8ae93ef6b79d86419d42fe3295a4559 -- ERC4626 underlying
    - USDL: 0xbdc7c08592ee4aa51d06c27ee23d5087d65adbcd -- underlying
The most useful swap paths in this case would be USDL<>USDC. This can be supported by simply adding an extra buffer step to the batch swap to wrap/unwrap as needed.

- Fetch nested ERC4626 addresses from API and include these for token in/out consideration
- Update ERC4626 onchain rate call to include nested
- Handle extra wrap/unwrap steps for nested ERC4626 
- Add integration tests for USDC<>USDL