### PR TITLE
finalize tests

### DIFF
--- a/src/abi/kelp/LRTDepositPool.json
+++ b/src/abi/kelp/LRTDepositPool.json
@@ -1,0 +1,679 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  { "inputs": [], "name": "AssetNotSupported", "type": "error" },
+  { "inputs": [], "name": "CallerNotLRTConfigAdmin", "type": "error" },
+  { "inputs": [], "name": "CallerNotLRTConfigManager", "type": "error" },
+  { "inputs": [], "name": "CallerNotLRTConfigOperator", "type": "error" },
+  { "inputs": [], "name": "EthTransferFailed", "type": "error" },
+  { "inputs": [], "name": "InvalidAmountToDeposit", "type": "error" },
+  { "inputs": [], "name": "InvalidMaximumNodeDelegatorLimit", "type": "error" },
+  { "inputs": [], "name": "MaximumDepositLimitReached", "type": "error" },
+  { "inputs": [], "name": "MaximumNodeDelegatorLimitReached", "type": "error" },
+  { "inputs": [], "name": "MinimumAmountToReceiveNotMet", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "assetAddress", "type": "address" },
+      { "internalType": "uint256", "name": "assetBalance", "type": "uint256" }
+    ],
+    "name": "NodeDelegatorHasAssetBalance",
+    "type": "error"
+  },
+  { "inputs": [], "name": "NodeDelegatorHasETH", "type": "error" },
+  {
+    "inputs": [],
+    "name": "NodeDelegatorHasUnaccountedWithdrawals",
+    "type": "error"
+  },
+  { "inputs": [], "name": "NodeDelegatorNotFound", "type": "error" },
+  { "inputs": [], "name": "NotEnoughAssetToTransfer", "type": "error" },
+  { "inputs": [], "name": "ValueAlreadyInUse", "type": "error" },
+  { "inputs": [], "name": "ZeroAddressNotAllowed", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "depositor",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rsethMintAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "referralId",
+        "type": "string"
+      }
+    ],
+    "name": "AssetDeposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "depositor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "depositAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rsethMintAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "referralId",
+        "type": "string"
+      }
+    ],
+    "name": "ETHDeposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "ethAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "toAsset",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "returnAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ETHSwappedForLST",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "EthTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxNegligibleAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxNegligibleAmountUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxNodeDelegatorLimit",
+        "type": "uint256"
+      }
+    ],
+    "name": "MaxNodeDelegatorLimitUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minAmountToDeposit",
+        "type": "uint256"
+      }
+    ],
+    "name": "MinAmountToDepositUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address[]",
+        "name": "nodeDelegatorContracts",
+        "type": "address[]"
+      }
+    ],
+    "name": "NodeDelegatorAddedinQueue",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "nodeDelegatorContracts",
+        "type": "address"
+      }
+    ],
+    "name": "NodeDelegatorRemovedFromQueue",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "lrtConfig",
+        "type": "address"
+      }
+    ],
+    "name": "UpdatedLRTConfig",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "nodeDelegatorContracts",
+        "type": "address[]"
+      }
+    ],
+    "name": "addNodeDelegatorContractToQueue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "depositAmount", "type": "uint256" },
+      {
+        "internalType": "uint256",
+        "name": "minRSETHAmountExpected",
+        "type": "uint256"
+      },
+      { "internalType": "string", "name": "referralId", "type": "string" }
+    ],
+    "name": "depositAsset",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "minRSETHAmountExpected",
+        "type": "uint256"
+      },
+      { "internalType": "string", "name": "referralId", "type": "string" }
+    ],
+    "name": "depositETH",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" }
+    ],
+    "name": "getAssetCurrentLimit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" }
+    ],
+    "name": "getAssetDistributionData",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "assetLyingInDepositPool",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assetLyingInNDCs",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int256",
+        "name": "assetStakedInEigenLayer",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assetUnstakingFromEigenLayer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assetLyingInConverter",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "assetLyingUnstakingVault",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getETHDistributionData",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "ethLyingInDepositPool",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ethLyingInNDCs",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int256",
+        "name": "ethStakedInEigenLayer",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ethUnstakingFromEigenLayer",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ethLyingInConverter",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ethLyingInUnstakingVault",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getNodeDelegatorQueue",
+    "outputs": [
+      { "internalType": "address[]", "name": "", "type": "address[]" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "getRsETHAmountToMint",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "rsethAmountToMint",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "toAsset", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "ethAmountToSend",
+        "type": "uint256"
+      }
+    ],
+    "name": "getSwapETHToAssetReturnAmount",
+    "outputs": [
+      { "internalType": "uint256", "name": "returnAmount", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" }
+    ],
+    "name": "getTotalAssetDeposits",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "totalAssetDeposit",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "lrtConfigAddr", "type": "address" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "isNodeDelegator",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lrtConfig",
+    "outputs": [
+      { "internalType": "contract ILRTConfig", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" }
+    ],
+    "name": "maxApproveToLRTConverter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxNegligibleAmount",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxNodeDelegatorLimit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minAmountToDeposit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "name": "nodeDelegatorQueue",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "receiveFromLRTConverter",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "receiveFromNodeDelegator",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "receiveFromRewardReceiver",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "nodeDelegatorContracts",
+        "type": "address[]"
+      }
+    ],
+    "name": "removeManyNodeDelegatorContractsFromQueue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "nodeDelegatorAddress",
+        "type": "address"
+      }
+    ],
+    "name": "removeNodeDelegatorContractFromQueue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxNegligibleAmount_",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxNegligibleAmount",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "minAmountToDeposit_",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMinAmountToDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "toAsset", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "minToAssetAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapETHForAssetWithinDepositPool",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferAssetToLRTUnstakingVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "ndcIndex", "type": "uint256" },
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferAssetToNodeDelegator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferETHToLRTUnstakingVault",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "ndcIndex", "type": "uint256" },
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "transferETHToNodeDelegator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "lrtConfigAddr", "type": "address" }
+    ],
+    "name": "updateLRTConfig",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "maxNodeDelegatorLimit_",
+        "type": "uint256"
+      }
+    ],
+    "name": "updateMaxNodeDelegatorLimit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  { "stateMutability": "payable", "type": "receive" }
+]

