### PR TITLE
[BACK-1941]: Aburkut/uni v4 fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.2.5-uni-v4-ticks-fix.2",
+  "version": "4.2.5-uni-v4-ticks-fix.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.2.5-uni-v4-ticks-fix.3",
+  "version": "4.2.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.2.4",
+  "version": "4.2.5-uni-v4-ticks-fix.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.2.5-uni-v4-ticks-fix.0",
+  "version": "4.2.5-uni-v4-ticks-fix.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,7 @@ export const SETUP_RETRY_TIMEOUT = 20 * 1000; // 20s
 
 // TODO: Undo
 export const FETCH_POOL_IDENTIFIER_TIMEOUT = 100 * 1000; // 1s
-export const FETCH_POOL_PRICES_TIMEOUT = 5 * 1000; // 3s
+export const FETCH_POOL_PRICES_TIMEOUT = 3 * 1000; // 3s
 
 // How frequently logs wil be printed
 export const STATEFUL_EVENT_SUBSCRIBER_LOG_BATCH_PERIOD = 60 * 1000;

--- a/src/dex/uniswap-v4/constants.ts
+++ b/src/dex/uniswap-v4/constants.ts
@@ -18,10 +18,8 @@ export const SUBGRAPH_TIMEOUT = 30 * 1000;
 
 export const POOL_CACHE_REFRESH_INTERVAL = 60 * 60 * 24; // 24 hours
 
-export const POOLS_INITIALIZATION_LIMIT = 5;
-
 export const SWAP_EVENT_MAX_CYCLES = 10_000;
 
 export const UNISWAPV4_EFFICIENCY_FACTOR = 3;
 
-export const POOL_MIN_TVL_USD = 10;
+export const POOL_MIN_TVL_USD = 50;

