### PR TITLE
fix(pre-commit): remove duplicate processes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn checks && yarn build
+yarn checks


### PR DESCRIPTION
Hi Paraswap team,

I noticed Husky's pre-commit was running `yarn checks` and `yarn build` and both do exactly the same. Consider removing one of them.