--- a/src/abi/kelp/LRTOracle.json
+++ b/src/abi/kelp/LRTOracle.json
@@ -1,0 +1,196 @@
+[
+  { "inputs": [], "stateMutability": "nonpayable", "type": "constructor" },
+  { "inputs": [], "name": "AssetOracleNotSupported", "type": "error" },
+  { "inputs": [], "name": "CallerNotLRTConfigAdmin", "type": "error" },
+  { "inputs": [], "name": "InvalidPriceOracle", "type": "error" },
+  { "inputs": [], "name": "RSETHPriceExceedsLimit", "type": "error" },
+  { "inputs": [], "name": "ZeroAddressNotAllowed", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "asset",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "priceOracle",
+        "type": "address"
+      }
+    ],
+    "name": "AssetPriceOracleUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "treasury",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "rsethAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeeMinted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newLimit",
+        "type": "uint256"
+      }
+    ],
+    "name": "PricePercentageLimitUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldPrice",
+        "type": "uint256"
+      }
+    ],
+    "name": "RsETHPriceUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "lrtConfig",
+        "type": "address"
+      }
+    ],
+    "name": "UpdatedLRTConfig",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" }
+    ],
+    "name": "assetPriceOracle",
+    "outputs": [
+      { "internalType": "address", "name": "priceOracle", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" }
+    ],
+    "name": "getAssetPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "lrtConfigAddr", "type": "address" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lrtConfig",
+    "outputs": [
+      { "internalType": "contract ILRTConfig", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pricePercentageLimit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rsETHPrice",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_pricePercentageLimit",
+        "type": "uint256"
+      }
+    ],
+    "name": "setPricePercentageLimit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "address", "name": "priceOracle", "type": "address" }
+    ],
+    "name": "updatePriceOracleFor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "asset", "type": "address" },
+      { "internalType": "address", "name": "priceOracle", "type": "address" }
+    ],
+    "name": "updatePriceOracleForValidated",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "updateRSETHPrice",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -99,6 +99,7 @@ import { balancerV3Merge } from './balancer-v3/optimizer';
 import { SkyConverter } from './sky-converter/sky-converter';
 import { Cables } from './cables/cables';
 import { Stader } from './stader/stader';
+import { Kelp } from './kelp/kelp';
 import { UsualBond } from './usual/usual-bond';
 import { UsualMWrappedM } from './usual/usual-m-wrapped-m';
 import { UsualMUsd0 } from './usual/usual-m-usd0';
