### PR TITLE
feat: expose legacy DEXes with getTopPoolsForToken to pool tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.40",
+  "version": "4.8.41",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.38",
+  "version": "4.8.39-pt-new-dexs.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.39-pt-new-dexs.0",
+  "version": "4.8.39-pt-new-dexs.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -1,7 +1,13 @@
 import _ from 'lodash';
 import { UnoptimizedRate } from '../types';
 import { CurveV2 } from './curve-v2/curve-v2';
-import { IDexTxBuilder, DexConstructor, IDex, IRouteOptimizer } from './idex';
+import {
+  IDexTxBuilder,
+  DexConstructor,
+  IDex,
+  IDexPooltracker,
+  IRouteOptimizer,
+} from './idex';
 import { StablePool } from './stable-pool/stable-pool';
 import { Weth } from './weth/weth';
 import { PolygonMigrator } from './polygon-migrator/polygon-migrator';
@@ -217,6 +223,9 @@ export class DexAdapterService {
   isLegacy: { [dexKey: string]: boolean } = {};
   // dexKeys only has keys for non legacy dexes
   dexKeys: string[] = [];
+  // legacy dex keys whose class implements `getTopPoolsForToken` and was
+  // successfully constructed for the current network
+  legacyPoolTrackerDexKeys: string[] = [];
   genericRFQDexKeys: Set<string> = new Set();
   uniswapV2Alias: string | null;
 
@@ -272,6 +281,28 @@ export class DexAdapterService {
         if (networks.includes(network)) {
           const dex = new DexAdapter(network, key, dexHelper);
           handleDex(dex, key);
+        }
+      });
+    });
+
+    LegacyDexes.forEach(DexAdapter => {
+      const proto = DexAdapter.prototype as Partial<IDexPooltracker>;
+      if (typeof proto.getTopPoolsForToken !== 'function') return;
+
+      DexAdapter.dexKeys.forEach(key => {
+        const _key = key.toLowerCase();
+        try {
+          const dex = new DexAdapter(dexHelper);
+          this.dexInstances[_key] = dex as unknown as IDexTxBuilder<any, any>;
+          this.legacyPoolTrackerDexKeys.push(key);
+        } catch (e) {
+          dexHelper
+            .getLogger('DexAdapterService')
+            .warn(
+              `Skipping legacy pool-tracker dex "${key}" on network ${network}: ${
+                (e as Error)?.message ?? e
+              }`,
+            );
         }
       });
     });
@@ -345,12 +376,27 @@ export class DexAdapterService {
     return _.uniq(this.dexKeys);
   }
 
