### PR TITLE
Balancer api query update

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@0x/utils": "^4.5.2",
-    "@balancer-labs/balancer-maths": "^0.0.19",
+    "@balancer-labs/balancer-maths": "^0.0.24",
     "@balancer-labs/sor": "4.1.3",
     "@bgd-labs/aave-address-book": "4.9.0",
     "@ethersproject/abi": "^5.7.0",

--- a/src/dex/balancer-v3/balancer-api.test.ts
+++ b/src/dex/balancer-v3/balancer-api.test.ts
@@ -1,0 +1,94 @@
+// npx jest src/dex/balancer-v3/balancer-api.test.ts
+/* eslint-disable no-console */
+import { getPoolsApi } from './getPoolsApi';
+import { getTopPoolsApi, Pool } from './getTopPoolsApi';
+import { loadHooksConfig } from './hooks/loadHooksConfig';
+import { ImmutablePoolStateMap } from './types';
+
+const network = 1;
+const rstETHLidoPoolAddr = '0x121edb0badc036f5fc610d015ee14093c142313b';
+const stableSurgePoolAddr = '0x9ed5175aecb6653c1bdaa19793c16fd74fbeeb37';
+const hooksConfigMap = loadHooksConfig(network);
+
+describe('Balancer API Tests', function () {
+  describe('getPoolsApi', function () {
+    let pools: ImmutablePoolStateMap;
+
+    beforeAll(async () => {
+      pools = await getPoolsApi(network, hooksConfigMap);
+    });
+
+    it('should handle pool with ERC4626 not suitable for swaps', function () {
+      const expectedPool = {
+        poolAddress: rstETHLidoPoolAddr,
+        tokens: [
+          '0x775f661b0bd1739349b9a2a3ef60be277c5d2d29',
+          '0x7a4effd87c2f3c55ca251080b1343b605f327e3a',
+        ],
+        tokensUnderlying: ['0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0', null],
+        weights: [0n, 0n],
+        poolType: 'STABLE',
+        hookAddress: undefined,
+        hookType: undefined,
+        supportsUnbalancedLiquidity: true,
+      };
+      expect(pools[rstETHLidoPoolAddr]).toEqual(expectedPool);
+    });
+
+    it('should fetch pool with stableSurge hook', function () {
+      const expectedPool = {
+        poolAddress: stableSurgePoolAddr,
+        tokens: [
+          '0x775f661b0bd1739349b9a2a3ef60be277c5d2d29',
+          '0xd11c452fc99cf405034ee446803b6f6c1f6d5ed8',
+        ],
+        tokensUnderlying: ['0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0', null],
+        weights: [0n, 0n],
+        poolType: 'STABLE',
+        hookAddress: '0xb18fa0cb5de8cecb8899aae6e38b1b7ed77885da',
+        hookType: 'StableSurge',
+        supportsUnbalancedLiquidity: true,
+      };
+      expect(pools[stableSurgePoolAddr]).toEqual(expectedPool);
+    });
+  });
+
+  describe('getTopPoolsApi', function () {
+    let pools: Pool[];
+
+    beforeAll(async () => {
+      pools = await getTopPoolsApi(
+        network,
+        [rstETHLidoPoolAddr, stableSurgePoolAddr],
+        2,
+        hooksConfigMap,
+      );
+    });
+
+    it('should handle pool with ERC4626 not suitable for swaps', async function () {
+      const expectedPoolTokens = [
+        {
+          address: '0x775f661b0bd1739349b9a2a3ef60be277c5d2d29',
+          decimals: 18,
+          canUseBufferForSwaps: true,
+          underlyingToken: {
+            address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+            decimals: 18,
+          },
+        },
+        {
+          address: '0x7a4effd87c2f3c55ca251080b1343b605f327e3a',
+          decimals: 18,
+          canUseBufferForSwaps: false,
+          underlyingToken: null,
+        },
+      ];
+      const pool = pools.find(p => p.address === rstETHLidoPoolAddr);
+      expect(pool).toBeDefined();
+      expect(pool!.poolTokens).toEqual(expectedPoolTokens);
+    });
+    it('should fetch pool with stableSurge hook', async function () {
+      expect(pools.some(p => p.address === stableSurgePoolAddr)).toBe(true);
+    });
+  });
+});

