### PR TITLE
Fix broken tests

### DIFF
--- a/src/dex/balancer-v3/balancer-api.test.ts
+++ b/src/dex/balancer-v3/balancer-api.test.ts
@@ -31,6 +31,20 @@ describe('Balancer API Tests', function () {
         hookAddress: undefined,
         hookType: undefined,
         supportsUnbalancedLiquidity: true,
+        dSq: 0n,
+        paramsAlpha: 0n,
+        paramsBeta: 0n,
+        paramsC: 0n,
+        paramsLambda: 0n,
+        paramsS: 0n,
+        tauAlphaX: 0n,
+        tauAlphaY: 0n,
+        tauBetaX: 0n,
+        tauBetaY: 0n,
+        u: 0n,
+        v: 0n,
+        w: 0n,
+        z: 0n,
       };
       expect(pools[rstETHLidoPoolAddr]).toEqual(expectedPool);
     });
@@ -48,6 +62,20 @@ describe('Balancer API Tests', function () {
         hookAddress: '0xb18fa0cb5de8cecb8899aae6e38b1b7ed77885da',
         hookType: 'StableSurge',
         supportsUnbalancedLiquidity: true,
+        dSq: 0n,
+        paramsAlpha: 0n,
+        paramsBeta: 0n,
+        paramsC: 0n,
+        paramsLambda: 0n,
+        paramsS: 0n,
+        tauAlphaX: 0n,
+        tauAlphaY: 0n,
+        tauBetaX: 0n,
+        tauBetaY: 0n,
+        u: 0n,
+        v: 0n,
+        w: 0n,
+        z: 0n,
       };
       expect(pools[stableSurgePoolAddr]).toEqual(expectedPool);
     });

--- a/src/dex/balancer-v3/balancer-v3-e2e.test.ts
+++ b/src/dex/balancer-v3/balancer-v3-e2e.test.ts
@@ -376,8 +376,8 @@ describe('BalancerV3 E2E', () => {
       const tokenASymbol: string = 'WETH';
       const tokenBSymbol: string = 'USDC';
 
-      const tokenAAmount: string = '3000000000000000';
-      const tokenBAmount: string = '100000000000000';
+      const tokenAAmount: string = '300000000000000';
+      const tokenBAmount: string = '100000000';
       const nativeTokenAmount = '0';
 
       testForNetwork(


### PR DESCRIPTION
* API test was missing GyroECLP params in expected pools which default to 0 for non-Gyro pool.
* e2e test was using amounts > currently available liquidity for WETH/USDC on Base V3 which resulted in no routes being available. Updated to use smaller amounts.