### PR TITLE
feat: add Rubicon Aquila V2 (constant-product AMM, 4 chains)

### DIFF
--- a/src/dex/uniswap-v2/config.ts
+++ b/src/dex/uniswap-v2/config.ts
@@ -166,6 +166,36 @@ export const UniswapV2Config: DexConfigMap<DexParams> = {
       feeCode: 30,
     },
   },
+  RubiconAquila: {
+    [Network.MAINNET]: {
+      factoryAddress: '0x7bad585c3ae4ae266f92a4af13b388bc7b26067c',
+      initCode:
+        '0x79cb29831f0abd24ae48de6fa5dc9eb647f10df38618ed09b70b2044d35dfba5',
+      poolGasCost: 80 * 1000,
+      feeCode: 30,
+    },
+    [Network.OPTIMISM]: {
+      factoryAddress: '0x3B2C6fe3039B42f00E98b76531C05932abfB258e',
+      initCode:
+        '0x79cb29831f0abd24ae48de6fa5dc9eb647f10df38618ed09b70b2044d35dfba5',
+      poolGasCost: 80 * 1000,
+      feeCode: 30,
+    },
+    [Network.ARBITRUM]: {
+      factoryAddress: '0xEca3EA559b7566e610d113bbA8D1B15B085C9c68',
+      initCode:
+        '0x79cb29831f0abd24ae48de6fa5dc9eb647f10df38618ed09b70b2044d35dfba5',
+      poolGasCost: 80 * 1000,
+      feeCode: 30,
+    },
+    [Network.BASE]: {
+      factoryAddress: '0xA5cA8Ba2e3017E9aF3Bd9EDa69e9E8C263Abf6cD',
+      initCode:
+        '0x79cb29831f0abd24ae48de6fa5dc9eb647f10df38618ed09b70b2044d35dfba5',
+      poolGasCost: 80 * 1000,
+      feeCode: 30,
+    },
+  },
   ApeSwap: {
     [Network.BSC]: {
       factoryAddress: '0x0841bd0b734e4f5853f0dd8d7ea041c241fb0da6',

--- a/src/dex/uniswap-v2/uniswap-v2-e2e-arbitrum.test.ts
+++ b/src/dex/uniswap-v2/uniswap-v2-e2e-arbitrum.test.ts
@@ -263,4 +263,24 @@ describe('UniswapV2 E2E Arbitrum', () => {
       }),
     );
   });
+
+  describe('RubiconAquila', () => {
+    const dexKey = 'RubiconAquila';
+
+    describe('Simpleswap', () => {
+      it('RubiconAquila WETH -> USDC', async () => {
+        await testE2E(
+          tokens.WETH,
+          tokens.USDC,
+          holders.WETH,
+          '10000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+    });
+  });
 });

--- a/src/dex/uniswap-v2/uniswap-v2-e2e-base.test.ts
+++ b/src/dex/uniswap-v2/uniswap-v2-e2e-base.test.ts
@@ -87,4 +87,23 @@ describe('UniswapV2 Base E2E', () => {
       tokenBAmount,
     );
   });
+
+  describe('RubiconAquila', () => {
+    const dexKey = 'RubiconAquila';
+
+    const tokenASymbol: string = 'WETH';
+    const tokenBSymbol: string = 'USDC';
+
+    const tokenAAmount: string = '50000000000000000';
+    const tokenBAmount: string = '150000000';
+
+    testForNetwork(
+      network,
+      dexKey,
+      tokenASymbol,
+      tokenBSymbol,
+      tokenAAmount,
+      tokenBAmount,
+    );
+  });
 });

--- a/src/dex/uniswap-v2/uniswap-v2-e2e-mainnet.test.ts
+++ b/src/dex/uniswap-v2/uniswap-v2-e2e-mainnet.test.ts
@@ -1828,4 +1828,24 @@ describe('UniswapV2 E2E Mainnet', () => {
       }),
     );
   });
