### PR TITLE
feat: optimize `FluidDex`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.33",
+  "version": "4.8.34",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/fluid-dex/constants.ts
+++ b/src/dex/fluid-dex/constants.ts
@@ -2,3 +2,5 @@
 export const MIN_SWAP_LIQUIDITY = 8500n;
 
 export const RESERVE_REFRESH_INTERVAL_MS = 10 * 1000;
+
+export const ONE_E18 = 1000000000000000000n;

--- a/src/dex/fluid-dex/fluid-dex.ts
+++ b/src/dex/fluid-dex/fluid-dex.ts
@@ -945,10 +945,8 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     y2: bigint,
   ): bigint {
     // Adding 1e18 precision
-    const xyRoot = sqrt(BigNumber.from(x).mul(y).mul(BigInt(1e18))).toBigInt();
-    const x2y2Root = sqrt(
-      BigNumber.from(x2).mul(y2).mul(BigInt(1e18)),
-    ).toBigInt();
+    const xyRoot = sqrt(x * y * 1000000000000000000n);
+    const x2y2Root = sqrt(x2 * y2 * 1000000000000000000n);
 
     // 1e18 precision gets cancelled out in division
     const numerator = t * xyRoot + y * x2y2Root - y2 * xyRoot;
@@ -980,11 +978,8 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     y2: bigint,
   ): bigint {
     // Adding 1e18 precision
-
-    const xyRoot = sqrt(BigNumber.from(x).mul(y).mul(BigInt(1e18))).toBigInt();
-    const x2y2Root = sqrt(
-      BigNumber.from(x2).mul(y2).mul(BigInt(1e18)),
-    ).toBigInt();
+    const xyRoot = sqrt(x * y * 1000000000000000000n);
+    const x2y2Root = sqrt(x2 * y2 * 1000000000000000000n);
 
     // Calculating 'a' using the given formula
     const a = (y2 * xyRoot + t * xyRoot - y * x2y2Root) / (xyRoot + x2y2Root);

--- a/src/dex/fluid-dex/fluid-dex.ts
+++ b/src/dex/fluid-dex/fluid-dex.ts
@@ -28,7 +28,6 @@ import { FluidDexConfig, FLUID_DEX_GAS_COST } from './config';
 import { FluidDexFactory } from './fluid-dex-factory';
 import { getDexKeysWithNetwork, getBigIntPow } from '../../utils';
 import { extractReturnAmountPosition } from '../../executor/utils';
-import { BigNumber } from 'ethers';
 import { sqrt } from './utils';
 import { FluidDexLiquidityProxy } from './fluid-dex-liquidity-proxy';
 import { FluidDexEventPool } from './fluid-dex-pool';

--- a/src/dex/fluid-dex/fluid-dex.ts
+++ b/src/dex/fluid-dex/fluid-dex.ts
@@ -32,7 +32,11 @@ import { BigNumber } from 'ethers';
 import { sqrt } from './utils';
 import { FluidDexLiquidityProxy } from './fluid-dex-liquidity-proxy';
 import { FluidDexEventPool } from './fluid-dex-pool';
-import { MIN_SWAP_LIQUIDITY, RESERVE_REFRESH_INTERVAL_MS } from './constants';
+import {
+  MIN_SWAP_LIQUIDITY,
+  ONE_E18,
+  RESERVE_REFRESH_INTERVAL_MS,
+} from './constants';
 
 export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
   readonly hasConstantPriceLargeAmounts = false;
@@ -945,8 +949,8 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     y2: bigint,
   ): bigint {
     // Adding 1e18 precision
-    const xyRoot = sqrt(x * y * 1000000000000000000n);
-    const x2y2Root = sqrt(x2 * y2 * 1000000000000000000n);
+    const xyRoot = sqrt(x * y * ONE_E18);
+    const x2y2Root = sqrt(x2 * y2 * ONE_E18);
 
     // 1e18 precision gets cancelled out in division
     const numerator = t * xyRoot + y * x2y2Root - y2 * xyRoot;
@@ -978,8 +982,8 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     y2: bigint,
   ): bigint {
     // Adding 1e18 precision
-    const xyRoot = sqrt(x * y * 1000000000000000000n);
-    const x2y2Root = sqrt(x2 * y2 * 1000000000000000000n);
+    const xyRoot = sqrt(x * y * ONE_E18);
+    const x2y2Root = sqrt(x2 * y2 * ONE_E18);
 
     // Calculating 'a' using the given formula
     const a = (y2 * xyRoot + t * xyRoot - y * x2y2Root) / (xyRoot + x2y2Root);

--- a/src/dex/fluid-dex/utils.ts
+++ b/src/dex/fluid-dex/utils.ts
@@ -1,15 +1,11 @@
-import { BigNumber } from 'ethers';
-
-const ONE = BigNumber.from(1);
-const TWO = BigNumber.from(2);
-
-export function sqrt(value: BigNumber) {
-  let x = value;
-  let z = x.add(ONE).div(TWO);
-  let y = x;
-  while (z.sub(y).isNegative()) {
-    y = z;
-    z = x.div(z).add(z).div(TWO);
+export function sqrt(value: bigint): bigint {
+  if (value < 0n) throw new Error('sqrt of negative');
+  if (value < 2n) return value;
+  let z = value;
+  let x = value / 2n + 1n;
+  while (x < z) {
+    z = x;
+    x = (value / x + x) / 2n;
   }
-  return y;
+  return z;
 }

--- a/src/dex/fluid-dex/utils.ts
+++ b/src/dex/fluid-dex/utils.ts
@@ -2,7 +2,7 @@ export function sqrt(value: bigint): bigint {
   if (value < 0n) throw new Error('sqrt of negative');
   if (value < 2n) return value;
   let z = value;
-  let x = value / 2n + 1n;
+  let x = (value + 1n) / 2n;
   while (x < z) {
     z = x;
     x = (value / x + x) / 2n;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches `FluidDex` swap routing math by replacing `ethers` `BigNumber` operations with pure `bigint` arithmetic and a new sqrt implementation, which can subtly change rounding/overflow behavior and impact quote correctness.
> 
> **Overview**
> Optimizes `FluidDex` routing calculations by removing `ethers` `BigNumber` usage and performing `sqrt` and 1e18-precision multiplications with native `bigint` math (via new `ONE_E18` constant). 
> 
> This updates `swapRoutingIn`/`swapRoutingOut` and replaces the prior `BigNumber`-based `sqrt` helper with a `bigint` Newton iteration implementation. Also bumps the package version to `4.8.34`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1f7918dba5e6c17d3d2192c2e6c7b9fa4d533ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->