### PR TITLE
feature : arena dex

### DIFF
--- a/src/dex/uniswap-v2/config.ts
+++ b/src/dex/uniswap-v2/config.ts
@@ -337,6 +337,15 @@ export const UniswapV2Config: DexConfigMap<DexParams> = {
       feeCode: 30,
     },
   },
+  ArenaDex: {
+    [Network.AVALANCHE]: {
+      factoryAddress: '0x231DF4D421f1F9e0AAe9bA3634a87EBC87A09c39',
+      initCode:
+        '0x5eae27f407e5d417db3b2c176a2221883934aa8eecf365f8795afb69ee0b23d1',
+      poolGasCost: 120 * 1000,
+      feeCode: 30,
+    },
+  },
   PancakeSwap: {
     [Network.BSC]: {
       factoryAddress: '0xBCfCcbde45cE874adCB698cC183deBcF17952812',

--- a/src/dex/uniswap-v2/uniswap-v2-e2e-avalanche.test.ts
+++ b/src/dex/uniswap-v2/uniswap-v2-e2e-avalanche.test.ts
@@ -196,6 +196,89 @@ describe('UniswapV2 E2E Avalanche', () => {
     });
   });
 
+  describe('ArenaDex', () => {
+    const dexKey = 'ArenaDex';
+    describe('ArenaDex_simpleSwapSell', () => {
+      it('AVAX -> ARENA', async () => {
+        await testE2E(
+          tokens.ARENA,
+          tokens.WAVAX,
+          holders.ARENA,
+          '10000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+    });
+
+    describe('ArenaDex_simpleSwapBuy', () => {
+      it('AVAX -> ARENA', async () => {
+        await testE2E(
+          tokens.ARENA,
+          tokens.WAVAX,
+          holders.ARENA,
+          '20000000',
+          SwapSide.BUY,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+    });
+
+    describe('ArenaDex_swapExactAmountIn', () => {
+      it('ARENA -> WAVAX', async () => {
+        await testE2E(
+          tokens.ARENA,
+          tokens.WAVAX,
+          holders.ARENA,
+          '10000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.swapExactAmountIn,
+          network,
+          provider,
+        );
+      });
+    });
+
+    describe('ArenaDex_swapExactAmountOut', () => {
+      it('ARENA -> WAVAX', async () => {
+        await testE2E(
+          tokens.ARENA,
+          tokens.WAVAX,
+          holders.ARENA,
+          '10000001',
+          SwapSide.BUY,
+          dexKey,
+          ContractMethod.swapExactAmountOut,
+          network,
+          provider,
+        );
+      });
+    });
+
+    describe('ArenaDex_multiSwap', () => {
+      it('ARENA -> WAVAX', async () => {
+        await testE2E(
+          tokens.ARENA,
+          tokens.WAVAX,
+          holders.ARENA,
+          '1000000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.multiSwap,
+          network,
+          provider,
+        );
+      });
+    });
+  });
+
   describe('TraderJoe', () => {
     const dexKey = 'TraderJoe';
     describe('TraderJoe: Fail: (Joe: K)', () => {

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -1202,6 +1202,10 @@ export const Tokens: {
       address: '0x6ab707aca953edaefbc4fd23ba73294241490620',
       decimals: 6,
     },
+    ARENA: {
+      address: '0xB8d7710f7d8349A506b75dD184F05777c82dAd0C',
+      decimals: 18,
+    },
   },
   [Network.ARBITRUM]: {
     SEN: {
@@ -2048,6 +2052,7 @@ export const Holders: {
     PHAR: '0x654296D56532f62B7d91d335791d3c364a9385b5',
     stataUSDT: '', // no holders yet
     aaveUSDT: '0xB2d3ad6e99D2A043EF77e3812461Ad2D4Ae3da8B',
+    ARENA: '0xEBf747761b6942adaBAA58A594BA24931AfA0a3F',
   },
   [Network.ARBITRUM]: {
     SEN: '0x76d39045d856caf9bfae12ba611ca4a94449a4f1',


### PR DESCRIPTION
Arena Dex is a uniswap v2 fork with a slight modification to the pair contract. The only difference is, instead of keeping the fees in the pair contract, this forl sends them to a given treasury address. You can find the implementation [here](https://github.com/starsarenaorg/arena-dex-contracts)

We have added the tests under uniswapv2 avalanche forks.