+
+  describe('RubiconAquila', () => {
+    const dexKey = 'RubiconAquila';
+
+    describe('Simpleswap', () => {
+      it('RubiconAquila WETH -> USDC', async () => {
+        await testE2E(
+          tokens.WETH,
+          tokens.USDC,
+          holders.WETH,
+          '10000000000000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+    });
+  });
 });

--- a/src/dex/uniswap-v2/uniswap-v2-e2e-optimism.test.ts
+++ b/src/dex/uniswap-v2/uniswap-v2-e2e-optimism.test.ts
@@ -15,4 +15,24 @@ describe('UniswapV2 E2E Optimism', () => {
     generateConfig(network).privateHttpProvider,
     network,
   );
+
+  describe('RubiconAquila', () => {
+    const dexKey = 'RubiconAquila';
+
+    describe('Simpleswap', () => {
+      it('RubiconAquila USDC -> DAI', async () => {
+        await testE2E(
+          tokens.USDC,
+          tokens.DAI,
+          holders.USDC,
+          '100000000',
+          SwapSide.SELL,
+          dexKey,
+          ContractMethod.simpleSwap,
+          network,
+          provider,
+        );
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds **Rubicon Aquila V2** — Rubicon Finance's UniswapV2-fork constant-product AMM — as a routable liquidity source via the existing generic `UniswapV2` adapter. Aquila is deployed on Ethereum, Optimism, Arbitrum, and Base.

## Scope

Config-only on the adapter side. The `UniswapV2` class in this repo is parameterized over `UniswapV2Config` and auto-registers every key via `getDexKeysWithNetwork`/`_.omit`. Adding Aquila is a new top-level entry in that map. No new directory, no new class, no math.

## Files changed (5 files, +109 / -0)

- `src/dex/uniswap-v2/config.ts` — one new entry, `RubiconAquila`, covering all four chains.
- `src/dex/uniswap-v2/uniswap-v2-e2e-mainnet.test.ts` — one minimal `describe('RubiconAquila', ...)` block with a single SELL test (WETH → USDC).
- `src/dex/uniswap-v2/uniswap-v2-e2e-optimism.test.ts` — same shape, single SELL test (USDC → DAI — Aquila Optimism has no native WETH/USDC pair).
- `src/dex/uniswap-v2/uniswap-v2-e2e-arbitrum.test.ts` — single SELL test (WETH → USDC).
- `src/dex/uniswap-v2/uniswap-v2-e2e-base.test.ts` — single SELL test via the file's `testForNetwork()` helper (WETH/USDC).

## Configuration

| Chain | Factory | Init code hash | `feeCode` |
|---|---|---|---|
| Ethereum | `0x7bad585c3ae4ae266f92a4af13b388bc7b26067c` | `0x79cb29831f0abd24ae48de6fa5dc9eb647f10df38618ed09b70b2044d35dfba5` | 30 |
| Optimism | `0x3B2C6fe3039B42f00E98b76531C05932abfB258e` | same | 30 |
| Arbitrum | `0xEca3EA559b7566e610d113bbA8D1B15B085C9c68` | same | 30 |
| Base     | `0xA5cA8Ba2e3017E9aF3Bd9EDa69e9E8C263Abf6cD` | same | 30 |

## Verification

- **Pair `swap()` ABI** — byte-identical to UniswapV2 (`IAquilaPair.sol:70-75`).
- **`getReserves()` shape** — standard UniV2 `(uint112, uint112, uint32)` confirmed on-chain.
- **Init code hash** — sourced from `RubiconDeFi/aquila → AquilaLibrary.sol:35`; verified on-chain by computing `pairFor(USDC.e, OP)` and matching `factory.allPairs(0)` on Optimism.
- **Fee** — `997/1000` numerator from `AquilaLibrary.sol:82` → `feeCode: 30` (standard UniV2).
- **Cross-validation** — the Aquila Base factory `0xA5cA8Ba2e3017E9aF3Bd9EDa69e9E8C263Abf6cD` is the same address `DefiLlama/DefiLlama-Adapters` already indexes at [`projects/rubicon/index.js`](https://github.com/DefiLlama/DefiLlama-Adapters/blob/main/projects/rubicon/index.js).

## Local checks

`pretty-quick`, `tsc`, and `eslint` all pass (run via the repo's `prepare` script during `pnpm install` and again via the pre-commit hook). Existing `uniswap-v2-integration.test.ts` continues to pass on the 2 RPC-only cases (`getTopPoolsForToken` requires `API_KEY_THE_GRAPH` which we don't set locally — affects all UniswapV2 forks equally, not specific to this change).

## Links

- Rubicon Finance: https://rubicon.finance
- Docs / integrations page: https://docs.rubicon.finance/integrations
- Deployments page: https://docs.rubicon.finance/developers/deployments
- Aquila contracts: https://github.com/RubiconDeFi/aquila

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only addition of a new UniswapV2-fork entry plus new e2e tests; main risk is incorrect `factoryAddress`/`initCode` values causing routing or quoting failures on the listed networks.
> 
> **Overview**
> Adds **`RubiconAquila`** to `UniswapV2Config`, wiring in factory addresses + init code hash (and standard `feeCode`/gas estimates) for **Mainnet, Optimism, Arbitrum, and Base** so the existing `UniswapV2` adapter can route against Aquila.
> 
> Extends UniswapV2 e2e suites on those networks with minimal `RubiconAquila` swap tests (e.g., WETH→USDC on Mainnet/Arbitrum/Base, USDC→DAI on Optimism) to validate integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ed2fe35e7f0df1d56df1e9f1ec5e007f38b25a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->