@@ -126,6 +127,7 @@ const LegacyDexes = [
 
 const Dexes = [
   Stader,
+  Kelp,
   Bebop,
   Dexalot,
   CurveV1,

--- a/src/dex/kelp/config.ts
+++ b/src/dex/kelp/config.ts
@@ -1,0 +1,17 @@
+import { DexParams } from './types';
+import { DexConfigMap } from '../../types';
+import { Network } from '../../constants';
+
+export const KelpConfig: DexConfigMap<DexParams> = {
+  Kelp: {
+    [Network.MAINNET]: {
+      lrtDepositPool: '0x036676389e48133B63a802f8635AD39E752D375D',
+      lrtOracle: '0x349A73444b1a310BAe67ef67973022020d70020d',
+      weth: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      stETH: '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84',
+      wstETH: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
+      ETHx: '0xA35b1B31Ce002FBF2058D22F30f95D405200A15b',
+      rsETH: '0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7',
+    },
+  },
+};

--- a/src/dex/kelp/kelp-e2e.test.ts
+++ b/src/dex/kelp/kelp-e2e.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import { Tokens, Holders } from '../../../tests/constants-e2e';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+
+describe('Kelp', () => {
+  const network = Network.MAINNET;
+  const tokens = Tokens[network];
+  const holders = Holders[network];
+  const provider = new StaticJsonRpcProvider(
+    generateConfig(network).privateHttpProvider,
+    network,
+  );
+  const dexKey = 'Kelp';
+
+  const contractMethod = ContractMethod.swapExactAmountIn;
+  const srcTokens = ['ETH', 'WETH', 'STETH', 'wstETH', 'ETHx'];
+  const destToken = 'rsETH';
+  const testAmount = '1000000000000000000';
+
+  srcTokens.forEach(srcToken => {
+    it(`${contractMethod} - ${srcToken} -> ${destToken}`, async () => {
+      await testE2E(
+        tokens[srcToken],
+        tokens[destToken],
+        holders[srcToken],
+        testAmount,
+        SwapSide.SELL,
+        dexKey,
+        contractMethod,
+        network,
+        provider,
+      );
+    });
+  });
+});

--- a/src/dex/kelp/kelp-events.test.ts
+++ b/src/dex/kelp/kelp-events.test.ts
@@ -1,0 +1,79 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { KelpEventPool } from './kelp-pool';
+import { Network } from '../../constants';
+import { Address } from '../../types';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { testEventSubscriber } from '../../../tests/utils-events';
+import { KelpPoolState } from './types';
+import { KelpConfig } from './config';
+import lrtOracleAbi from '../../abi/kelp/LRTOracle.json';
+import { Interface, JsonFragment } from '@ethersproject/abi';
+
+jest.setTimeout(50 * 1000);
+
+async function fetchPoolState(
+  kelpPools: KelpEventPool,
+  blockNumber: number,
+  poolAddress: string,
+): Promise<KelpPoolState> {
+  return kelpPools.generateState(blockNumber);
+}
+
+type EventMappings = Record<string, number[]>;
+
+describe('KelpEventPool Mainnet', function () {
+  const dexKey = 'Kelp';
+  const network = Network.MAINNET;
+  const dexHelper = new DummyDexHelper(network);
+  const logger = dexHelper.getLogger(dexKey);
+  let kelpPool: KelpEventPool;
+
+  const eventsToTest: Record<Address, EventMappings> = {
+    [KelpConfig.Kelp[network].lrtOracle.toLowerCase()]: {
+      RsETHPriceUpdate: [
+        22166810, 22159610, 22152410, 22145210, 22138010, 22130810, 22123610,
+        22051610, 21331610,
+      ],
+    },
+  };
+
+  beforeEach(async () => {
+    kelpPool = new KelpEventPool(
+      dexKey,
+      network,
+      dexHelper,
+      logger,
+      KelpConfig.Kelp[network].lrtOracle.toLowerCase(),
+      new Interface(lrtOracleAbi as JsonFragment[]),
+    );
+  });
+
+  Object.entries(eventsToTest).forEach(
+    ([poolAddress, events]: [string, EventMappings]) => {
+      describe(`Events for ${poolAddress}`, () => {
+        Object.entries(events).forEach(
+          ([eventName, blockNumbers]: [string, number[]]) => {
+            describe(`${eventName}`, () => {
+              blockNumbers.forEach((blockNumber: number) => {
+                it(`State after ${blockNumber}`, async function () {
+                  await testEventSubscriber(
+                    kelpPool,
+                    kelpPool.addressesSubscribed,
+                    (_blockNumber: number) =>
+                      fetchPoolState(kelpPool, _blockNumber, poolAddress),
+                    blockNumber,
+                    `${dexKey}_${poolAddress}`,
+                    dexHelper.provider,
+                  );
+                });
+              });
+            });
+          },
+        );
+      });
+    },
+  );
+});

--- a/src/dex/kelp/kelp-gas-estimation.test.ts
+++ b/src/dex/kelp/kelp-gas-estimation.test.ts
@@ -1,0 +1,37 @@
+/* eslint-disable no-console */
+import 'dotenv/config';
+import { testGasEstimation } from '../../../tests/utils-e2e';
+import { Tokens } from '../../../tests/constants-e2e';
+import { Network, SwapSide } from '../../constants';
+import { ContractMethodV6 } from '@paraswap/core';
+
+describe('Kelp Gas Estimation', () => {
+  const dexKey = 'Kelp';
+  const network = Network.MAINNET;
+
+  describe('swapExactAmountIn', () => {
+    const srcTokens = [
+      Tokens[network]['ETH'],
+      Tokens[network]['WETH'],
+      Tokens[network]['STETH'],
+      Tokens[network]['wstETH'],
+      Tokens[network]['ETHx'],
+    ];
+    const destToken = Tokens[network]['rsETH'];
+    const testAmount = 1000000000000000000n;
+
+    srcTokens.forEach(srcToken => {
+      it('depositAsset', async () => {
+        await testGasEstimation(
+          network,
+          srcToken,
+          destToken,
+          testAmount,
+          SwapSide.SELL,
+          dexKey,
+          ContractMethodV6.swapExactAmountIn,
+        );
+      });
+    });
+  });
+});

--- a/src/dex/kelp/kelp-integration.test.ts
+++ b/src/dex/kelp/kelp-integration.test.ts
@@ -1,0 +1,223 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Interface, Result, JsonFragment } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide } from '../../constants';
+import { BI_POWS } from '../../bigint-constants';
+import { Kelp } from './kelp';
+import {
+  checkPoolPrices,
+  checkPoolsLiquidity,
+  checkConstantPoolPrices,
+} from '../../../tests/utils';
+import { Tokens } from '../../../tests/constants-e2e';
+import lrtDepositPoolAbi from '../../abi/kelp/LRTDepositPool.json';
+import { KelpConfig } from './config';
+
+function getReaderCalldata(
+  exchangeAddress: string,
+  readerIface: Interface,
+  srcToken: string,
+  amounts: bigint[],
+  funcName: string,
+) {
+  return amounts.map(amount => ({
+    target: exchangeAddress,
+    callData: readerIface.encodeFunctionData(funcName, [srcToken, amount]),
+  }));
+}
+
+function decodeReaderResult(
+  results: Result,
+  readerIface: Interface,
+  funcName: string,
+) {
+  return results.map(result => {
+    const parsed = readerIface.decodeFunctionResult(funcName, result);
+    return BigInt(parsed[0]._hex);
+  });
+}
+
+async function checkOnChainPricing(
+  kelp: Kelp,
+  funcName: string,
+  blockNumber: number,
+  prices: bigint[],
+  amounts: bigint[],
+  srcToken: string,
+) {
+  const exchangeAddress =
+    KelpConfig.Kelp[kelp.network].lrtDepositPool.toLowerCase();
+
+  const readerIface = new Interface(lrtDepositPoolAbi as JsonFragment[]);
+
+  const readerCallData = getReaderCalldata(
+    exchangeAddress,
+    readerIface,
+    srcToken,
+    amounts.slice(1),
+    funcName,
+  );
+  const readerResult = (
+    await kelp.dexHelper.multiContract.methods
+      .aggregate(readerCallData)
+      .call({}, blockNumber)
+  ).returnData;
+
+  const expectedPrices = [0n].concat(
+    decodeReaderResult(readerResult, readerIface, funcName),
+  );
+
+  expect(prices).toEqual(expectedPrices);
+}
+
+async function testPricingOnNetwork(
+  kelp: Kelp,
+  network: Network,
+  dexKey: string,
+  blockNumber: number,
+  srcTokenSymbol: string,
+  destTokenSymbol: string,
+  side: SwapSide,
+  amounts: bigint[],
+  funcNameToCheck: string,
+) {
+  const networkTokens = Tokens[network];
+
+  const pools = await kelp.getPoolIdentifiers(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    side,
+    blockNumber,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Identifiers: `,
+    pools,
+  );
+
+  expect(pools.length).toBeGreaterThan(0);
+
+  const poolPrices = await kelp.getPricesVolume(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    amounts,
+    side,
+    blockNumber,
+    pools,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Prices: `,
+    poolPrices,
+  );
+
+  expect(poolPrices).not.toBeNull();
+  if (kelp.hasConstantPriceLargeAmounts) {
+    checkConstantPoolPrices(poolPrices!, amounts, dexKey);
+  } else {
+    checkPoolPrices(poolPrices!, amounts, side, dexKey);
+  }
+
+  const actualSrcTokenSymbol =
+    srcTokenSymbol === 'WETH'
+      ? 'ETH'
+      : srcTokenSymbol === 'wstETH'
+      ? 'STETH'
+      : srcTokenSymbol;
+
+  let actualSrcAmounts: bigint[] = [];
+
+  if (srcTokenSymbol === 'wstETH') {
+    const actualSrcAmountsPromises = amounts.map(amount =>
+      kelp.getActualSrcAmount(networkTokens[srcTokenSymbol].address, amount),
+    );
+    actualSrcAmounts = await Promise.all(actualSrcAmountsPromises);
+  } else {
+    actualSrcAmounts = amounts;
+  }
+
+  await checkOnChainPricing(
+    kelp,
+    funcNameToCheck,
+    blockNumber,
+    poolPrices![0].prices,
+    actualSrcAmounts,
+    networkTokens[actualSrcTokenSymbol].address,
+  );
+}
+
+describe('Kelp', function () {
+  const dexKey = 'Kelp';
+  let blockNumber: number;
+  let kelp: Kelp;
+
+  describe('Mainnet', () => {
+    const network = Network.MAINNET;
+    const dexHelper = new DummyDexHelper(network);
+
+    const tokens = Tokens[network];
+
+    const srcTokenSymbols = ['ETH', 'WETH', 'STETH', 'wstETH', 'ETHx'];
+    const destTokenSymbol = 'rsETH';
+    const decimals = 18;
+
+    const amountsForSell = [
+      0n,
+      1n * BI_POWS[decimals],
+      2n * BI_POWS[decimals],
+      3n * BI_POWS[decimals],
+      4n * BI_POWS[decimals],
+      5n * BI_POWS[decimals],
+      6n * BI_POWS[decimals],
+      7n * BI_POWS[decimals],
+      8n * BI_POWS[decimals],
+      9n * BI_POWS[decimals],
+      10n * BI_POWS[decimals],
+    ];
+
+    beforeAll(async () => {
+      blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      kelp = new Kelp(network, dexKey, dexHelper);
+      if (kelp.initializePricing) {
+        await kelp.initializePricing(blockNumber);
+      }
+    });
+
+    srcTokenSymbols.forEach(srcTokenSymbol => {
+      it(`getPoolIdentifiers and getPricesVolume SELL (${srcTokenSymbol} -> ${destTokenSymbol})`, async function () {
+        await testPricingOnNetwork(
+          kelp,
+          network,
+          dexKey,
+          blockNumber,
+          srcTokenSymbol,
+          destTokenSymbol,
+          SwapSide.SELL,
+          amountsForSell,
+          'getRsETHAmountToMint',
+        );
+      });
+
+      it(`getTopPoolsForToken for ${srcTokenSymbol}`, async function () {
+        const newKelp = new Kelp(network, dexKey, dexHelper);
+        if (newKelp.updatePoolState) {
+          await newKelp.updatePoolState();
+        }
+        const poolLiquidity = await newKelp.getTopPoolsForToken(
+          tokens[srcTokenSymbol].address,
+          10,
+        );
+        console.log(`${srcTokenSymbol} Top Pools:`, poolLiquidity);
+
+        if (!newKelp.hasConstantPriceLargeAmounts) {
+          checkPoolsLiquidity(
+            poolLiquidity,
+            Tokens[network][srcTokenSymbol].address,
+            dexKey,
+          );
+        }
+      });
+    });
+  });
+});

