### PR TITLE
fix/pro methods encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.42-genericWithPartnerFee.1",
+  "version": "4.8.42",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.42-genericWithPartnerFee.0",
+  "version": "4.8.42-genericWithPartnerFee.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.41",
+  "version": "4.8.42-genericWithPartnerFee.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/generic-swap-transaction-builder.ts
+++ b/src/generic-swap-transaction-builder.ts
@@ -292,12 +292,11 @@ export class GenericSwapTransactionBuilder {
       bytecode,
     ];
 
-    let method: ContractMethodV6 = isSell
-      ? ContractMethod.swapExactAmountIn
-      : ContractMethod.swapExactAmountOut;
-
     const encoder = (...params: any[]) =>
-      this.augustusV6Interface.encodeFunctionData(method, params);
+      this.augustusV6Interface.encodeFunctionData(
+        priceRoute.contractMethod,
+        params,
+      );
 
     return {
       encoder,

--- a/src/generic-swap-transaction-builder.ts
+++ b/src/generic-swap-transaction-builder.ts
@@ -244,7 +244,6 @@ export class GenericSwapTransactionBuilder {
     beneficiary: Address,
     permit: string,
     uuid: string,
-    genericWithPartnerFee: boolean,
   ) {
     const executorName =
       this.executorDetector.getExecutorByPriceRoute(priceRoute);
@@ -296,12 +295,6 @@ export class GenericSwapTransactionBuilder {
     let method: ContractMethodV6 = isSell
       ? ContractMethod.swapExactAmountIn
       : ContractMethod.swapExactAmountOut;
-
-    if (genericWithPartnerFee) {
-      method = isSell
-        ? ContractMethod.swapExactAmountInPro
-        : ContractMethod.swapExactAmountOutPro;
-    }
 
     const encoder = (...params: any[]) =>
       this.augustusV6Interface.encodeFunctionData(method, params);
@@ -456,7 +449,6 @@ export class GenericSwapTransactionBuilder {
     uuid,
     beneficiary = NULL_ADDRESS,
     onlyParams = false,
-    genericWithPartnerFee = false,
   }: {
     priceRoute: OptimalRate;
     minMaxAmount: string;
@@ -477,7 +469,6 @@ export class GenericSwapTransactionBuilder {
     uuid: string;
     beneficiary?: Address;
     onlyParams?: boolean;
-    genericWithPartnerFee?: boolean;
   }): Promise<TxObject | (string | string[])[]> {
     // if quotedAmount wasn't passed, use the amount from the route
     const _quotedAmount = quotedAmount
@@ -530,7 +521,6 @@ export class GenericSwapTransactionBuilder {
         _beneficiary,
         permit || '0x',
         uuid,
-        genericWithPartnerFee,
       ));
     }
 


### PR DESCRIPTION
- **fix: skip `genericWithPartnerFee` param handling**
- **4.8.42-genericWithPartnerFee.0**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how swap transactions choose the Augustus V6 method to encode, which can alter on-chain call data and cause swaps to fail if `contractMethod` is incorrect or missing.
> 
> **Overview**
> Updates the generic swap transaction builder to **stop deriving the Augustus V6 function selector from `SwapSide`/`genericWithPartnerFee`**, and instead always encode using `priceRoute.contractMethod`.
> 
> Removes the `genericWithPartnerFee` flag from the `build` API and internal `_build` call chain, and bumps the package version to `4.8.42`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6ef2d7b4de6bc3aedf8c28a5d7059a4bc67e0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->