### PR TITLE
Cables fix volumes

### DIFF
--- a/src/dex/cables/cables.ts
+++ b/src/dex/cables/cables.ts
@@ -399,11 +399,15 @@ export class Cables extends SimpleExchange implements IDex<any> {
       let decimals = baseToken.decimals;
       let out_decimals = quoteToken.decimals;
 
-      let price = this.calculatePriceSwap(
-        orderbook,
-        Number(amt) / 10 ** decimals,
-        isInputQuote,
-      );
+      let price = 0;
+
+      try {
+        price = this.calculatePriceSwap(
+          orderbook,
+          Number(amt) / 10 ** decimals,
+          isInputQuote,
+        );
+      } catch (error) {}
       result.push(BigInt(Math.round(price * 10 ** out_decimals)));
     }
     return result;
@@ -487,11 +491,11 @@ export class Cables extends SimpleExchange implements IDex<any> {
 
     if (isQuote) {
       if (requiredQty > totalVolume) {
-        throw new Error(`Not enough liquidity`);
+        result = 0;
       }
     } else {
       if (result > totalVolume) {
-        throw new Error(`Not enough liquidity`);
+        result = 0;
       }
     }
 


### PR DESCRIPTION
Check for total liquidity for Cables.
Cables integration will return 0 prices if there are not enough volumes for a specified amounts.