### PR TITLE
feat(BACK-2191): add encoding for `Tessera` dex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.43",
+  "version": "4.8.44-tessera-encoding.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.44-tessera-encoding.0",
+  "version": "4.8.44-tessera-encoding.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.44-tessera-encoding.1",
+  "version": "4.8.44",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/abi/tessera/TesseraSwap.json
+++ b/src/abi/tessera/TesseraSwap.json
@@ -1,0 +1,40 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "tokenIn",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "tokenOut",
+        "type": "address"
+      },
+      {
+        "internalType": "int256",
+        "name": "amountSpecified",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amountCheck",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "swapData",
+        "type": "bytes"
+      }
+    ],
+    "name": "tesseraSwapWithAllowances",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -106,6 +106,7 @@ import { dETH } from './deth/dETH';
 import { Cap } from './cap/cap';
 import { PancakeSwapInfinity } from './pancakeswap-infinity/pancakeswap-infinity';
 import { Metric } from './metric/metric';
+import { Tessera } from './tessera/tessera';
 
 const LegacyDexes = [
   CurveV2,
@@ -119,6 +120,7 @@ const LegacyDexes = [
   EtherFi,
   PancakeSwapInfinity,
   Metric,
+  Tessera,
 ];
 
 const Dexes = [

--- a/src/dex/tessera/config.ts
+++ b/src/dex/tessera/config.ts
@@ -1,0 +1,11 @@
+import { Network } from '../../constants';
+import { Address } from '../../types';
+
+export const TesseraConfig: Record<number, { routerAddress: Address }> = {
+  [Network.BASE]: {
+    routerAddress: '0x55555522005BcAE1c2424D474BfD5ed477749E3e',
+  },
+  [Network.BSC]: {
+    routerAddress: '0x55555522005BcAE1c2424D474BfD5ed477749E3e',
+  },
+};

--- a/src/dex/tessera/tessera-e2e.test.ts
+++ b/src/dex/tessera/tessera-e2e.test.ts
@@ -12,7 +12,9 @@ function buildTesseraRoute(params: {
   destToken: string;
   destDecimals: number;
   destAmount: string;
+  side?: 'SELL' | 'BUY';
 }): OptimalRate {
+  const side = params.side ?? 'SELL';
   return {
     blockNumber: params.blockNumber,
     network: params.network,
@@ -48,11 +50,12 @@ function buildTesseraRoute(params: {
     gasCostUSD: '0',
     gasCost: '150000',
     others: [],
-    side: 'SELL',
+    side,
     version: '6.2',
     contractAddress: '0x6a000f20005980200259b80c5102003040001068',
     tokenTransferProxy: '0x6a000f20005980200259b80c5102003040001068',
-    contractMethod: 'swapExactAmountIn',
+    contractMethod:
+      side === 'SELL' ? 'swapExactAmountIn' : 'swapExactAmountOut',
     partnerFee: 0,
     srcUSD: '0',
     destUSD: '0',
@@ -118,6 +121,24 @@ describe('Tessera E2E', () => {
       });
       await testPriceRoute(route);
     });
+
+    it('USDC → WETH (BUY)', async () => {
+      const route = buildTesseraRoute({
+        ...baseUsdcShared,
+        destToken: baseWeth.address,
+        side: 'BUY',
+      });
+      await testPriceRoute(route);
+    });
+
+    it('USDC → ETH (BUY, unwraps WETH)', async () => {
+      const route = buildTesseraRoute({
+        ...baseUsdcShared,
+        destToken: ETHER_ADDRESS,
+        side: 'BUY',
+      });
+      await testPriceRoute(route);
+    });
   });
 
   describe('BSC', () => {
@@ -172,6 +193,24 @@ describe('Tessera E2E', () => {
       const route = buildTesseraRoute({
         ...bscUsdtShared,
         destToken: ETHER_ADDRESS,
+      });
+      await testPriceRoute(route);
+    });
+
+    it('WBNB → USDT (BUY)', async () => {
+      const route = buildTesseraRoute({
+        ...bscWbnbShared,
+        srcToken: bscWbnb.address,
+        side: 'BUY',
+      });
+      await testPriceRoute(route);
+    });
+
+    it('BNB → USDT (BUY, wraps to WBNB)', async () => {
+      const route = buildTesseraRoute({
+        ...bscWbnbShared,
+        srcToken: ETHER_ADDRESS,
+        side: 'BUY',
       });
       await testPriceRoute(route);
     });

--- a/src/dex/tessera/tessera-e2e.test.ts
+++ b/src/dex/tessera/tessera-e2e.test.ts
@@ -1,0 +1,179 @@
+import { testPriceRoute } from '../../../tests/utils-e2e';
+import { OptimalRate } from '@paraswap/core';
+import { ETHER_ADDRESS, Network } from '../../constants';
+import { Tokens } from '../../../tests/constants-e2e';
+
+function buildTesseraRoute(params: {
+  network: number;
+  blockNumber: number;
+  srcToken: string;
+  srcDecimals: number;
+  srcAmount: string;
+  destToken: string;
+  destDecimals: number;
+  destAmount: string;
+}): OptimalRate {
+  return {
+    blockNumber: params.blockNumber,
+    network: params.network,
+    srcToken: params.srcToken,
+    srcDecimals: params.srcDecimals,
+    srcAmount: params.srcAmount,
+    destToken: params.destToken,
+    destDecimals: params.destDecimals,
+    destAmount: params.destAmount,
+    bestRoute: [
+      {
+        percent: 100,
+        swaps: [
+          {
+            srcToken: params.srcToken,
+            srcDecimals: params.srcDecimals,
+            destToken: params.destToken,
+            destDecimals: params.destDecimals,
+            swapExchanges: [
+              {
+                exchange: 'Tessera',
+                srcAmount: params.srcAmount,
+                destAmount: params.destAmount,
+                percent: 100,
+                poolAddresses: [],
+                data: null,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    gasCostUSD: '0',
+    gasCost: '150000',
+    others: [],
+    side: 'SELL',
+    version: '6.2',
+    contractAddress: '0x6a000f20005980200259b80c5102003040001068',
+    tokenTransferProxy: '0x6a000f20005980200259b80c5102003040001068',
+    contractMethod: 'swapExactAmountIn',
+    partnerFee: 0,
+    srcUSD: '0',
+    destUSD: '0',
+    partner: 'anon',
+    maxImpactReached: false,
+    hmac: '',
+  } as unknown as OptimalRate;
+}
+
+describe('Tessera E2E', () => {
+  describe('Base', () => {
+    const baseWeth = Tokens[Network.BASE].WETH;
+    const baseUsdc = Tokens[Network.BASE].USDC;
+
+    const baseUsdcShared = {
+      network: Network.BASE,
+      blockNumber: 45600823,
+      srcToken: baseUsdc.address,
+      srcDecimals: baseUsdc.decimals,
+      srcAmount: '1000000',
+      destDecimals: baseWeth.decimals,
+      destAmount: '420526831788390',
+    };
+
+    it('USDC → WETH', async () => {
+      const route = buildTesseraRoute({
+        ...baseUsdcShared,
+        destToken: baseWeth.address,
+      });
+      await testPriceRoute(route);
+    });
+
+    it('USDC → ETH (unwraps WETH)', async () => {
+      const route = buildTesseraRoute({
+        ...baseUsdcShared,
+        destToken: ETHER_ADDRESS,
+      });
+      await testPriceRoute(route);
+    });
+
+    const baseWethShared = {
+      network: Network.BASE,
+      blockNumber: 45600823,
+      srcDecimals: baseWeth.decimals,
+      srcAmount: '1000000000000000000',
+      destToken: baseUsdc.address,
+      destDecimals: baseUsdc.decimals,
+      destAmount: '2377679443',
+    };
+
+    it('WETH → USDC', async () => {
+      const route = buildTesseraRoute({
+        ...baseWethShared,
+        srcToken: baseWeth.address,
+      });
+      await testPriceRoute(route);
+    });
+
+    it('ETH → USDC (wraps to WETH)', async () => {
+      const route = buildTesseraRoute({
+        ...baseWethShared,
+        srcToken: ETHER_ADDRESS,
+      });
+      await testPriceRoute(route);
+    });
+  });
+
+  describe('BSC', () => {
+    const bscWbnb = Tokens[Network.BSC].WBNB;
+    const bscUsdt = Tokens[Network.BSC].USDT;
+
+    const bscWbnbShared = {
+      network: Network.BSC,
+      blockNumber: 96572572,
+      srcDecimals: bscWbnb.decimals,
+      srcAmount: '1000000000000000000',
+      destToken: bscUsdt.address,
+      destDecimals: bscUsdt.decimals,
+      destAmount: '631755922471100996711',
+    };
+
+    it('WBNB → USDT', async () => {
+      const route = buildTesseraRoute({
+        ...bscWbnbShared,
+        srcToken: bscWbnb.address,
+      });
+      await testPriceRoute(route);
+    });
+
+    it('BNB → USDT (wraps to WBNB)', async () => {
+      const route = buildTesseraRoute({
+        ...bscWbnbShared,
+        srcToken: ETHER_ADDRESS,
+      });
+      await testPriceRoute(route);
+    });
+
+    const bscUsdtShared = {
+      network: Network.BSC,
+      blockNumber: 96572572,
+      srcToken: bscUsdt.address,
+      srcDecimals: bscUsdt.decimals,
+      srcAmount: '1000000000000000000',
+      destDecimals: bscWbnb.decimals,
+      destAmount: '1582521639071061',
+    };
+
+    it('USDT → WBNB', async () => {
+      const route = buildTesseraRoute({
+        ...bscUsdtShared,
+        destToken: bscWbnb.address,
+      });
+      await testPriceRoute(route);
+    });
+
+    it('USDT → BNB (unwraps WBNB)', async () => {
+      const route = buildTesseraRoute({
+        ...bscUsdtShared,
+        destToken: ETHER_ADDRESS,
+      });
+      await testPriceRoute(route);
+    });
+  });
+});

--- a/src/dex/tessera/tessera.ts
+++ b/src/dex/tessera/tessera.ts
@@ -1,0 +1,65 @@
+import { Interface, JsonFragment } from '@ethersproject/abi';
+import { SwapSide } from '../../constants';
+import {
+  AdapterExchangeParam,
+  Address,
+  DexExchangeParam,
+  NumberAsString,
+} from '../../types';
+import { IDexTxBuilder } from '../idex';
+import { SimpleExchange } from '../simple-exchange';
+import TesseraSwapABI from '../../abi/tessera/TesseraSwap.json';
+import { IDexHelper } from '../../dex-helper';
+import { TesseraConfig } from './config';
+
+export class Tessera extends SimpleExchange implements IDexTxBuilder<null> {
+  static dexKeys = ['tessera'];
+  needWrapNative = true;
+
+  readonly routerInterface: Interface;
+  readonly routerAddress: Address;
+
+  constructor(readonly dexHelper: IDexHelper) {
+    super(dexHelper, 'tessera');
+    this.routerInterface = new Interface(TesseraSwapABI as JsonFragment[]);
+
+    const config = TesseraConfig[this.network];
+    if (!config) {
+      throw new Error(`Tessera: unsupported network ${this.network}`);
+    }
+    this.routerAddress = config.routerAddress;
+  }
+
+  getAdapterParam(): AdapterExchangeParam {
+    throw new Error('Tessera: V5 not supported');
+  }
+
+  getDexParam(
+    srcToken: Address,
+    destToken: Address,
+    srcAmount: NumberAsString,
+    _destAmount: NumberAsString,
+    recipient: Address,
+    _data: null,
+    side: SwapSide,
+  ): DexExchangeParam {
+    if (side !== SwapSide.SELL) {
+      throw new Error('Tessera: BUY not supported');
+    }
+
+    const tokenIn = this.dexHelper.config.wrapETH(srcToken);
+    const tokenOut = this.dexHelper.config.wrapETH(destToken);
+
+    const swapCalldata = this.routerInterface.encodeFunctionData(
+      'tesseraSwapWithAllowances',
+      [tokenIn, tokenOut, srcAmount, '0', recipient, '0x'],
+    );
+
+    return {
+      needWrapNative: this.needWrapNative,
+      dexFuncHasRecipient: true,
+      exchangeData: swapCalldata,
+      targetExchange: this.routerAddress,
+    };
+  }
+}

--- a/src/dex/tessera/tessera.ts
+++ b/src/dex/tessera/tessera.ts
@@ -38,21 +38,21 @@ export class Tessera extends SimpleExchange implements IDexTxBuilder<null> {
     srcToken: Address,
     destToken: Address,
     srcAmount: NumberAsString,
-    _destAmount: NumberAsString,
+    destAmount: NumberAsString,
     recipient: Address,
     _data: null,
     side: SwapSide,
   ): DexExchangeParam {
-    if (side !== SwapSide.SELL) {
-      throw new Error('Tessera: BUY not supported');
-    }
-
     const tokenIn = this.dexHelper.config.wrapETH(srcToken);
     const tokenOut = this.dexHelper.config.wrapETH(destToken);
 
+    const isSell = side === SwapSide.SELL;
+    const amountSpecified = isSell ? srcAmount : `-${destAmount}`;
+    const amountCheck = isSell ? '0' : srcAmount;
+
     const swapCalldata = this.routerInterface.encodeFunctionData(
       'tesseraSwapWithAllowances',
-      [tokenIn, tokenOut, srcAmount, '0', recipient, '0x'],
+      [tokenIn, tokenOut, amountSpecified, amountCheck, recipient, '0x'],
     );
 
     return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new legacy DEX integration that constructs on-chain swap calldata and routes traffic through a configured router on Base/BSC, so incorrect encoding or config could cause failed swaps or misrouted funds.
> 
> **Overview**
> Adds **Tessera** as a new (legacy) DEX option, wiring it into `src/dex/index.ts` so it can be selected by key.
> 
> Implements `Tessera` tx building (`getDexParam`) using a new `TesseraSwap` ABI to encode `tesseraSwapWithAllowances`, including native wrap/unwrap handling and BUY vs SELL amount semantics, backed by per-network router addresses (Base/BSC).
> 
> Adds Tessera-focused E2E tests that exercise SELL and BUY routes across Base and BSC token pairs, and bumps the package version to `4.8.44`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32d4a6f5fe349635528f1df7fd17480e50a5dc26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->