--- a/src/dex/balancer-v3/config.ts
+++ b/src/dex/balancer-v3/config.ts
@@ -28,10 +28,12 @@ export const BalancerV3Config: DexConfigMap<DexParams> = {
       hooks: [
         {
           type: 'DirectionalFee',
+          apiName: 'DIRECTIONAL_FEE',
           address: '0xd68372e85d8a14afa5fdb3d506bf765939aaf382',
         },
         {
           type: 'StableSurge',
+          apiName: 'STABLE_SURGE',
           factory: '0x9eB9867C1d4B6fd3a7D0dAd3101b5A153b1107Ec', // Pools with StableSurge hook will always be deployed from this factory
           address: '0xc0cbcdd6b823a4f22aa6bbdde44c17e754266aef', // Address of the hook that will be used by pools
         },
@@ -45,6 +47,7 @@ export const BalancerV3Config: DexConfigMap<DexParams> = {
       hooks: [
         {
           type: 'StableSurge',
+          apiName: 'STABLE_SURGE',
           factory: '0x268E2EE1413D768b6e2dc3F5a4ddc9Ae03d9AF42', // Pools with StableSurge hook will always be deployed from this factory
           address: '0xe4f1878eC9710846E2B529C1b5037F8bA94583b1', // Address of the hook that will be used by pools
         },
@@ -58,6 +61,7 @@ export const BalancerV3Config: DexConfigMap<DexParams> = {
       hooks: [
         {
           type: 'StableSurge',
+          apiName: 'STABLE_SURGE',
           factory: '0xD53F5d8d926fb2a0f7Be614B16e649B8aC102D83', // Pools with StableSurge hook will always be deployed from this factory
           address: '0xb18fA0cb5DE8cecB8899AAE6e38b1B7ed77885dA', // Address of the hook that will be used by pools
         },
@@ -71,6 +75,7 @@ export const BalancerV3Config: DexConfigMap<DexParams> = {
       hooks: [
         {
           type: 'StableSurge',
+          apiName: 'STABLE_SURGE',
           factory: '0x86e67E115f96DF37239E0479441303De0de7bc2b', // Pools with StableSurge hook will always be deployed from this factory
           address: '0x0Fa0f9990D7969a7aE6f9961d663E4A201Ed6417', // Address of the hook that will be used by pools
         },
@@ -84,6 +89,7 @@ export const BalancerV3Config: DexConfigMap<DexParams> = {
       hooks: [
         {
           type: 'StableSurge',
+          apiName: 'STABLE_SURGE',
           factory: '0x4fb47126Fa83A8734991E41B942Ac29A3266C968', // Pools with StableSurge hook will always be deployed from this factory
           address: '0xb2007B8B7E0260042517f635CFd8E6dD2Dd7f007', // Address of the hook that will be used by pools
         },

--- a/src/dex/balancer-v3/hooks/directionalFeeHook.ts
+++ b/src/dex/balancer-v3/hooks/directionalFeeHook.ts
@@ -8,10 +8,12 @@ import { HookStateMap } from './balancer-hook-event-subscriber';
 
 export const DirectionalFee = {
   type: 'DirectionalFee' as const,
+  apiName: 'DIRECTIONAL_FEE' as const,
 };
 
 export type DirectionalFeeConfig = {
   type: typeof DirectionalFee.type;
+  apiName: typeof DirectionalFee.apiName;
   address: string;
 };
 

--- a/src/dex/balancer-v3/hooks/stableSurgeHook.ts
+++ b/src/dex/balancer-v3/hooks/stableSurgeHook.ts
@@ -10,10 +10,12 @@ import { Logger } from 'log4js';
 
 export const StableSurge = {
   type: 'StableSurge' as const,
+  apiName: 'STABLE_SURGE' as const,
 };
 
 export type StableSurgeConfig = {
   type: typeof StableSurge.type;
+  apiName: typeof StableSurge.apiName;
   factory: string;
   address: string;
 };

--- a/src/dex/balancer-v3/utils.ts
+++ b/src/dex/balancer-v3/utils.ts
@@ -1,0 +1,11 @@
+import { HooksConfigMap } from './hooks/balancer-hook-event-subscriber';
+
+export function getUniqueHookNames(hooksConfigMap: HooksConfigMap): string {
+  // Use Object.values to get all HookConfig objects
+  // Then map to extract just the names
+  // Use Set to get unique names
+  // Convert back to array and join with comma
+  return Array.from(
+    new Set(Object.values(hooksConfigMap).map(hook => hook.apiName)),
+  ).join(', ');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,10 +348,10 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@balancer-labs/balancer-maths@^0.0.22":
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/@balancer-labs/balancer-maths/-/balancer-maths-0.0.22.tgz#35293889880eb002162c81dfafe61ed9af168fac"
-  integrity sha512-0aJKWDhrseE8lrYXPG494ldMpsHbQpaUVGBcQ5L9gY2YSDwCvo0sxBBkEH1h+wHgSLANNII8XV9NLEEYV8jMoA==
+"@balancer-labs/balancer-maths@^0.0.24":
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/@balancer-labs/balancer-maths/-/balancer-maths-0.0.24.tgz#465a8b7bd5daaf6a43d3271da936331f66e61baa"
+  integrity sha512-M6iqcmLfR9CP1mw3R5w0FdtZkUk7M0vCJhloAfhE/xufbAZrCSoapFYlt/NMBKLDQoGNJ2FN5E4zpdLVsxhoow==
 
 "@balancer-labs/sor@4.1.3":
   version "4.1.3"


### PR DESCRIPTION
Update to use the new Balancer API endpoint: `aggregatorPools`. Its designed to replace `poolGetAggregatorPools`. It should be mostly backward compatible to make it easy to switch but has a new field: `canUseBufferForSwaps`. This will be dynamic, defaulting to false, and will only be changed to true if an ERC4626 token used in a pool has been manually confirmed to:
* be a valid ERC4626 (we check it passes some erc4626 fork tests)
* has an initialised Balancer V3 Buffer
So if canUseBufferForSwaps === true it should always be ok to use to swap.
