### PR TITLE
feat: encode swap calldata for new DEXes via remote API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.44-new-dexs-encoding.0",
+  "version": "4.8.44-new-dexs-encoding.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.43",
+  "version": "4.8.44-new-dexs-encoding.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.44-new-dexs-encoding.3",
+  "version": "4.8.44",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.44",
+  "version": "4.8.45",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.44-new-dexs-encoding.2",
+  "version": "4.8.44-new-dexs-encoding.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "4.8.44-new-dexs-encoding.1",
+  "version": "4.8.44-new-dexs-encoding.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/aave-v3-pt-roll-over/aave-v3-pt-roll-over.ts
+++ b/src/dex/aave-v3-pt-roll-over/aave-v3-pt-roll-over.ts
@@ -17,7 +17,7 @@ import {
 } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { getDexKeysWithNetwork } from '../../utils';
-import { Context, IDex } from '../../dex/idex';
+import { IDex } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import { AaveV3PtRollOverData, DexParams, PendleSDKMarket } from './types';
 import { SimpleExchange } from '../simple-exchange';
@@ -408,7 +408,6 @@ export class AaveV3PtRollOver
     recipient: Address,
     data: AaveV3PtRollOverData,
     side: SwapSide,
-    context: Context,
     executorAddress: Address,
   ): Promise<DexExchangeParam> {
     // Call Pendle SDK roll-over-pt endpoint for PT rollover

--- a/src/dex/aave-v3-stata-v2/aave-v3-stata-v2.ts
+++ b/src/dex/aave-v3-stata-v2/aave-v3-stata-v2.ts
@@ -12,7 +12,7 @@ import {
 import { SwapSide, Network, UNLIMITED_USD_LIQUIDITY } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { Utils, getBigIntPow, getDexKeysWithNetwork } from '../../utils';
-import { Context, IDex } from '../../dex/idex';
+import { IDex } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import {
   AaveV3StataV2Data,
@@ -288,7 +288,6 @@ export class AaveV3StataV2
     recipient: Address,
     data: AaveV3StataV2Data,
     side: SwapSide,
-    _: Context,
     executorAddress: Address,
   ): DexExchangeParam {
     const { exchange, srcType, destType } = data;

--- a/src/dex/aave-v3-stata/aave-v3-stata.ts
+++ b/src/dex/aave-v3-stata/aave-v3-stata.ts
@@ -13,7 +13,7 @@ import {
 import { SwapSide, Network, UNLIMITED_USD_LIQUIDITY } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { Utils, getBigIntPow, getDexKeysWithNetwork } from '../../utils';
-import { Context, IDex } from '../../dex/idex';
+import { IDex } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import {
   AaveV3StataData,
@@ -368,7 +368,6 @@ export class AaveV3Stata
     recipient: Address,
     data: AaveV3StataData,
     side: SwapSide,
-    _: Context,
     executorAddress: Address,
   ): DexExchangeParam {
     const { exchange, srcType, destType } = data;

--- a/src/dex/angle-staked-stable/angle-staked-stable.ts
+++ b/src/dex/angle-staked-stable/angle-staked-stable.ts
@@ -15,7 +15,7 @@ import type {
 import { SwapSide, Network, UNLIMITED_USD_LIQUIDITY } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { getDexKeysWithNetwork } from '../../utils';
-import type { Context, IDex } from '../../dex/idex';
+import type { IDex } from '../../dex/idex';
 import type { IDexHelper } from '../../dex-helper/idex-helper';
 import type { AngleStakedStableData, DexParams } from './types';
 import { SimpleExchange } from '../simple-exchange';
@@ -240,7 +240,6 @@ export class AngleStakedStable
     recipient: Address,
     data: AngleStakedStableData,
     side: SwapSide,
-    _: Context,
     executorAddress: Address,
   ): DexExchangeParam {
     const { exchange } = data;

--- a/src/dex/angle-transmuter/angle-transmuter.ts
+++ b/src/dex/angle-transmuter/angle-transmuter.ts
@@ -13,7 +13,7 @@ import {
 import { SwapSide, Network, UNLIMITED_USD_LIQUIDITY } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { getDexKeysWithNetwork } from '../../utils';
-import { Context, IDex } from '../../dex/idex';
+import { IDex } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import { AngleTransmuterData, DexParams } from './types';
 import { SimpleExchange } from '../simple-exchange';
@@ -223,7 +223,6 @@ export class AngleTransmuter
     recipient: Address,
     data: AngleTransmuterData,
     side: SwapSide,
-    _: Context,
     executorAddress: Address,
   ): DexExchangeParam {
     const { exchange } = data;

--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -39,7 +39,7 @@ import {
   getDexKeysWithNetwork,
   uuidToBytes16,
 } from '../../utils';
-import { Context, IDex } from '../../dex/idex';
+import { IDex } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper';
 import {
   BalancerV2BatchSwapParam,
@@ -1654,7 +1654,6 @@ export class BalancerV2
     recipient: Address,
     data: OptimizedBalancerV2Data,
     side: SwapSide,
-    context: Context,
     executor: Address,
   ): DexExchangeParam {
     const balancerBatchSwapParam = this.getBalancerV2BatchSwapParam(

--- a/src/dex/ekubo-v3/ekubo-v3.ts
+++ b/src/dex/ekubo-v3/ekubo-v3.ts
@@ -2,7 +2,7 @@ import { Interface } from '@ethersproject/abi';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { ETHER_ADDRESS, Network, SwapSide } from '../../constants';
 import { IDexHelper } from '../../dex-helper/idex-helper';
-import { Context, IDex } from '../idex';
+import { IDex } from '../idex';
 import {
   AdapterExchangeParam,
   Address,
@@ -184,7 +184,6 @@ export class EkuboV3 extends SimpleExchange implements IDex<EkuboData> {
     recipient: Address,
     data: EkuboData,
     side: SwapSide,
-    _context: Context,
     _executorAddress: Address,
   ): DexExchangeParam {
     const amount = BigInt(side === SwapSide.BUY ? `-${destAmount}` : srcAmount);

--- a/src/dex/ekubo/ekubo.ts
+++ b/src/dex/ekubo/ekubo.ts
@@ -3,7 +3,7 @@ import Joi from 'joi';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { ETHER_ADDRESS, Network, SwapSide } from '../../constants';
 import { IDexHelper } from '../../dex-helper/idex-helper';
-import { Context, IDex } from '../../dex/idex';
+import { IDex } from '../../dex/idex';
 import {
   AdapterExchangeParam,
   Address,
@@ -488,7 +488,6 @@ export class Ekubo extends SimpleExchange implements IDex<EkuboData> {
     recipient: Address,
     data: EkuboData,
     side: SwapSide,
-    _context: Context,
     _executorAddress: Address,
   ): DexExchangeParam {
     const amount = BigInt(side === SwapSide.BUY ? `-${destAmount}` : srcAmount);

--- a/src/dex/erc4626/erc4626.ts
+++ b/src/dex/erc4626/erc4626.ts
@@ -18,7 +18,7 @@ import {
 } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { getDexKeysWithNetwork } from '../../utils';
-import { IDex, Context } from '../idex';
+import { IDex } from '../idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import {
   ERC4626Data,
@@ -295,7 +295,6 @@ export class ERC4626
     recipient: Address,
     data: ERC4626Data,
     side: SwapSide,
-    _: Context,
     executorAddress: Address,
   ): DexExchangeParam {
     const isSell = side === SwapSide.SELL;

--- a/src/dex/fluid-dex/fluid-dex.ts
+++ b/src/dex/fluid-dex/fluid-dex.ts
@@ -11,7 +11,7 @@ import {
 } from '../../types';
 import { SwapSide, Network } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
-import { Context, IDex } from '../idex';
+import { IDex } from '../idex';
 import { IDexHelper } from '../../dex-helper';
 import {
   CollateralReserves,
@@ -474,7 +474,6 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     recipient: Address,
     data: FluidDexData,
     side: SwapSide,
-    context: Context,
     executorAddress: Address,
   ): Promise<DexExchangeParam> {
     let args: any;

--- a/src/dex/idex.ts
+++ b/src/dex/idex.ts
@@ -20,11 +20,6 @@ import { SwapSide, Network } from '../constants';
 import { IDexHelper } from '../dex-helper/idex-helper';
 import { OptimalRate, OptimalSwap } from '@paraswap/core';
 
-export type Context = {
-  isGlobalSrcToken: boolean;
-  isGlobalDestToken: boolean;
-};
-
 export type NeedWrapNativeFunc = (
   priceRoute: OptimalRate,
   swap: OptimalSwap,
@@ -88,7 +83,6 @@ export interface IDexTxBuilderV6<ExchangeData, DirectParam = null> {
     recipient: Address,
     data: ExchangeData,
     side: SwapSide,
-    context: Context,
     executorAddress: Address,
   ): AsyncOrSync<DexExchangeParam>;
 

--- a/src/dex/maverick-v2/maverick-v2.ts
+++ b/src/dex/maverick-v2/maverick-v2.ts
@@ -13,7 +13,7 @@ import {
 import { SwapSide, Network, NULL_ADDRESS } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { getBigIntPow, getDexKeysWithNetwork, isTruthy } from '../../utils';
-import { Context, IDex } from '../../dex/idex';
+import { IDex } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import { MaverickV2Data, PoolAPIResponse } from './types';
 import { SimpleExchange } from '../simple-exchange';

--- a/src/dex/metric/config.ts
+++ b/src/dex/metric/config.ts
@@ -3,19 +3,19 @@ import { Address } from '../../types';
 
 export const MetricConfig: Record<number, { routerAddress: Address }> = {
   [Network.MAINNET]: {
-    routerAddress: '0xcB41C10c6414aCbea022c7662df4005dd8FBEF91',
+    routerAddress: '0xcb41c10c6414acbea022c7662df4005dd8fbef91',
   },
   [Network.BASE]: {
-    routerAddress: '0xA6A16C00B7E9DBE1D54acEd7d6FE264fc4732eaF',
+    routerAddress: '0xa6a16c00b7e9dbe1d54aced7d6fe264fc4732eaf',
   },
   [Network.BSC]: {
-    routerAddress: '0xa9a63266bB70eb3419C34C245F4318983f325Bbd',
+    routerAddress: '0xa9a63266bb70eb3419c34c245f4318983f325bbd',
   },
   [Network.ARBITRUM]: {
-    routerAddress: '0x82A562fD9F02d4346B95D3a2a501411979C8F920',
+    routerAddress: '0x82a562fd9f02d4346b95d3a2a501411979c8f920',
   },
   [Network.POLYGON]: {
-    routerAddress: '0x976c26402E1EC10454c5Fe6D2C9857DD57aE78f3',
+    routerAddress: '0x976c26402e1ec10454c5fe6d2c9857dd57ae78f3',
   },
 };
 

--- a/src/dex/metric/metric-e2e.test.ts
+++ b/src/dex/metric/metric-e2e.test.ts
@@ -1,6 +1,83 @@
 import { testPriceRoute } from '../../../tests/utils-e2e';
 import { OptimalRate } from '@paraswap/core';
-import { ETHER_ADDRESS } from '../../constants';
+import { ETHER_ADDRESS, SwapSide } from '../../constants';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { DexAdapterService } from '..';
+import {
+  GenericSwapTransactionBuilder,
+  normaliseRemoteDexExchangeParam,
+} from '../../generic-swap-transaction-builder';
+import { Metric } from './metric';
+
+const METRIC_REMOTE_BASE_URL = 'http://api-go.staging.paraswap.io';
+const METRIC_REMOTE_DEX_KEY = 'metric';
+const PARITY_HTTP_TIMEOUT_MS = 10_000;
+
+async function expectMetricEncodingMatches(route: OptimalRate) {
+  const dexHelper = new DummyDexHelper(route.network);
+  const dexAdapterService = new DexAdapterService(dexHelper, route.network);
+  const metric = new Metric(dexHelper);
+  const builder = new GenericSwapTransactionBuilder(dexAdapterService);
+
+  const executorAddress = builder.getExecutionContractAddress(route);
+  const swap = route.bestRoute[0].swaps[0];
+  const se = swap.swapExchanges[0];
+
+  // minMaxAmount value doesn't matter for encoding parity as long as both
+  // calls see the same one.
+  const minMaxAmount = route.side === SwapSide.SELL ? '1' : route.srcAmount;
+
+  const callParams = builder.getDexCallsParams(
+    route,
+    0,
+    swap,
+    0,
+    se,
+    minMaxAmount,
+    metric.needWrapNative,
+    executorAddress,
+  );
+
+  // Mirror `buildCalls`: BUY uses the per-leg `se.srcAmount`, SELL uses the
+  // (possibly slippage-adjusted) normalized srcAmount.
+  const srcAmountForCall =
+    route.side === SwapSide.BUY ? se.srcAmount : callParams.srcAmount;
+
+  const localParam = metric.getDexParam(
+    callParams.srcToken,
+    callParams.destToken,
+    srcAmountForCall,
+    callParams.destAmount,
+    callParams.recipient,
+    se.data,
+    route.side,
+  );
+
+  const url = `${METRIC_REMOTE_BASE_URL}/api/v1/dexs/${route.network}/${METRIC_REMOTE_DEX_KEY}/dex-param`;
+  const remoteRaw = await dexHelper.httpRequest.post<unknown>(
+    url,
+    {
+      srcToken: callParams.srcToken,
+      destToken: callParams.destToken,
+      srcAmount: srcAmountForCall,
+      destAmount: callParams.destAmount,
+      recipient: callParams.recipient,
+      executorAddress,
+      side: route.side,
+      data: se.data,
+    },
+    PARITY_HTTP_TIMEOUT_MS,
+  );
+  const remoteParam = normaliseRemoteDexExchangeParam(remoteRaw);
+
+  // Resolve any function-typed `needWrapNative` on the local side. Metric
+  // uses a plain bool today, but the interface allows a function.
+  if (typeof localParam.needWrapNative === 'function') {
+    localParam.needWrapNative = localParam.needWrapNative(route, swap, se);
+  }
+
+  expect(remoteParam).toEqual(localParam);
+}
 
 function buildMetricRoute(params: {
   network: number;
@@ -95,6 +172,7 @@ describe('Metric E2E', () => {
         srcToken: BASE_WETH,
       });
       await testPriceRoute(route);
+      await expectMetricEncodingMatches(route);
     });
 
     it('ETH → cbBTC (wraps to WETH)', async () => {
@@ -103,6 +181,7 @@ describe('Metric E2E', () => {
         srcToken: ETHER_ADDRESS,
       });
       await testPriceRoute(route);
+      await expectMetricEncodingMatches(route);
     });
 
     // Base tx 0xc49fd6804e1d0b38324a4146edfcdd2cca0be71c328952e2a7a6aeff4cf969ac
@@ -125,6 +204,7 @@ describe('Metric E2E', () => {
         srcToken: BASE_WETH,
       });
       await testPriceRoute(route);
+      await expectMetricEncodingMatches(route);
     });
 
     it('ETH → USDC (wraps to WETH)', async () => {
@@ -133,6 +213,7 @@ describe('Metric E2E', () => {
         srcToken: ETHER_ADDRESS,
       });
       await testPriceRoute(route);
+      await expectMetricEncodingMatches(route);
     });
 
     // ~5.006 USDC → ~0.00223 WETH (zeroForOne=false)
@@ -154,6 +235,7 @@ describe('Metric E2E', () => {
         destToken: BASE_WETH,
       });
       await testPriceRoute(route);
+      await expectMetricEncodingMatches(route);
     });
 
     it('USDC → ETH (unwraps WETH)', async () => {
@@ -162,6 +244,7 @@ describe('Metric E2E', () => {
         destToken: ETHER_ADDRESS,
       });
       await testPriceRoute(route);
+      await expectMetricEncodingMatches(route);
     });
 
     it('USDC → WETH (BUY)', async () => {
@@ -171,6 +254,7 @@ describe('Metric E2E', () => {
         side: 'BUY',
       });
       await testPriceRoute(route);
+      await expectMetricEncodingMatches(route);
     });
 
     it('USDC → ETH (BUY, unwraps WETH)', async () => {
@@ -180,6 +264,7 @@ describe('Metric E2E', () => {
         side: 'BUY',
       });
       await testPriceRoute(route);
+      await expectMetricEncodingMatches(route);
     });
   });
 });

--- a/src/dex/metric/metric-e2e.test.ts
+++ b/src/dex/metric/metric-e2e.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../../generic-swap-transaction-builder';
 import { Metric } from './metric';
 
-const METRIC_REMOTE_BASE_URL = 'http://api-go.staging.paraswap.io';
+const METRIC_REMOTE_BASE_URL = 'http://api.example.paraswap.io';
 const METRIC_REMOTE_DEX_KEY = 'metric';
 const PARITY_HTTP_TIMEOUT_MS = 10_000;
 

--- a/src/dex/oswap/oswap.ts
+++ b/src/dex/oswap/oswap.ts
@@ -20,7 +20,7 @@ import {
 } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { getDexKeysWithNetwork, getBigIntPow } from '../../utils';
-import { Context, IDex } from '../../dex/idex';
+import { IDex } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import { OSwapData, OSwapPool, OSwapPoolState } from './types';
 import {
@@ -403,7 +403,6 @@ export class OSwap extends SimpleExchange implements IDex<OSwapData> {
     recipient: Address,
     data: OSwapData,
     side: SwapSide,
-    _: Context,
     executorAddress: Address,
   ): DexExchangeParam {
     let method: string;

--- a/src/dex/spark/spark-psm.ts
+++ b/src/dex/spark/spark-psm.ts
@@ -7,7 +7,6 @@ import {
   SparkSUSDSPsmFunctions,
 } from './types';
 import { SwapSide } from '@paraswap/core/build/constants';
-import { Context } from '../idex';
 import {
   ConnectorToken,
   DexConfigMap,
@@ -320,7 +319,6 @@ export class SparkPsm extends Spark {
     recipient: Address,
     data: SparkData,
     side: SwapSide,
-    _: Context,
     executorAddress: Address,
   ): DexExchangeParam {
     const isSell = side === SwapSide.SELL;

--- a/src/dex/spark/spark.ts
+++ b/src/dex/spark/spark.ts
@@ -1,5 +1,5 @@
 import { SimpleExchange } from '../simple-exchange';
-import { Context, IDex } from '../idex';
+import { IDex } from '../idex';
 import { SparkParams, SparkData, SparkSDaiPoolState } from './types';
 import { Network, SwapSide, UNLIMITED_USD_LIQUIDITY } from '../../constants';
 import { getDexKeysWithNetwork } from '../../utils';
@@ -239,7 +239,6 @@ export class Spark
     recipient: Address,
     data: SparkData,
     side: SwapSide,
-    _: Context,
     executorAddress: Address,
   ): DexExchangeParam {
     const isSell = side === SwapSide.SELL;

--- a/src/dex/tessera/config.ts
+++ b/src/dex/tessera/config.ts
@@ -3,9 +3,9 @@ import { Address } from '../../types';
 
 export const TesseraConfig: Record<number, { routerAddress: Address }> = {
   [Network.BASE]: {
-    routerAddress: '0x55555522005BcAE1c2424D474BfD5ed477749E3e',
+    routerAddress: '0x55555522005bcae1c2424d474bfd5ed477749e3e',
   },
   [Network.BSC]: {
-    routerAddress: '0x55555522005BcAE1c2424D474BfD5ed477749E3e',
+    routerAddress: '0x55555522005bcae1c2424d474bfd5ed477749e3e',
   },
 };

--- a/src/dex/tessera/tessera-e2e.test.ts
+++ b/src/dex/tessera/tessera-e2e.test.ts
@@ -1,7 +1,85 @@
 import { testPriceRoute } from '../../../tests/utils-e2e';
 import { OptimalRate } from '@paraswap/core';
-import { ETHER_ADDRESS, Network } from '../../constants';
+import { ETHER_ADDRESS, Network, SwapSide } from '../../constants';
 import { Tokens } from '../../../tests/constants-e2e';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { DexAdapterService } from '..';
+import {
+  GenericSwapTransactionBuilder,
+  normaliseRemoteDexExchangeParam,
+} from '../../generic-swap-transaction-builder';
+import { Tessera } from './tessera';
+
+const TESSERA_REMOTE_BASE_URL = 'http://api.example.paraswap.io';
+const TESSERA_REMOTE_DEX_KEY = 'tessera';
+const PARITY_HTTP_TIMEOUT_MS = 10_000;
+
+async function expectTesseraEncodingMatches(route: OptimalRate) {
+  const dexHelper = new DummyDexHelper(route.network);
+  const dexAdapterService = new DexAdapterService(dexHelper, route.network);
+  const tessera = new Tessera(dexHelper);
+  const builder = new GenericSwapTransactionBuilder(dexAdapterService);
+
+  const executorAddress = builder.getExecutionContractAddress(route);
+  const swap = route.bestRoute[0].swaps[0];
+  const se = swap.swapExchanges[0];
+
+  // minMaxAmount value doesn't matter for encoding parity as long as both
+  // calls see the same one — pick the value `_build()` would choose at the
+  // upper-bound slippage edge.
+  const minMaxAmount = route.side === SwapSide.SELL ? '1' : route.srcAmount;
+
+  const callParams = builder.getDexCallsParams(
+    route,
+    0,
+    swap,
+    0,
+    se,
+    minMaxAmount,
+    tessera.needWrapNative,
+    executorAddress,
+  );
+
+  // Mirror `buildCalls`: BUY uses the per-leg `se.srcAmount`, SELL uses the
+  // (possibly slippage-adjusted) normalized srcAmount.
+  const srcAmountForCall =
+    route.side === SwapSide.BUY ? se.srcAmount : callParams.srcAmount;
+
+  const localParam = tessera.getDexParam(
+    callParams.srcToken,
+    callParams.destToken,
+    srcAmountForCall,
+    callParams.destAmount,
+    callParams.recipient,
+    null,
+    route.side,
+  );
+
+  const url = `${TESSERA_REMOTE_BASE_URL}/api/v1/dexs/${route.network}/${TESSERA_REMOTE_DEX_KEY}/dex-param`;
+  const remoteRaw = await dexHelper.httpRequest.post<unknown>(
+    url,
+    {
+      srcToken: callParams.srcToken,
+      destToken: callParams.destToken,
+      srcAmount: srcAmountForCall,
+      destAmount: callParams.destAmount,
+      recipient: callParams.recipient,
+      executorAddress,
+      side: route.side,
+      data: null,
+    },
+    PARITY_HTTP_TIMEOUT_MS,
+  );
+  const remoteParam = normaliseRemoteDexExchangeParam(remoteRaw);
+
+  // Resolve any function-typed `needWrapNative` on the local side. Tessera
+  // uses a plain bool today, but the interface allows a function.
+  if (typeof localParam.needWrapNative === 'function') {
+    localParam.needWrapNative = localParam.needWrapNative(route, swap, se);
+  }
+
+  expect(remoteParam).toEqual(localParam);
+}
 
 function buildTesseraRoute(params: {
   network: number;
@@ -86,6 +164,7 @@ describe('Tessera E2E', () => {
         destToken: baseWeth.address,
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     it('USDC → ETH (unwraps WETH)', async () => {
@@ -94,6 +173,7 @@ describe('Tessera E2E', () => {
         destToken: ETHER_ADDRESS,
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     const baseWethShared = {
@@ -112,6 +192,7 @@ describe('Tessera E2E', () => {
         srcToken: baseWeth.address,
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     it('ETH → USDC (wraps to WETH)', async () => {
@@ -120,6 +201,7 @@ describe('Tessera E2E', () => {
         srcToken: ETHER_ADDRESS,
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     it('USDC → WETH (BUY)', async () => {
@@ -129,6 +211,7 @@ describe('Tessera E2E', () => {
         side: 'BUY',
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     it('USDC → ETH (BUY, unwraps WETH)', async () => {
@@ -138,6 +221,7 @@ describe('Tessera E2E', () => {
         side: 'BUY',
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
   });
 
@@ -161,6 +245,7 @@ describe('Tessera E2E', () => {
         srcToken: bscWbnb.address,
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     it('BNB → USDT (wraps to WBNB)', async () => {
@@ -169,6 +254,7 @@ describe('Tessera E2E', () => {
         srcToken: ETHER_ADDRESS,
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     const bscUsdtShared = {
@@ -187,6 +273,7 @@ describe('Tessera E2E', () => {
         destToken: bscWbnb.address,
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     it('USDT → BNB (unwraps WBNB)', async () => {
@@ -195,6 +282,7 @@ describe('Tessera E2E', () => {
         destToken: ETHER_ADDRESS,
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     it('WBNB → USDT (BUY)', async () => {
@@ -204,6 +292,7 @@ describe('Tessera E2E', () => {
         side: 'BUY',
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
 
     it('BNB → USDT (BUY, wraps to WBNB)', async () => {
@@ -213,6 +302,7 @@ describe('Tessera E2E', () => {
         side: 'BUY',
       });
       await testPriceRoute(route);
+      await expectTesseraEncodingMatches(route);
     });
   });
 });

--- a/src/generic-swap-transaction-builder.ts
+++ b/src/generic-swap-transaction-builder.ts
@@ -75,7 +75,9 @@ const remoteDexExchangeParamSchema = joi
   })
   .unknown(true);
 
-function normaliseRemoteDexExchangeParam(raw: unknown): DexExchangeParam {
+export function normaliseRemoteDexExchangeParam(
+  raw: unknown,
+): DexExchangeParam {
   return validateAndCast<DexExchangeParam>(
     raw,
     remoteDexExchangeParamSchema,
@@ -122,6 +124,7 @@ export class GenericSwapTransactionBuilder {
     // Held by reference, not snapshotted: callers can mutate this map between
     // `buildCalls` invocations and the next call will see the new state.
     protected newDexs?: NewDexsConfig,
+    protected skipApprovalCheck = false, // used only for testing outdated price routes
   ) {
     this.abiCoder = new AbiCoder();
     this.erc20Interface = new Interface(ERC20ABI);
@@ -881,11 +884,12 @@ export class GenericSwapTransactionBuilder {
       ),
     );
 
-    const approvals =
-      await this.dexAdapterService.dexHelper.augustusApprovals.hasApprovals(
-        spender,
-        tokenTargetMapping.map(t => t.params),
-      );
+    const approvals = this.skipApprovalCheck // used only for testing outdated price routes
+      ? tokenTargetMapping.map(t => false)
+      : await this.dexAdapterService.dexHelper.augustusApprovals.hasApprovals(
+          spender,
+          tokenTargetMapping.map(t => t.params),
+        );
 
     const dexExchangeBuildParams: DexExchangeBuildParam[] = [
       ...dexExchangeParams,

--- a/src/generic-swap-transaction-builder.ts
+++ b/src/generic-swap-transaction-builder.ts
@@ -243,14 +243,6 @@ export class GenericSwapTransactionBuilder {
                 recipient,
                 se.data,
                 side,
-                {
-                  isGlobalSrcToken:
-                    priceRoute.srcToken.toLowerCase() ===
-                    srcToken.toLowerCase(),
-                  isGlobalDestToken:
-                    priceRoute.destToken.toLowerCase() ===
-                    destToken.toLowerCase(),
-                },
                 executorAddress,
               );
             }

--- a/src/generic-swap-transaction-builder.ts
+++ b/src/generic-swap-transaction-builder.ts
@@ -108,8 +108,6 @@ export class GenericSwapTransactionBuilder {
 
   executorDetector: ExecutorDetector;
 
-  protected newDexsLower: Record<string, NewDexEntry>;
-
   constructor(
     protected dexAdapterService: DexAdapterService,
     protected wExchangeNetworkToKey = Weth.dexKeysWithNetwork.reduce<
@@ -121,7 +119,9 @@ export class GenericSwapTransactionBuilder {
       return prev;
     }, {}),
     protected newDexsApiUrl?: string,
-    newDexs?: NewDexsConfig,
+    // Held by reference, not snapshotted: callers can mutate this map between
+    // `buildCalls` invocations and the next call will see the new state.
+    protected newDexs?: NewDexsConfig,
   ) {
     this.abiCoder = new AbiCoder();
     this.erc20Interface = new Interface(ERC20ABI);
@@ -130,12 +130,6 @@ export class GenericSwapTransactionBuilder {
       this.dexAdapterService.dexHelper.config.data.augustusV6Address!;
     this.executorDetector = new ExecutorDetector(
       this.dexAdapterService.dexHelper,
-    );
-    this.newDexsLower = Object.fromEntries(
-      Object.entries(newDexs ?? {}).map(([key, value]) => [
-        key.toLowerCase(),
-        { key, ...value },
-      ]),
     );
   }
 
@@ -169,6 +163,19 @@ export class GenericSwapTransactionBuilder {
     );
   }
 
+  protected findNewDex(exchange: string): NewDexEntry | undefined {
+    if (!this.newDexs) return undefined;
+
+    const exchangeKey = exchange.toLowerCase();
+    const newDexKey = Object.keys(this.newDexs).find(
+      dexKey => dexKey.toLowerCase() === exchangeKey,
+    );
+
+    return newDexKey === undefined
+      ? undefined
+      : { key: newDexKey, ...this.newDexs[newDexKey] };
+  }
+
   protected async buildCalls(
     priceRoute: OptimalRate,
     minMaxAmount: string,
@@ -180,7 +187,7 @@ export class GenericSwapTransactionBuilder {
       priceRoute.bestRoute.flatMap((route, routeIndex) =>
         route.swaps.flatMap((swap, swapIndex) =>
           swap.swapExchanges.map(async se => {
-            const newDex = this.newDexsLower[se.exchange.toLowerCase()];
+            const newDex = this.findNewDex(se.exchange);
             const executorAddress = bytecodeBuilder.getAddress();
 
             let dexNeedWrapNative: boolean;

--- a/src/generic-swap-transaction-builder.ts
+++ b/src/generic-swap-transaction-builder.ts
@@ -21,7 +21,9 @@ import {
   NULL_ADDRESS,
 } from './constants';
 import { AbiCoder, Interface } from '@ethersproject/abi';
+import joi from 'joi';
 import AugustusV6ABI from './abi/augustus-v6/ABI.json';
+import { validateAndCast } from './lib/validators';
 import { isETHAddress, uuidToBytes16 } from './utils';
 import {
   DepositWithdrawReturn,
@@ -44,6 +46,47 @@ const {
   utils: { hexlify, hexConcat, hexZeroPad },
 } = ethers;
 
+const REMOTE_DEX_PARAM_TIMEOUT_MS = 10_000;
+
+// `.empty(null)` makes joi treat a JSON `null` as missing (i.e. undefined),
+// which is what downstream `value !== undefined` checks expect — see
+// docs/specs/get-dex-param.md §3.1 and DEX-PARAM-API.md:123 (returnAmountPos
+// may be omitted *or* null on BUY).
+const remoteDexExchangeParamSchema = joi
+  .object({
+    needWrapNative: joi.boolean().required(),
+    exchangeData: joi.string().required(),
+    targetExchange: joi.string().required(),
+    dexFuncHasRecipient: joi.boolean().required(),
+
+    needUnwrapNative: joi.boolean().empty(null),
+    skipApproval: joi.boolean().empty(null),
+    wethAddress: joi.string().empty(null),
+    specialDexFlag: joi.number().integer().min(0).max(255).empty(null),
+    transferSrcTokenBeforeSwap: joi.string().empty(null),
+    spender: joi.string().empty(null),
+    sendEthButSupportsInsertFromAmount: joi.boolean().empty(null),
+    specialDexSupportsInsertFromAmount: joi.boolean().empty(null),
+    swappedAmountNotPresentInExchangeData: joi.boolean().empty(null),
+    returnAmountPos: joi.number().integer().min(0).max(255).empty(null),
+    insertFromAmountPos: joi.number().integer().min(0).max(65535).empty(null),
+    amountsPacked128: joi.boolean().empty(null),
+    permit2Approval: joi.boolean().empty(null),
+  })
+  .unknown(true);
+
+function normaliseRemoteDexExchangeParam(raw: unknown): DexExchangeParam {
+  return validateAndCast<DexExchangeParam>(
+    raw,
+    remoteDexExchangeParamSchema,
+    'DexExchangeParam',
+  );
+}
+
+export type NewDexConfig = { needWrapNative: boolean };
+export type NewDexsConfig = { [dexKey: string]: NewDexConfig };
+type NewDexEntry = NewDexConfig & { key: string };
+
 interface FeeParams {
   partner: string;
   feePercent: string;
@@ -65,6 +108,8 @@ export class GenericSwapTransactionBuilder {
 
   executorDetector: ExecutorDetector;
 
+  protected newDexsLower: Record<string, NewDexEntry>;
+
   constructor(
     protected dexAdapterService: DexAdapterService,
     protected wExchangeNetworkToKey = Weth.dexKeysWithNetwork.reduce<
@@ -75,6 +120,8 @@ export class GenericSwapTransactionBuilder {
       }
       return prev;
     }, {}),
+    protected newDexsApiUrl?: string,
+    newDexs?: NewDexsConfig,
   ) {
     this.abiCoder = new AbiCoder();
     this.erc20Interface = new Interface(ERC20ABI);
@@ -83,6 +130,12 @@ export class GenericSwapTransactionBuilder {
       this.dexAdapterService.dexHelper.config.data.augustusV6Address!;
     this.executorDetector = new ExecutorDetector(
       this.dexAdapterService.dexHelper,
+    );
+    this.newDexsLower = Object.fromEntries(
+      Object.entries(newDexs ?? {}).map(([key, value]) => [
+        key.toLowerCase(),
+        { key, ...value },
+      ]),
     );
   }
 
@@ -127,11 +180,21 @@ export class GenericSwapTransactionBuilder {
       priceRoute.bestRoute.flatMap((route, routeIndex) =>
         route.swaps.flatMap((swap, swapIndex) =>
           swap.swapExchanges.map(async se => {
-            const dex = this.dexAdapterService.getTxBuilderDexByKey(
-              se.exchange,
-            );
-
+            const newDex = this.newDexsLower[se.exchange.toLowerCase()];
             const executorAddress = bytecodeBuilder.getAddress();
+
+            let dexNeedWrapNative: boolean;
+            let dex: IDexTxBuilder<any, any> | undefined;
+            if (newDex) {
+              dexNeedWrapNative = newDex.needWrapNative;
+            } else {
+              dex = this.dexAdapterService.getTxBuilderDexByKey(se.exchange);
+              dexNeedWrapNative =
+                typeof dex.needWrapNative === 'function'
+                  ? dex.needWrapNative(priceRoute, swap, se)
+                  : dex.needWrapNative;
+            }
+
             const {
               srcToken,
               destToken,
@@ -147,27 +210,50 @@ export class GenericSwapTransactionBuilder {
               swapIndex,
               se,
               minMaxAmount,
-              dex,
+              dexNeedWrapNative,
               executorAddress,
             );
 
-            let dexParams = await dex.getDexParam!(
-              srcToken,
-              destToken,
-              side === SwapSide.BUY ? se.srcAmount : srcAmount, // in other case we would not be able to make insert from amount on Ex3
-              destAmount,
-              recipient,
-              se.data,
-              side,
-              {
-                isGlobalSrcToken:
-                  priceRoute.srcToken.toLowerCase() === srcToken.toLowerCase(),
-                isGlobalDestToken:
-                  priceRoute.destToken.toLowerCase() ===
-                  destToken.toLowerCase(),
-              },
-              executorAddress,
-            );
+            let dexParams: DexExchangeParam;
+            if (newDex) {
+              dexParams = await this.fetchRemoteDexParam({
+                dexKey: newDex.key,
+                srcToken,
+                destToken,
+                srcAmount: side === SwapSide.BUY ? se.srcAmount : srcAmount,
+                destAmount,
+                recipient,
+                data: se.data,
+                side,
+                executorAddress,
+              });
+
+              // The local `newDexs[*].needWrapNative` is the single source of
+              // truth: it already drove `getDexCallsParams` (and therefore
+              // `wethDeposit`/`wethWithdraw`). Keep the executor builder in
+              // lockstep so the wrap accounting and the bytecode wiring
+              // can't diverge.
+              dexParams.needWrapNative = newDex.needWrapNative;
+            } else {
+              dexParams = await dex!.getDexParam!(
+                srcToken,
+                destToken,
+                side === SwapSide.BUY ? se.srcAmount : srcAmount, // in other case we would not be able to make insert from amount on Ex3
+                destAmount,
+                recipient,
+                se.data,
+                side,
+                {
+                  isGlobalSrcToken:
+                    priceRoute.srcToken.toLowerCase() ===
+                    srcToken.toLowerCase(),
+                  isGlobalDestToken:
+                    priceRoute.destToken.toLowerCase() ===
+                    destToken.toLowerCase(),
+                },
+                executorAddress,
+              );
+            }
 
             if (typeof dexParams.needWrapNative === 'function') {
               dexParams.needWrapNative = dexParams.needWrapNative(
@@ -227,6 +313,50 @@ export class GenericSwapTransactionBuilder {
       userAddress,
       maybeWethCallData,
     );
+  }
+
+  protected async fetchRemoteDexParam(args: {
+    dexKey: string;
+    srcToken: Address;
+    destToken: Address;
+    srcAmount: string;
+    destAmount: string;
+    recipient: Address;
+    data: any;
+    side: SwapSide;
+    executorAddress: Address;
+  }): Promise<DexExchangeParam> {
+    if (!this.newDexsApiUrl) {
+      throw new Error(
+        `[GenericSwapTransactionBuilder] new-dex API URL not configured; cannot encode swap for ${args.dexKey}`,
+      );
+    }
+
+    const chainId = this.dexAdapterService.network;
+    const base = this.newDexsApiUrl.replace(/\/+$/, '');
+    const url = `${base}/api/v1/dexs/${chainId}/${encodeURIComponent(
+      args.dexKey,
+    )}/dex-param`;
+
+    const body = {
+      srcToken: args.srcToken,
+      destToken: args.destToken,
+      srcAmount: args.srcAmount,
+      destAmount: args.destAmount,
+      recipient: args.recipient,
+      executorAddress: args.executorAddress,
+      side: args.side,
+      data: args.data,
+    };
+
+    const raw =
+      await this.dexAdapterService.dexHelper.httpRequest.post<unknown>(
+        url,
+        body,
+        REMOTE_DEX_PARAM_TIMEOUT_MS,
+      );
+
+    return normaliseRemoteDexExchangeParam(raw);
   }
 
   protected async _build(
@@ -635,7 +765,7 @@ export class GenericSwapTransactionBuilder {
     swapIndex: number,
     se: OptimalSwapExchange<any>,
     minMaxAmount: string,
-    dex: IDexTxBuilder<any, any>,
+    dexNeedWrapNative: boolean,
     executionContractAddress: string,
   ): {
     srcToken: Address;
@@ -678,11 +808,6 @@ export class GenericSwapTransactionBuilder {
     // even if the individual dex is rekt by slippage the swap
     // should work if the final slippage check passes.
     const _destAmount = side === SwapSide.SELL ? '1' : se.destAmount;
-
-    const dexNeedWrapNative =
-      typeof dex.needWrapNative === 'function'
-        ? dex.needWrapNative(priceRoute, swap, se)
-        : dex.needWrapNative;
 
     if (isETHAddress(swap.srcToken) && dexNeedWrapNative) {
       _src = wethAddress;

--- a/src/implementations/local-paraswap-sdk.ts
+++ b/src/implementations/local-paraswap-sdk.ts
@@ -257,6 +257,10 @@ export class LocalParaswapSDK implements IParaSwapSDK {
                   );
 
                   if (dexLibExchange && dexLibExchange.preProcessTransaction) {
+                    const dexNeedWrapNative =
+                      typeof dex.needWrapNative === 'function'
+                        ? dex.needWrapNative(priceRoute, swap, se)
+                        : dex.needWrapNative;
                     const { recipient } =
                       priceRoute.version === ParaSwapVersion.V5
                         ? this.transactionBuilderV5.getDexCallsParams(
@@ -276,7 +280,7 @@ export class LocalParaswapSDK implements IParaSwapSDK {
                             swapIndex,
                             se,
                             minMaxAmount.toString(),
-                            dex,
+                            dexNeedWrapNative,
                             executionContractAddress,
                           );
 

--- a/src/implementations/local-paraswap-sdk.ts
+++ b/src/implementations/local-paraswap-sdk.ts
@@ -80,6 +80,10 @@ export class LocalParaswapSDK implements IParaSwapSDK {
     );
     this.transactionBuilder = new GenericSwapTransactionBuilder(
       this.dexAdapterService,
+      undefined,
+      undefined,
+      undefined,
+      true,
     );
     this.transactionBuilderV5 = new TransactionBuilder(this.dexAdapterService);
 

--- a/src/implementations/local-paraswap-sdk.ts
+++ b/src/implementations/local-paraswap-sdk.ts
@@ -270,7 +270,7 @@ export class LocalParaswapSDK implements IParaSwapSDK {
                             swapIndex,
                             se,
                             minMaxAmount.toString(),
-                            dex,
+                            dexNeedWrapNative,
                             executionContractAddress,
                           )
                         : this.transactionBuilder.getDexCallsParams(

--- a/src/transaction-builder.ts
+++ b/src/transaction-builder.ts
@@ -104,7 +104,7 @@ export class TransactionBuilder {
     swapIndex: number,
     se: OptimalSwapExchange<any>,
     minMaxAmount: string,
-    dex: IDexTxBuilder<any, any>,
+    dexNeedWrapNative: boolean,
     executionContractAddress: string,
   ): {
     srcToken: Address;

--- a/tests/utils-e2e.ts
+++ b/tests/utils-e2e.ts
@@ -76,6 +76,10 @@ class APIParaswapSDK implements IParaSwapSDK {
     );
     this.transactionBuilder = new GenericSwapTransactionBuilder(
       this.dexAdapterService,
+      undefined,
+      undefined,
+      undefined,
+      true,
     );
     this.pricingHelper = new PricingHelper(
       this.dexAdapterService,


### PR DESCRIPTION
## Summary

- `GenericSwapTransactionBuilder` accepts two optional constructor params — `newDexsApiUrl: string` and `newDexs: { [dexKey]: { needWrapNative: boolean } }`. When a swap leg's `exchange` matches an entry in the map, `buildCalls` POSTs to `{base}/api/v1/dexs/{chainId}/{dexKey}/dex-param` to get the `DexExchangeParam` instead of calling `getDexParam` on a local `IDex` instance — necessary because new DEXes won't be registered in this lib.
- Response is validated with `joi` via `validateAndCast` (matches existing `native` / `dexalot` / `bebop` rate-fetcher pattern). Required keys must be present; optional keys with JSON `null` are stripped to `undefined` so downstream `value !== undefined` checks behave correctly.
- Local `newDexs[*].needWrapNative` is the single source of truth: `getDexCallsParams` runs against it *before* the API call, and the remote response's `needWrapNative` is overwritten with the local value to keep wrap accounting and bytecode wiring in lockstep.
- Lookup is case-insensitive (lowercased map at construction time); URL embeds the caller's canonical casing, URL-encoded.
- `Context` (`isGlobalSrcToken`/`isGlobalDestToken`) is removed from `IDexTxBuilderV6.getDexParam` — no DEX read those fields, and the new remote contract has no need for them either.

## Out of scope

- `LocalParaswapSDK.buildTransaction` calls `getTxBuilderDexByKey` unconditionally during preprocessing, which still throws for unknown DEXes — production callers go through `_build` directly so this is fine. Local e2e via `LocalParaswapSDK` will need a follow-up.
- `_buildDirect` (`getDirectParamV6`) is unchanged: direct routes are in-lib-only by construction.

## Test plan

- [x] \`yarn check:tsc\` passes
- [x] \`yarn check:es\` passes
- [ ] Stub-server smoke test: POST hits \`/api/v1/dexs/{chainId}/{dexKey}/dex-param\` with caller-canonical casing in the URL and \`{srcToken, destToken, srcAmount, destAmount, recipient, executorAddress, side, data}\` in the body (no \`context\`)
- [ ] Stub returns \`returnAmountPos: null\` on a BUY → \`_build\` succeeds, executor encodes default \`255\`
- [ ] Stub returns \`needWrapNative: false\` while config says \`true\` → bytecode still wraps ETH→WETH for native-src (local config wins)
- [ ] Stub 500 / malformed JSON / hangs past 10s timeout → \`_build\` rejects, no retry
- [ ] Multi-leg ordering: out-of-order stub responses → resulting bytecode preserves route order
- [ ] Existing in-lib DEX routes unchanged behaviourally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new remote call path in `GenericSwapTransactionBuilder.buildCalls`, so swap encoding can now fail due to API errors/timeouts or schema mismatches; however existing in-lib DEX encoding paths are largely unchanged aside from a signature cleanup.
> 
> **Overview**
> **Adds remote encoding for “new DEXes”.** `GenericSwapTransactionBuilder` now accepts optional `newDexsApiUrl` + `newDexs` config; when a swap leg’s `exchange` matches this map (case-insensitive), it POSTs to `/api/v1/dexs/{chainId}/{dexKey}/dex-param`, validates/normalizes the response (Joi; `null` treated as omitted), and uses it instead of calling a local `IDex.getDexParam`.
> 
> **Tightens swap-building plumbing.** Removes the unused `Context` argument from `IDexTxBuilderV6.getDexParam` and updates all affected DEX implementations/callers; `getDexCallsParams` now takes a computed `dexNeedWrapNative` boolean, and remote legs force `needWrapNative` to the locally configured value to keep wrap/unwrap accounting consistent. E2E tests for `metric` and `tessera` add local-vs-remote encoding parity checks, and router addresses in their configs are normalized to lowercase; package version bumps to `4.8.45`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39b8d4fe8570dd7c357a8fda5ebd47a8d7c428a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->