### PR TITLE
Enable Balancer reClamm V3 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ When making fixes based on code review comments or feedback, add a concise descr
 <!-- Add new fixes at the top of this list -->
 <!-- Format: - **[Date] Issue**: Brief description of fix -->
 
+- **[2025-05] Balancer reClamm v3**: API `version: 3` pools are aliased to `RECLAMM_V2` at `getPoolsApi.ts` mapping; immutable state keeps `version: 3`. On-chain ABI and maths are identical to v2.
+
 - **[2025-01] Block manager unavailable in certain methods**: `dexHelper.blockManager` is not available in `getTopPoolsForToken()` and `updatePoolState()` methods since these are called on a service that does not have it implemented. Use direct RPC calls (e.g., `dexHelper.provider.getBlock('latest')`) instead when block data is needed in these methods.
 
 - **[2025-01] Remove unused ABIs when removing DEXes**: When removing DEX integrations, also remove their associated ABI files from `src/abi/` if no longer referenced. Use `grep` to verify ABIs are not imported elsewhere before deletion.

--- a/src/dex/balancer-v3/balancer-reClamm.test.ts
+++ b/src/dex/balancer-v3/balancer-reClamm.test.ts
@@ -17,119 +17,18 @@ const usdc = tokens['USDC'];
 const eurc = tokens['EURC'];
 
 describe('BalancerV3 reClamm tests', function () {
-  describe('reClamm version 1', function () {
-    // https://balancer.fi/pools/base/v3/0x97c4B3E63566D6Ece3c9BCE535EDc2CA52FC6d5B
+  // reClamm V1 & V2 are paused so we only test V3
+  describe('reClamm version 3', function () {
+    const network = Network.MAINNET;
+    const dexHelper = new DummyDexHelper(network);
+    const tokens = Tokens[network];
+    const usdc = tokens['USDC'];
+    const weth = tokens['WETH'];
+    const blockNumber = 25135240;
+    // https://balancer.fi/pools/ethereum/v3/0xda66e8ddf9959e4db759bfd06256730d8a8b2d13
     const reClammPool =
-      '0x97c4B3E63566D6Ece3c9BCE535EDc2CA52FC6d5B'.toLowerCase();
-    describe('reClamm pool should be returned', function () {
-      const blockNumber = 31484040;
-      beforeAll(async () => {
-        balancerV3 = new BalancerV3(network, dexKey, dexHelper);
-        if (balancerV3.initializePricing) {
-          await balancerV3.initializePricing(blockNumber);
-        }
-      });
+      '0xda66e8ddf9959e4db759bfd06256730d8a8b2d13'.toLowerCase();
 
-      it('getPoolIdentifiers', async function () {
-        const pools = await balancerV3.getPoolIdentifiers(
-          weth,
-          usdc,
-          SwapSide.SELL,
-          blockNumber,
-        );
-        expect(pools.some(pool => pool === reClammPool)).toBe(true);
-      });
-
-      it('getTopPoolsForToken', async function () {
-        const pools = await balancerV3.getTopPoolsForToken(usdc.address, 100);
-        expect(pools.some(pool => pool.address === reClammPool)).toBe(true);
-      });
-    });
-
-    describe('should match onchain pricing - in range', function () {
-      const blockNumber = 31484040;
-      beforeAll(async () => {
-        balancerV3 = new BalancerV3(network, dexKey, dexHelper);
-        if (balancerV3.initializePricing) {
-          await balancerV3.initializePricing(blockNumber);
-        }
-      });
-
-      it('SELL', async function () {
-        const amounts = [0n, 100000n];
-        const side = SwapSide.SELL;
-        await testPricesVsOnchain(
-          balancerV3,
-          network,
-          amounts,
-          usdc,
-          weth,
-          side,
-          blockNumber,
-          [reClammPool],
-        );
-      });
-      it('BUY', async function () {
-        const amounts = [0n, 200000n];
-        const side = SwapSide.BUY;
-        await testPricesVsOnchain(
-          balancerV3,
-          network,
-          amounts,
-          weth,
-          usdc,
-          side,
-          blockNumber,
-          [reClammPool],
-        );
-      });
-    });
-
-    describe('should match onchain pricing - out of range', function () {
-      // Pool out of range after this tx: https://basescan.org/tx/0xa0a1e8fc10d421400cbecaeb8e9cf0c3a556f19dcfc5f6006459c86b64b79d99
-      const blockNumber = 31484055;
-      beforeAll(async () => {
-        balancerV3 = new BalancerV3(network, dexKey, dexHelper);
-        if (balancerV3.initializePricing) {
-          await balancerV3.initializePricing(blockNumber);
-        }
-      });
-
-      it('SELL', async function () {
-        const amounts = [0n, 100000n];
-        const side = SwapSide.SELL;
-        await testPricesVsOnchain(
-          balancerV3,
-          network,
-          amounts,
-          usdc,
-          weth,
-          side,
-          blockNumber,
-          [reClammPool],
-        );
-      });
-      it('BUY', async function () {
-        const amounts = [0n, 2200000000000n];
-        const side = SwapSide.BUY;
-        await testPricesVsOnchain(
-          balancerV3,
-          network,
-          amounts,
-          usdc,
-          weth,
-          side,
-          blockNumber,
-          [reClammPool],
-        );
-      });
-    });
-  });
-  describe('reClamm version 2', function () {
-    const blockNumber = 32651442;
-    // https://balancer.fi/pools/base/v3/0x12c2de9522f377b86828f6af01f58c046f814d3c
-    const reClammPool =
-      '0x12c2de9522f377b86828f6af01f58c046f814d3c'.toLowerCase();
     describe('reClamm pool should be returned', function () {
       beforeAll(async () => {
         balancerV3 = new BalancerV3(network, dexKey, dexHelper);
@@ -140,8 +39,8 @@ describe('BalancerV3 reClamm tests', function () {
 
       it('getPoolIdentifiers', async function () {
         const pools = await balancerV3.getPoolIdentifiers(
-          eurc,
           usdc,
+          weth,
           SwapSide.SELL,
           blockNumber,
         );
@@ -170,49 +69,6 @@ describe('BalancerV3 reClamm tests', function () {
           network,
           amounts,
           usdc,
-          eurc,
-          side,
-          blockNumber,
-          [reClammPool],
-        );
-      });
-      it('BUY', async function () {
-        const amounts = [0n, 200000n];
-        const side = SwapSide.BUY;
-        await testPricesVsOnchain(
-          balancerV3,
-          network,
-          amounts,
-          eurc,
-          usdc,
-          side,
-          blockNumber,
-          [reClammPool],
-        );
-      });
-    });
-
-    describe('should match onchain pricing - out of range', function () {
-      const blockNumber = 32641745;
-      // https://balancer.fi/pools/base/v3/0x3De1E230193F39DF0c122A345a928d909034c1a1
-      const reClammPool =
-        '0x3De1E230193F39DF0c122A345a928d909034c1a1'.toLowerCase();
-
-      beforeAll(async () => {
-        balancerV3 = new BalancerV3(network, dexKey, dexHelper);
-        if (balancerV3.initializePricing) {
-          await balancerV3.initializePricing(blockNumber);
-        }
-      });
-
-      it('SELL', async function () {
-        const amounts = [0n, 100000n];
-        const side = SwapSide.SELL;
-        await testPricesVsOnchain(
-          balancerV3,
-          network,
-          amounts,
-          usdc,
           weth,
           side,
           blockNumber,
@@ -220,7 +76,7 @@ describe('BalancerV3 reClamm tests', function () {
         );
       });
       it('BUY', async function () {
-        const amounts = [0n, 20000n];
+        const amounts = [0n, 200000n];
         const side = SwapSide.BUY;
         await testPricesVsOnchain(
           balancerV3,

--- a/src/dex/balancer-v3/getPoolsApi.ts
+++ b/src/dex/balancer-v3/getPoolsApi.ts
@@ -111,17 +111,19 @@ function toImmutablePoolStateMap(
           pool.type === ReClammApiName || // In reClamm the pool is also its own hook. We don't track hook state as its not needed for pricing
           pool.hook.address.toLowerCase() in hooksConfigMap,
       )
-      // Filter out ReClamm pools that don't have version 1 or 2
+      // Filter out ReClamm pools that don't have version 1, 2 or 3
       .filter(
         pool =>
           pool.type !== ReClammApiName ||
           pool.version === 1 ||
-          pool.version === 2,
+          pool.version === 2 ||
+          pool.version === 3,
       )
       .reduce((map, pool) => {
-        // Set poolType to RECLAMM_V2 for version 2 ReClamm pools
+        // v3 is aliased to RECLAMM_V2: on-chain ABI and maths match v2
         const poolType =
-          pool.type === ReClammApiName && pool.version === 2
+          pool.type === ReClammApiName &&
+          (pool.version === 2 || pool.version === 3)
             ? 'RECLAMM_V2'
             : pool.type;
 

--- a/src/dex/balancer-v3/getTopPoolsApi.ts
+++ b/src/dex/balancer-v3/getTopPoolsApi.ts
@@ -117,12 +117,13 @@ export async function getTopPoolsApi(
           pool.type === ReClammApiName || // In reClamm the pool is also its own hook. We don't track hook state as its not needed for pricing
           (pool.hook && pool.hook.address.toLowerCase() in hooksConfigMap),
       )
-      // Filter out ReClamm pools that don't have version 1 or 2
+      // Filter out ReClamm pools that don't have version 1, 2 or 3
       .filter(
         pool =>
           pool.type !== ReClammApiName ||
           pool.version === 1 ||
-          pool.version === 2,
+          pool.version === 2 ||
+          pool.version === 3,
       )
       .map(pool => ({
         ...pool,


### PR DESCRIPTION
Enables Balancer reClamm V3. This has same onchain/ABI and maths as reClamm V2 but is tagged as version: 3 on API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands pool discovery to include API `version: 3` reClamm pools and routes them through existing `RECLAMM_V2` pricing/ABI paths; incorrect aliasing or filtering could impact BalancerV3 routing/prices for these pools.
> 
> **Overview**
> **Enables BalancerV3 reClamm *v3* pools** by accepting `version: 3` in both pool list APIs and mapping them to the existing `RECLAMM_V2` pool type for on-chain calls/pricing while preserving the immutable `version` value.
> 
> Updates the reClamm test suite to drop paused v1/v2 coverage and instead validate pool discovery and on-chain price matching for a mainnet reClamm v3 pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eac8aae06dccda2cc8ae30a802773925156aebbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->