--- a/src/dex/uniswap-v4/contract-math/Tick.ts
+++ b/src/dex/uniswap-v4/contract-math/Tick.ts
@@ -32,20 +32,21 @@ export class Tick {
 
   static cross(
     ticks: Record<NumberAsString, TickInfo>,
-    tick: bigint,
+    _tick: bigint,
     feeGrowthGlobal0X128: bigint,
     feeGrowthGlobal1X128: bigint,
   ): bigint {
-    let info = ticks[Number(tick)];
+    const tick = Number(_tick);
+    let info = ticks[tick];
 
     if (!info) {
-      ticks[Number(tick)] = {
+      ticks[tick] = {
         liquidityGross: 0n,
         liquidityNet: 0n,
         feeGrowthOutside0X128: 0n,
         feeGrowthOutside1X128: 0n,
       };
-      info = ticks[Number(tick)];
+      info = ticks[tick];
     }
 
     info.feeGrowthOutside0X128 =

--- a/src/dex/uniswap-v4/contract-math/Tick.ts
+++ b/src/dex/uniswap-v4/contract-math/Tick.ts
@@ -27,12 +27,7 @@ export class Tick {
   }
 
   static clear(poolState: PoolState, tick: bigint): void {
-    poolState.ticks[Number(tick)] = {
-      liquidityGross: 0n,
-      liquidityNet: 0n,
-      feeGrowthOutside0X128: 0n,
-      feeGrowthOutside1X128: 0n,
-    };
+    delete poolState.ticks[Number(tick)];
   }
 
   static cross(

--- a/src/dex/uniswap-v4/contract-math/Tick.ts
+++ b/src/dex/uniswap-v4/contract-math/Tick.ts
@@ -41,9 +41,17 @@ export class Tick {
     feeGrowthGlobal0X128: bigint,
     feeGrowthGlobal1X128: bigint,
   ): bigint {
-    const info = ticks[Number(tick)];
+    let info = ticks[Number(tick)];
 
-    _require(Boolean(info), 'Tick not initialized');
+    if (!info) {
+      ticks[Number(tick)] = {
+        liquidityGross: 0n,
+        liquidityNet: 0n,
+        feeGrowthOutside0X128: 0n,
+        feeGrowthOutside1X128: 0n,
+      };
+      info = ticks[Number(tick)];
+    }
 
     info.feeGrowthOutside0X128 =
       feeGrowthGlobal0X128 - info.feeGrowthOutside0X128;

--- a/src/dex/uniswap-v4/contract-math/uniswap-v4-pool-math.ts
+++ b/src/dex/uniswap-v4/contract-math/uniswap-v4-pool-math.ts
@@ -106,12 +106,13 @@ class UniswapV4PoolMath {
     const zeroForOne = params.zeroForOne;
 
     // making a copy because we don't need to modify existing poolState.ticks
-    const ticksCopy = Object.keys(poolState.ticks).reduce<
-      Record<NumberAsString, TickInfo>
-    >((memo, index) => {
-      memo[index] = { ...poolState.ticks[index] };
-      return memo;
-    }, {} as Record<NumberAsString, TickInfo>);
+    // console.time('ticksCopy');
+    let ticksCopy: Record<NumberAsString, TickInfo> = {};
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key in poolState.ticks) {
+      ticksCopy[key] = { ...poolState.ticks[key] };
+    }
+    // console.timeEnd('ticksCopy');
 
     const protocolFee = zeroForOne
       ? ProtocolFeeLibrary.getZeroForOneFee(BigInt(slot0Start.protocolFee))
@@ -133,7 +134,7 @@ class UniswapV4PoolMath {
     const swapFee =
       protocolFee === 0n
         ? lpFee
-        : ProtocolFeeLibrary.calculateSwapFee(protocolFee, BigInt(lpFee));
+        : ProtocolFeeLibrary.calculateSwapFee(protocolFee, lpFee);
 
     if (swapFee >= SwapMath.MAX_SWAP_FEE) {
       _require(

--- a/src/dex/uniswap-v4/contract-math/uniswap-v4-pool-math.ts
+++ b/src/dex/uniswap-v4/contract-math/uniswap-v4-pool-math.ts
@@ -108,7 +108,7 @@ class UniswapV4PoolMath {
     // making a copy because we don't need to modify existing poolState.ticks
     let ticksCopy: Record<NumberAsString, TickInfo> = {};
     // eslint-disable-next-line no-restricted-syntax
-    for (const key in poolState.ticks) {
+    for (const key of Object.keys(poolState.ticks)) {
       ticksCopy[key] = { ...poolState.ticks[key] };
     }
 

--- a/src/dex/uniswap-v4/contract-math/uniswap-v4-pool-math.ts
+++ b/src/dex/uniswap-v4/contract-math/uniswap-v4-pool-math.ts
@@ -106,10 +106,10 @@ class UniswapV4PoolMath {
     const zeroForOne = params.zeroForOne;
 
     // making a copy because we don't need to modify existing poolState.ticks
-    let ticksCopy: Record<NumberAsString, TickInfo> = {};
+    const ticksCopy: Record<NumberAsString, TickInfo> = {};
     // eslint-disable-next-line no-restricted-syntax
-    for (const key of Object.keys(poolState.ticks)) {
-      ticksCopy[key] = { ...poolState.ticks[key] };
+    for (const tick of Object.keys(poolState.ticks)) {
+      ticksCopy[tick] = { ...poolState.ticks[tick] };
     }
 
     const protocolFee = zeroForOne

--- a/src/dex/uniswap-v4/contract-math/uniswap-v4-pool-math.ts
+++ b/src/dex/uniswap-v4/contract-math/uniswap-v4-pool-math.ts
@@ -106,13 +106,11 @@ class UniswapV4PoolMath {
     const zeroForOne = params.zeroForOne;
 
     // making a copy because we don't need to modify existing poolState.ticks
-    // console.time('ticksCopy');
     let ticksCopy: Record<NumberAsString, TickInfo> = {};
     // eslint-disable-next-line no-restricted-syntax
     for (const key in poolState.ticks) {
       ticksCopy[key] = { ...poolState.ticks[key] };
     }
-    // console.timeEnd('ticksCopy');
 
     const protocolFee = zeroForOne
       ? ProtocolFeeLibrary.getZeroForOneFee(BigInt(slot0Start.protocolFee))

--- a/src/dex/uniswap-v4/uniswap-v4-e2e.test.ts
+++ b/src/dex/uniswap-v4/uniswap-v4-e2e.test.ts
@@ -95,7 +95,7 @@ describe('UniswapV4 E2E', () => {
       );
     });
 
-    describe('WETH -> USDC', () => {
+    describe.skip('WETH -> USDC', () => {
       const tokenASymbol: string = 'WETH';
       const tokenBSymbol: string = 'USDC';
 

--- a/src/dex/uniswap-v4/uniswap-v4-pool.ts
+++ b/src/dex/uniswap-v4/uniswap-v4-pool.ts
@@ -320,12 +320,29 @@ export class UniswapV4Pool extends StatefulEventSubscriber<PoolState> {
           returnData: TickInfo;
         };
 
-        memo[tick.tickIdx] = {
-          liquidityNet: curResults.returnData.liquidityNet,
-          liquidityGross: curResults.returnData.liquidityGross,
-          feeGrowthOutside0X128: curResults.returnData.feeGrowthOutside0X128,
-          feeGrowthOutside1X128: curResults.returnData.feeGrowthOutside1X128,
-        };
+        const {
+          liquidityNet,
+          liquidityGross,
+          feeGrowthOutside0X128,
+          feeGrowthOutside1X128,
+        } = curResults.returnData;
+
+        if (
+          // skips ticks with 0n values to optimize state size
+          !(
+            liquidityNet === 0n &&
+            liquidityGross === 0n &&
+            feeGrowthOutside0X128 === 0n &&
+            feeGrowthOutside1X128 === 0n
+          )
+        ) {
+          memo[tick.tickIdx] = {
+            liquidityNet,
+            liquidityGross,
+            feeGrowthOutside0X128,
+            feeGrowthOutside1X128,
+          };
+        }
 
         tickCounter++;
 

--- a/src/dex/uniswap-v4/uniswap-v4.ts
+++ b/src/dex/uniswap-v4/uniswap-v4.ts
@@ -186,6 +186,7 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
         // const label = `_getOutputs_${pool.id}`;
         // console.time(label);
         prices = this._getOutputs(pool, poolState, amounts, zeroForOne, side);
+        // console.log('TICKS LENGTH: ', Object.keys(poolState.ticks).length);
         // console.timeEnd(label);
       } else {
         this.logger.warn(

--- a/src/dex/uniswap-v4/uniswap-v4.ts
+++ b/src/dex/uniswap-v4/uniswap-v4.ts
@@ -183,7 +183,10 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
 
       let prices: bigint[] | null;
       if (poolState) {
+        const label = `_getOutputs_${pool.id}`;
+        console.time(label);
         prices = this._getOutputs(pool, poolState, amounts, zeroForOne, side);
+        console.timeEnd(label);
       } else {
         this.logger.warn(
           `${this.dexKey}-${this.network}: pool ${poolId} state was not found...falling back to rpc`,

--- a/src/dex/uniswap-v4/uniswap-v4.ts
+++ b/src/dex/uniswap-v4/uniswap-v4.ts
@@ -183,10 +183,10 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
 
       let prices: bigint[] | null;
       if (poolState) {
-        const label = `_getOutputs_${pool.id}`;
-        console.time(label);
+        // const label = `_getOutputs_${pool.id}`;
+        // console.time(label);
         prices = this._getOutputs(pool, poolState, amounts, zeroForOne, side);
-        console.timeEnd(label);
+        // console.timeEnd(label);
       } else {
         this.logger.warn(
           `${this.dexKey}-${this.network}: pool ${poolId} state was not found...falling back to rpc`,

--- a/src/dex/uniswap-v4/uniswap-v4.ts
+++ b/src/dex/uniswap-v4/uniswap-v4.ts
@@ -112,7 +112,15 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
       blockNumber,
     );
 
-    return pools.map(pool => pool.id);
+    const eventPools = (
+      await Promise.all(
+        pools.map(async pool =>
+          this.poolManager.getEventPool(pool.id, blockNumber),
+        ),
+      )
+    ).filter(pool => pool !== null);
+
+    return eventPools.map(eventPool => eventPool!.poolId);
   }
 
   protected _getOutputs(
@@ -183,11 +191,7 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
 
       let prices: bigint[] | null;
       if (poolState) {
-        // const label = `_getOutputs_${pool.id}`;
-        // console.time(label);
         prices = this._getOutputs(pool, poolState, amounts, zeroForOne, side);
-        // console.log('TICKS LENGTH: ', Object.keys(poolState.ticks).length);
-        // console.timeEnd(label);
       } else {
         this.logger.warn(
           `${this.dexKey}-${this.network}: pool ${poolId} state was not found...falling back to rpc`,


### PR DESCRIPTION

### Summary of the changes:
- [x] removed ticks with 0n values from poolState to reduce size of poolState object
- [x] updated math to support poolState where no ticks with 0n values
- [x] filter out pools with tvl less than 50 usd
- [x] replace Object.keys(...).reduce(...) with for (const key in poolState.ticks) <- for loop has better performance
- [x] call this.poolManager.getEventPool in getPoolIdentifiers to initialize pools before getPricesVolume (the same way as it's done for UniV3)