--- a/src/dex/kelp/kelp-pool.ts
+++ b/src/dex/kelp/kelp-pool.ts
@@ -1,0 +1,117 @@
+import { Interface, AbiCoder } from '@ethersproject/abi';
+import { DeepReadonly } from 'ts-essentials';
+import { Log, Logger } from '../../types';
+import { catchParseLogError } from '../../utils';
+import { StatefulEventSubscriber } from '../../stateful-event-subscriber';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { KelpPoolState, lrtOracleFunctions } from './types';
+import { Contract } from 'web3-eth-contract';
+import { Address } from '@paraswap/sdk';
+import { BI_POWS } from '../../bigint-constants';
+
+export class KelpEventPool extends StatefulEventSubscriber<KelpPoolState> {
+  handlers: {
+    [event: string]: (
+      event: any,
+      state: DeepReadonly<KelpPoolState>,
+      log: Readonly<Log>,
+    ) => DeepReadonly<KelpPoolState> | null;
+  } = {};
+
+  logDecoder: (log: Log) => any;
+
+  addressesSubscribed: string[];
+
+  constructor(
+    readonly parentName: string,
+    protected network: number,
+    protected dexHelper: IDexHelper,
+    logger: Logger,
+    private lrtOracleAddress: Address,
+    private lrtOracleInterface: Interface,
+  ) {
+    super(parentName, 'rsETH', dexHelper, logger);
+
+    this.logDecoder = (log: Log) => this.lrtOracleInterface.parseLog(log);
+    this.addressesSubscribed = [this.lrtOracleAddress];
+  }
+
+  protected processLog(
+    state: DeepReadonly<KelpPoolState>,
+    log: Readonly<Log>,
+  ): DeepReadonly<KelpPoolState> | null {
+    try {
+      const event = this.logDecoder(log);
+      if (event.name === 'RsETHPriceUpdate') {
+        const newRsETHPrice = BigInt(event.args.newPrice);
+        return {
+          rsETHToETHRate: newRsETHPrice,
+        };
+      }
+    } catch (e) {
+      catchParseLogError(e, this.logger);
+    }
+
+    return null;
+  }
+
+  async getOrGenerateState(
+    blockNumber: number,
+  ): Promise<DeepReadonly<KelpPoolState>> {
+    let state = this.getState(blockNumber);
+    if (!state) {
+      state = await this.generateState(blockNumber);
+      this.setState(state, blockNumber);
+    }
+    return state;
+  }
+
+  async generateState(
+    blockNumber: number,
+  ): Promise<DeepReadonly<KelpPoolState>> {
+    const state = await this.getOnChainState(
+      this.dexHelper.multiContract,
+      this.lrtOracleAddress,
+      this.lrtOracleInterface,
+      blockNumber,
+    );
+
+    return state;
+  }
+
+  async getOnChainState(
+    multiContract: Contract,
+    lrtOracleAddress: Address,
+    lrtOracleInterface: Interface,
+    blockNumber: number | 'latest',
+  ): Promise<KelpPoolState> {
+    const coder = new AbiCoder();
+    const data: { returnData: any[] } = await multiContract.methods
+      .aggregate([
+        {
+          target: lrtOracleAddress,
+          callData: lrtOracleInterface.encodeFunctionData(
+            lrtOracleFunctions.rsETHPrice,
+            [],
+          ),
+        },
+      ])
+      .call({}, blockNumber);
+
+    const decodedData = coder.decode(['uint256'], data.returnData[0]);
+
+    const rsETHToETHRate = BigInt(decodedData[0].toString());
+
+    return {
+      rsETHToETHRate,
+    };
+  }
+
+  getPrice(blockNumber: number, ethAmount: bigint): bigint {
+    const state = this.getState(blockNumber);
+    if (!state) throw new Error('Cannot compute price');
+    const { rsETHToETHRate } = state;
+
+    return (ethAmount * BI_POWS[18]) / rsETHToETHRate;
+  }
+}

