### PR TITLE
feat: `Metric` `BUY` encoding 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.43-metric-buy.0",
+  "version": "4.8.43",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.42",
+  "version": "4.8.43-metric-buy.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/abi/metric/MetricOmmSwapRouter.json
+++ b/src/abi/metric/MetricOmmSwapRouter.json
@@ -52,5 +52,59 @@
     ],
     "stateMutability": "payable",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "pool",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "zeroForOne",
+        "type": "bool"
+      },
+      {
+        "internalType": "uint128",
+        "name": "amountOutDesired",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint128",
+        "name": "priceLimitX64",
+        "type": "uint128"
+      },
+      {
+        "internalType": "uint256",
+        "name": "maxAmountIn",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      }
+    ],
+    "name": "swapExactOutput",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "amountOut",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountInUsed",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "payable",
+    "type": "function"
   }
 ]

--- a/src/dex/metric/metric-e2e.test.ts
+++ b/src/dex/metric/metric-e2e.test.ts
@@ -13,7 +13,9 @@ function buildMetricRoute(params: {
   destAmount: string;
   pool: string;
   zeroForOne: boolean;
+  side?: 'SELL' | 'BUY';
 }): OptimalRate {
+  const side = params.side ?? 'SELL';
   return {
     blockNumber: params.blockNumber,
     network: params.network,
@@ -52,11 +54,12 @@ function buildMetricRoute(params: {
     gasCostUSD: '0',
     gasCost: '150000',
     others: [],
-    side: 'SELL',
+    side,
     version: '6.2',
     contractAddress: '0x6a000f20005980200259b80c5102003040001068',
     tokenTransferProxy: '0x6a000f20005980200259b80c5102003040001068',
-    contractMethod: 'swapExactAmountIn',
+    contractMethod:
+      side === 'SELL' ? 'swapExactAmountIn' : 'swapExactAmountOut',
     partnerFee: 0,
     srcUSD: '0',
     destUSD: '0',
@@ -132,16 +135,15 @@ describe('Metric E2E', () => {
       await testPriceRoute(route);
     });
 
-    // Base tx 0x9e623c0126df14b0ed63d5c2631ccff788873103d3c8d01ddda230beda761e10
-    // 1,250 USDC → ~0.572 WETH (zeroForOne=false)
+    // ~5.006 USDC → ~0.00223 WETH (zeroForOne=false)
     const baseUsdcReverseShared = {
       network: 8453,
-      blockNumber: 44495533,
+      blockNumber: 45353456,
       srcToken: BASE_USDC,
       srcDecimals: 6,
-      srcAmount: '1250000000',
+      srcAmount: '5006456',
       destDecimals: 18,
-      destAmount: '572250811824233202',
+      destAmount: '2232395713582392',
       pool: '0xa6929e903c42a79394f09365f59e916cb0accfd9',
       zeroForOne: false,
     };
@@ -158,6 +160,24 @@ describe('Metric E2E', () => {
       const route = buildMetricRoute({
         ...baseUsdcReverseShared,
         destToken: ETHER_ADDRESS,
+      });
+      await testPriceRoute(route);
+    });
+
+    it('USDC → WETH (BUY)', async () => {
+      const route = buildMetricRoute({
+        ...baseUsdcReverseShared,
+        destToken: BASE_WETH,
+        side: 'BUY',
+      });
+      await testPriceRoute(route);
+    });
+
+    it('USDC → ETH (BUY, unwraps WETH)', async () => {
+      const route = buildMetricRoute({
+        ...baseUsdcReverseShared,
+        destToken: ETHER_ADDRESS,
+        side: 'BUY',
       });
       await testPriceRoute(route);
     });

--- a/src/dex/metric/metric.ts
+++ b/src/dex/metric/metric.ts
@@ -61,34 +61,35 @@ export class Metric
     data: MetricData,
     side: SwapSide,
   ): DexExchangeParam {
-    if (side === SwapSide.BUY) throw new Error(`Buy not supported`);
-
     const deadline = getLocalDeadlineAsFriendlyPlaceholder();
     const priceLimit = this.getPriceLimit(data.zeroForOne);
 
-    const swapData = this.routerInterface.encodeFunctionData(
-      'swapExactInput(address,address,bool,uint128,uint128,uint256,uint256)',
-      [
-        data.pool,
-        recipient,
-        data.zeroForOne,
-        srcAmount,
-        priceLimit,
-        '1',
-        deadline,
-      ],
-    );
+    const swapFunction =
+      side === SwapSide.SELL ? 'swapExactInput' : 'swapExactOutput';
+
+    const swapData = this.routerInterface.encodeFunctionData(swapFunction, [
+      data.pool,
+      recipient,
+      data.zeroForOne,
+      side === SwapSide.SELL ? srcAmount : destAmount,
+      priceLimit,
+      side === SwapSide.SELL ? '1' : srcAmount,
+      deadline,
+    ]);
 
     return {
       needWrapNative: this.needWrapNative,
       dexFuncHasRecipient: true,
       exchangeData: swapData,
       targetExchange: this.routerAddress,
-      returnAmountPos: extractReturnAmountPosition(
-        this.routerInterface,
-        'swapExactInput',
-        'amountOut',
-      ),
+      returnAmountPos:
+        side === SwapSide.SELL
+          ? extractReturnAmountPosition(
+              this.routerInterface,
+              'swapExactInput',
+              'amountOut',
+            )
+          : undefined,
     };
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds BUY-side transaction encoding for the Metric DEX by switching to a new router method and changing calldata/return parsing, which could cause incorrect on-chain swaps if parameter ordering/limits are wrong. Scope is limited to Metric integration plus ABI/test updates.
> 
> **Overview**
> Enables **Metric BUY-side swaps** by adding `swapExactOutput` to the Metric router ABI and updating `Metric.getDexParam` to encode `swapExactOutput` when `side === BUY` (previously BUY was rejected).
> 
> Updates Metric E2E coverage to build routes with an optional `side`, choose the correct `contractMethod`, refresh one USDC→WETH test vector, and add explicit BUY test cases (including unwrap flow). Also bumps package version to `4.8.43`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a71c4a87f9dcde33b5667a0c943612539515bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->