+  getPoolTrackerDexKeys(): string[] {
+    return _.uniq([...this.dexKeys, ...this.legacyPoolTrackerDexKeys]);
+  }
+
   getDexByKey(key: string): IDex<any, any, any> {
     const _key = key.toLowerCase();
     if (!(_key in this.isLegacy) || this.isLegacy[_key])
       throw new Error(`Invalid Dex Key ${key}`);
 
     return this.dexInstances[_key] as IDex<any, any, any>;
+  }
+
+  getPoolTrackerByKey(key: string): IDexPooltracker {
+    const _key = key.toLowerCase();
+    const instance = this.dexInstances[_key] as
+      | Partial<IDexPooltracker>
+      | undefined;
+    if (!instance || typeof instance.getTopPoolsForToken !== 'function')
+      throw new Error(`Invalid pool-tracker dex key ${key}`);
+
+    return instance as IDexPooltracker;
   }
 
   getAllDexAdapters(side: SwapSide = SwapSide.SELL) {

--- a/src/dex/pancakeswap-infinity/subgraph.ts
+++ b/src/dex/pancakeswap-infinity/subgraph.ts
@@ -16,12 +16,11 @@ export async function queryAvailablePoolsForToken(
   pools0: SubgraphConnectorPool[];
   pools1: SubgraphConnectorPool[];
 }> {
-  const poolsQuery = `query ($token: Bytes!, $count: Int, $minTVL: Int!) {
+  const poolsQuery = `query ($token: Bytes!, $count: Int) {
     pools0: pools(
       where: {
         token0: $token
         liquidity_gt: 0
-        totalValueLockedUSD_gte: $minTVL
       }
       orderBy: totalValueLockedUSD
       orderDirection: desc
@@ -42,7 +41,6 @@ export async function queryAvailablePoolsForToken(
       where: {
         token1: $token
         liquidity_gt: 0
-        totalValueLockedUSD_gte: $minTVL
       }
       orderBy: totalValueLockedUSD
       orderDirection: desc
@@ -74,7 +72,7 @@ export async function queryAvailablePoolsForToken(
       variables: {
         token: tokenAddress,
         count: limit,
-        minTVL: POOL_MIN_TVL_USD,
+        // minTVL: POOL_MIN_TVL_USD,
       },
     },
     { timeout: SUBGRAPH_TIMEOUT },

--- a/src/pools-helper.ts
+++ b/src/pools-helper.ts
@@ -12,7 +12,7 @@ export class PoolsHelper {
   }
 
   public getAllDexKeys(): string[] {
-    return this.dexAdapterService.getAllDexKeys();
+    return this.dexAdapterService.getPoolTrackerDexKeys();
   }
 
   private async getTopPoolsDex(
@@ -21,7 +21,7 @@ export class PoolsHelper {
     count: number,
   ): Promise<PoolLiquidity[] | string> {
     try {
-      const dex = this.dexAdapterService.getDexByKey(dexKey);
+      const dex = this.dexAdapterService.getPoolTrackerByKey(dexKey);
       return await dex.getTopPoolsForToken(tokenAddress, count);
     } catch (e) {
       this.logger.error(`getTopPools_${dexKey}`, e);
@@ -31,7 +31,7 @@ export class PoolsHelper {
 
   async updateDexPoolState(dexKey: string) {
     try {
-      const dexInstance = this.dexAdapterService.getDexByKey(dexKey);
+      const dexInstance = this.dexAdapterService.getPoolTrackerByKey(dexKey);
       if (!dexInstance.updatePoolState) return;
 
       return await dexInstance.updatePoolState();


### PR DESCRIPTION
## Summary
- Some DEXes in the `LegacyDexes` array (e.g. `PancakeSwapInfinity`) implement `getTopPoolsForToken` even though they are tx-builder-only. By design, `DexAdapterService.getDexByKey()` rejects legacy keys, which prevents them from being reached from `PoolsHelper.getTopPools()`.
- This PR opts those DEXes in: at construction time we eagerly instantiate any `LegacyDexes` entry whose prototype defines `getTopPoolsForToken`, cache the instance, and expose it via two new accessors `DexAdapterService.getPoolTrackerDexKeys()` / `getPoolTrackerByKey()`. `PoolsHelper` now uses those accessors.
- Pricing call sites are unaffected: `getDexByKey()` keeps its existing semantics (still throws for legacy keys), so `pricing-helper.ts` and `local-paraswap-sdk.ts` see no change. Network filtering for legacy DEXes falls out of constructor behavior — failures are warn-logged and the key is skipped (e.g. `PancakeSwapInfinity` only registers on BSC).

## Test plan
- [x] `yarn check:tsc`
- [x] `yarn check:es`
- [x] `yarn prettier --check src/dex/index.ts src/pools-helper.ts`
- [ ] Smoke test on BSC: `getPoolTrackerDexKeys()` includes `pancakeswapinfinity`, `getPoolTrackerByKey('pancakeswapinfinity').getTopPoolsForToken(...)` returns pools, `getDexByKey('pancakeswapinfinity')` still throws
- [ ] Smoke test on Mainnet: `pancakeswapinfinity` absent from `getPoolTrackerDexKeys()`, warn log emitted at construction
- [ ] `yarn test src/dex/pancakeswap-infinity/pancakeswap-infinity-integration.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands pool-tracking to eagerly instantiate certain legacy DEX adapters and changes pool discovery behavior, which could affect runtime initialization and pool selection (plus higher subgraph load due to removed TVL filtering).
> 
> **Overview**
> **Pool tracking now supports selected legacy DEXes.** `DexAdapterService` detects legacy adapters whose prototype implements `getTopPoolsForToken`, instantiates them at startup (skipping/waswo logging on unsupported networks), and exposes them via new `getPoolTrackerDexKeys()` / `getPoolTrackerByKey()` accessors while keeping `getDexByKey()` behavior unchanged.
> 
> **Pool discovery behavior changed.** `PoolsHelper` now uses the new pool-tracker accessors (so legacy pool-trackers are included), and PancakeSwap Infinity’s subgraph query drops the `totalValueLockedUSD_gte` filter (no longer passing `minTVL`).
> 
> Bumps package version to `4.8.41`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61447f63e28e7ce90abdbedb62eb3b47e09d8d44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->