--- a/src/dex/kelp/kelp.ts
+++ b/src/dex/kelp/kelp.ts
@@ -1,0 +1,378 @@
+import { Interface, JsonFragment, AbiCoder } from '@ethersproject/abi';
+import { NumberAsString } from '@paraswap/core';
+import {
+  Token,
+  Address,
+  ExchangePrices,
+  PoolPrices,
+  AdapterExchangeParam,
+  PoolLiquidity,
+  Logger,
+  DexExchangeParam,
+} from '../../types';
+import {
+  SwapSide,
+  Network,
+  ETHER_ADDRESS,
+  NULL_ADDRESS,
+} from '../../constants';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+import _ from 'lodash';
+import { getDexKeysWithNetwork, isETHAddress } from '../../utils';
+import { IDex } from '../../dex/idex';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { KelpData, lrtDepositPoolFunctions, wstETHFunctions } from './types';
+import { SimpleExchange } from '../simple-exchange';
+import { KelpConfig } from './config';
+import { KelpEventPool } from './kelp-pool';
+import { WethFunctions } from '../weth/types';
+import ERC20ABI from '../../abi/erc20.json';
+import wstEthAbi from '../../abi/wstETH.json';
+import lrtDepositPoolAbi from '../../abi/kelp/LRTDepositPool.json';
+import { Contract } from 'web3-eth-contract';
+import lrtOracleAbi from '../../abi/kelp/LRTOracle.json';
+import { BI_POWS } from '../../bigint-constants';
+import { AsyncOrSync } from 'ts-essentials';
+
+export class Kelp extends SimpleExchange implements IDex<KelpData> {
+  static dexKeys = ['Kelp'];
+  protected kelpPool: KelpEventPool;
+
+  readonly hasConstantPriceLargeAmounts = false;
+  readonly needWrapNative = false;
+
+  readonly isFeeOnTransferSupported = false;
+
+  erc20Interface: Interface;
+  wstEthInterface: Interface;
+  lrtDepositPoolInterface: Interface;
+  lrtDepositPoolAddress: Address;
+  rsETHAddress: Address;
+  wethAddress: Address;
+  stETHAddress: Address;
+  wstETHAddress: Address;
+  ETHxAddress: Address;
+
+  referralId = '';
+  logger: Logger;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(_.pick(KelpConfig, ['Kelp']));
+
+  constructor(
+    readonly network: Network,
+    readonly dexKey: string,
+    readonly dexHelper: IDexHelper,
+    protected config = KelpConfig[dexKey][network],
+  ) {
+    super(dexHelper, dexKey);
+    this.network = dexHelper.config.data.network;
+    this.ETHxAddress = this.config.ETHx.toLowerCase();
+    this.rsETHAddress = this.config.rsETH.toLowerCase();
+    this.wethAddress = this.config.weth.toLowerCase();
+    this.stETHAddress = this.config.stETH.toLowerCase();
+    this.wstETHAddress = this.config.wstETH.toLowerCase();
+    this.erc20Interface = new Interface(ERC20ABI as JsonFragment[]);
+    this.wstEthInterface = new Interface(wstEthAbi as JsonFragment[]);
+    this.lrtDepositPoolInterface = new Interface(
+      lrtDepositPoolAbi as JsonFragment[],
+    );
+    this.lrtDepositPoolAddress = this.config.lrtDepositPool.toLowerCase();
+    this.logger = dexHelper.getLogger(dexKey);
+    this.kelpPool = new KelpEventPool(
+      dexKey,
+      network,
+      dexHelper,
+      this.logger,
+      this.config.lrtOracle.toLowerCase(),
+      new Interface(lrtOracleAbi as JsonFragment[]),
+    );
+  }
+
+  getAdapterParam(
+    srcToken: Address,
+    destToken: Address,
+    srcAmount: NumberAsString,
+    destAmount: NumberAsString,
+    data: KelpData,
+    side: SwapSide,
+  ): AdapterExchangeParam {
+    return {
+      targetExchange: NULL_ADDRESS,
+      payload: '0x',
+      networkFee: '0',
+    };
+  }
+
+  async initializePricing(blockNumber: number) {
+    await this.kelpPool.initialize(blockNumber);
+  }
+
+  getAdapters(side: SwapSide): { name: string; index: number }[] | null {
+    return null;
+  }
+
+  async getPoolIdentifiers(
+    srcToken: Token,
+    destToken: Token,
+    side: SwapSide,
+    blockNumber: number,
+  ): Promise<string[]> {
+    if (side === SwapSide.BUY) return [];
+
+    if (!this.isEligibleSwap(srcToken, destToken)) return [];
+
+    return [`${this.dexKey}_${this.lrtDepositPoolAddress}`];
+  }
+
+  async getPricesVolume(
+    srcToken: Token,
+    destToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    limitPools?: string[],
+  ): Promise<null | ExchangePrices<KelpData>> {
+    if (side === SwapSide.BUY) return null;
+    if (!this.isEligibleSwap(srcToken, destToken)) return null;
+
+    const pool = this.kelpPool;
+    if (!pool.getState(blockNumber)) return null;
+
+    const unitIn = BI_POWS[18];
+    const unitOut = pool.getPrice(blockNumber, unitIn);
+
+    const amountsOutPromises = amounts.map(amountIn =>
+      this.getRsETHAmountToMint(
+        this.dexHelper.multiContract,
+        srcToken.address,
+        amountIn,
+      ),
+    );
+    const amountsOut = await Promise.all(amountsOutPromises);
+
+    return [
+      {
+        // @ts-ignore
+        prices: amountsOut,
+        unit: unitOut,
+        data: {},
+        exchange: this.dexKey,
+        poolIdentifier:
+          `${srcToken.address}_${destToken.address}`.toLowerCase(),
+        gasCost: 850_000,
+        poolAddresses: [destToken.address],
+      },
+    ];
+  }
+
+  async getDexParam(
+    srcToken: Address,
+    _destToken: Address,
+    srcAmount: NumberAsString,
+    _destAmount: NumberAsString,
+    _recipient: Address,
+    _data: KelpData,
+    _side: SwapSide,
+  ): Promise<DexExchangeParam> {
+    if (_side === SwapSide.BUY) throw new Error(`Buy not supported`);
+
+    const actualSrcToken = await this.getActualSrcToken(srcToken);
+    const actualSrcAmount = await this.getActualSrcAmount(
+      srcToken,
+      BigInt(srcAmount),
+    );
+
+    const minRSETHAmountExpected = await this.getRsETHAmountToMint(
+      this.dexHelper.multiContract,
+      actualSrcToken,
+      actualSrcAmount,
+    );
+
+    const swapData =
+      isETHAddress(srcToken) || this.isWETH(srcToken)
+        ? this.lrtDepositPoolInterface.encodeFunctionData(
+            lrtDepositPoolFunctions.depositETH,
+            [minRSETHAmountExpected, this.referralId],
+          )
+        : this.lrtDepositPoolInterface.encodeFunctionData(
+            lrtDepositPoolFunctions.depositAsset,
+            [
+              actualSrcToken,
+              actualSrcAmount,
+              minRSETHAmountExpected,
+              this.referralId,
+            ],
+          );
+
+    return {
+      needWrapNative: this.needWrapNative,
+      dexFuncHasRecipient: false,
+      exchangeData: swapData,
+      targetExchange: this.lrtDepositPoolAddress.toLowerCase(),
+      preSwapUnwrapCalldata: this.isWETH(srcToken)
+        ? this.erc20Interface.encodeFunctionData(WethFunctions.withdraw, [
+            srcAmount,
+          ])
+        : this.isWstETH(srcToken)
+        ? this.wstEthInterface.encodeFunctionData(wstETHFunctions.unwrap, [
+            srcAmount,
+          ])
+        : undefined,
+      returnAmountPos: undefined,
+    };
+  }
+
+  async updatePoolState(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  getCalldataGasCost(poolPrices: PoolPrices<KelpData>): number | number[] {
+    return CALLDATA_GAS_COST.DEX_NO_PAYLOAD;
+  }
+
+  getTopPoolsForToken(
+    tokenAddress: string,
+    limit: number,
+  ): AsyncOrSync<PoolLiquidity[]> {
+    if (this.isSupportedAsset(tokenAddress.toLowerCase())) {
+      return [
+        {
+          exchange: this.dexKey,
+          address: this.config.rsETH,
+          connectorTokens: [
+            {
+              address: this.config.rsETH,
+              decimals: 18,
+            },
+          ],
+          liquidityUSD: 1000000000,
+        },
+      ];
+    }
+
+    if (tokenAddress.toLowerCase() === this.rsETHAddress.toLowerCase()) {
+      const eth = ETHER_ADDRESS;
+      const weth = this.wethAddress;
+      const stETH = this.stETHAddress;
+      const wstETH = this.wstETHAddress;
+      const ETHx = this.ETHxAddress;
+
+      return [eth, weth, stETH, wstETH, ETHx].map(t => ({
+        exchange: this.dexKey,
+        address: this.config.rsETH,
+        connectorTokens: [{ address: t, decimals: 18 }],
+        liquidityUSD: 1000000000,
+      }));
+    }
+
+    return [];
+  }
+
+  isEligibleSwap(srcToken: Token | string, destToken: Token | string): boolean {
+    const srcTokenAddress = (
+      typeof srcToken === 'string' ? srcToken : srcToken.address
+    ).toLowerCase();
+    const destTokenAddress = (
+      typeof destToken === 'string' ? destToken : destToken.address
+    ).toLowerCase();
+
+    return (
+      this.isSupportedAsset(srcTokenAddress) &&
+      destTokenAddress === this.rsETHAddress
+    );
+  }
+
+  isWETH(tokenAddress: string) {
+    return tokenAddress.toLowerCase() === this.wethAddress;
+  }
+
+  isStETH(tokenAddress: string) {
+    return tokenAddress.toLowerCase() === this.stETHAddress;
+  }
+
+  isWstETH(tokenAddress: string) {
+    return tokenAddress.toLowerCase() === this.wstETHAddress;
+  }
+
+  isETHx(tokenAddress: string) {
+    return tokenAddress.toLowerCase() === this.ETHxAddress;
+  }
+
+  isSupportedAsset(tokenAddress: string) {
+    const formattedTokenAddress = tokenAddress.toLowerCase();
+
+    return (
+      isETHAddress(formattedTokenAddress) ||
+      this.isWETH(formattedTokenAddress) ||
+      this.isStETH(formattedTokenAddress) ||
+      this.isWstETH(formattedTokenAddress) ||
+      this.isETHx(formattedTokenAddress)
+    );
+  }
+
+  async getActualSrcToken(srcToken: Address): Promise<Address> {
+    return this.isWETH(srcToken)
+      ? ETHER_ADDRESS
+      : this.isWstETH(srcToken)
+      ? this.stETHAddress
+      : srcToken;
+  }
+
+  async getActualSrcAmount(
+    srcToken: Address,
+    srcAmount: bigint,
+  ): Promise<bigint> {
+    return this.isWstETH(srcToken)
+      ? await this.getStETHByWstETH(this.dexHelper.multiContract, srcAmount)
+      : srcAmount;
+  }
+
+  async getRsETHAmountToMint(
+    multiContract: Contract,
+    srcToken: Address,
+    srcAmount: bigint,
+  ): Promise<bigint> {
+    const actualSrcToken = await this.getActualSrcToken(srcToken);
+    const actualSrcAmount = await this.getActualSrcAmount(srcToken, srcAmount);
+
+    const data: { returnData: any[] } = await multiContract.methods
+      .aggregate([
+        {
+          target: this.lrtDepositPoolAddress,
+          callData: this.lrtDepositPoolInterface.encodeFunctionData(
+            lrtDepositPoolFunctions.getRsETHAmountToMint,
+            [actualSrcToken, actualSrcAmount],
+          ),
+        },
+      ])
+      .call();
+
+    const coder = new AbiCoder();
+    const decodedData = coder.decode(['uint256'], data.returnData[0]);
+
+    return BigInt(decodedData[0].toString());
+  }
+
+  async getStETHByWstETH(
+    multiContract: Contract,
+    amount: bigint,
+  ): Promise<bigint> {
+    const data: { returnData: any[] } = await multiContract.methods
+      .aggregate([
+        {
+          target: this.wstETHAddress,
+          callData: this.wstEthInterface.encodeFunctionData(
+            wstETHFunctions.getStETHByWstETH,
+            [amount],
+          ),
+        },
+      ])
+      .call();
+
+    const coder = new AbiCoder();
+    const decodedData = coder.decode(['uint256'], data.returnData[0]);
+
+    return BigInt(decodedData[0].toString());
+  }
+}

--- a/src/dex/kelp/types.ts
+++ b/src/dex/kelp/types.ts
@@ -1,0 +1,30 @@
+export type KelpPoolState = {
+  rsETHToETHRate: bigint;
+};
+
+export type KelpData = {};
+
+export type DexParams = {
+  lrtDepositPool: string;
+  rsETH: string;
+  weth: string;
+  stETH: string;
+  wstETH: string;
+  ETHx: string;
+  lrtOracle: string;
+};
+
+export enum wstETHFunctions {
+  unwrap = 'unwrap',
+  getStETHByWstETH = 'getStETHByWstETH',
+}
+
+export enum lrtDepositPoolFunctions {
+  getRsETHAmountToMint = 'getRsETHAmountToMint',
+  depositETH = 'depositETH',
+  depositAsset = 'depositAsset',
+}
+
+export enum lrtOracleFunctions {
+  rsETHPrice = 'rsETHPrice',
+}

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -101,6 +101,10 @@ export const Tokens: {
       address: '0xFAe103DC9cf190eD75350761e95403b7b8aFa6c0',
       decimals: 18,
     },
+    rsETH: {
+      address: '0xA1290d69c65A6Fe4DF752f95823fae25cB99e5A7',
+      decimals: 18,
+    },
     REQ: {
       address: '0x8f8221aFbB33998d8584A2B05749bA73c37a938a',
       decimals: 18,
@@ -1904,6 +1908,8 @@ export const Holders: {
     wUSDL: '0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb',
     UsualM: '0xE3f7A0c4a44b740328157A5152A85c3bCB54DA09',
     EKUBO: '0xF5b6Ee2CAEb6769659f6C091D209DfdCaF3F69Eb',
+    ETHx: '0xaDFf77c3b3204d6371d3C037CF0988ab34444CA3',
+    rsETH: '0x22162DbBa43fE0477cdC5234E248264eC7C6EA7c',
   },
   [Network.POLYGON]: {
     jGBP: '0x02aa0B826c7BA6386DdBE04C0a8715A1c0A16B24',


### PR DESCRIPTION
### Background

KernelDAO is a leading restaking protocol with three key products: Kernel (restaking on BNB Chain), Kelp Liquid Restaking (rsETH) and Kelp Gain (automated rewards farming).

### Pricing Logic

The rsETH price is computed by taking the total ETH value of the protocol (including staked assets and newly accrued rewards), subtracting protocol fees and dividing by rsETH’s total supply.

Users are able to deposit approved assets to mint rsETH directly. These currently include native ETH, Lido's liquid staked ether (stETH) and Stader's ETHx. Also, wrapped ether (WETH) and wrapped stETH (wstETH) can be indirectly supported if unwrapped into ETH or stETH, respectively, as a part of the same deposit transaction.

### Existing Docs

Existing protocol documentation can be found at [https://kerneldao.gitbook.io/kernel/getting-started/kelp](https://kerneldao.gitbook.io/kernel/getting-started/kelp)

### Important Contract Addresses

Important contract addresses on Ethereum mainnet can be found at [https://github.com/Kelp-DAO/LRT-rsETH?tab=readme-ov-file#eth-mainnet](https://github.com/Kelp-DAO/LRT-rsETH?tab=readme-ov-file#eth-mainnet)