### PR TITLE
feat: parameters encoding for alpha hook support

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  transform: { '^.+\\.ts?$': 'ts-jest' },
+  transform: { '^.+\\.(ts|js)$': 'ts-jest' },
   testEnvironment: 'node',
   testRegex: [
     '/tests/.*\\.(test|spec)\\.(ts)$',
@@ -7,4 +7,5 @@ module.exports = {
   ],
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   testTimeout: 30 * 1000,
+  transformIgnorePatterns: ['node_modules/(?!.*uuid)'],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/pancakeswap-infinity/encoder.ts
+++ b/src/dex/pancakeswap-infinity/encoder.ts
@@ -59,20 +59,27 @@ function getFirstStep(data: PancakeSwapInfinityData): PathStep {
 //   bits [16:39] — tickSpacing (int24)
 //   bits [40:]   — reserved / zero for CL pools
 //
-// WARNING — incorrect for pools with hook callbacks registered:
-// The new PancakeSwapInfinityData shape carries only `tickSpacing`, not the
-// hooks registration bitmap, so we zero out bits [0:15]. For pools where
-// `hooks == address(0)` (or a hook contract that registers no callbacks)
-// the bitmap is 0 and this is correct. For any pool with registered hook
-// callbacks, the produced `parameters` differs from the on-chain value,
-// which changes `poolId = keccak256(poolKey)` and causes the swap to revert
-// (`PoolNotInitialized`). Fix requires either extending the input shape
-// with `hooksRegistration`, or reading the bitmap from the hook contract.
-function encodeParameters(tickSpacing: number): string {
-  return ethers.utils.hexZeroPad(
-    ethers.utils.hexlify(BigInt(tickSpacing) << 16n),
-    32,
-  );
+// `hooksRegistration` must match the value the hook contract returns from
+// `getHooksRegistrationBitmap()` (0 for hookless pools). A mismatch
+// produces a different `poolId = keccak256(poolKey)` and the swap reverts
+// with `PoolNotInitialized`.
+const HOOKS_REGISTRATION_BITMAP: Record<string, number> = {
+  '0xb0baa371b899950b4ef6a27c21baf5ef7c434d0f': 69,
+  '0x72e09ebd9b24f47730b651889a4ed984cba53d90': 85,
+  '0x9a9b5331ce8d74b2b721291d57de696e878353fd': 85,
+};
+
+function getHooksRegistration(hooks: string): number {
+  return HOOKS_REGISTRATION_BITMAP[hooks.toLowerCase()] ?? 0;
+}
+
+function encodeParameters(
+  tickSpacing: number,
+  hooksRegistration: number,
+): string {
+  const packed =
+    (BigInt(tickSpacing) << 16n) | BigInt(hooksRegistration & 0xffff);
+  return ethers.utils.hexZeroPad(ethers.utils.hexlify(packed), 32);
 }
 
 function encodePoolKeyTuple(step: PathStep): any[] {
@@ -83,7 +90,10 @@ function encodePoolKeyTuple(step: PathStep): any[] {
     key.hooks,
     key.poolManager,
     key.fee,
-    encodeParameters(key.tickSpacing),
+    encodeParameters(
+      key.tickSpacing,
+      getHooksRegistration(key.hooks.toLowerCase()),
+    ),
   ];
 }
 

--- a/src/dex/pancakeswap-infinity/pancakeswap-infinity-e2e.test.ts
+++ b/src/dex/pancakeswap-infinity/pancakeswap-infinity-e2e.test.ts
@@ -26,13 +26,10 @@ type TestRoute = {
   pool: Pool;
 };
 
-// NOTE: pools whose `hooks` address registers callbacks (non-zero hooks
-// registration bitmap, lower 16 bits of the on-chain `parameters` bytes32)
-// cannot be round-tripped through this encoder yet — see `encodeParameters`
-// in ./encoder.ts. The `parameters` it produces will not match the pool's
-// on-chain value, so `poolId = keccak256(poolKey)` mismatches and swaps
-// revert. Only add test routes for pools with `hooks = address(0)` (or hook
-// contracts that register no callbacks) until that's fixed.
+// NOTE: Pools whose `hooks` address registers callbacks need a matching
+// entry in `HOOKS_REGISTRATION_BITMAP` in ./encoder.ts so the encoded
+// `parameters` matches the on-chain value. Hookless pools
+// (`hooks == address(0)`) need no entry.
 const testRoutes: TestRoute[] = [
   {
     // CAKE -> BNB via CLPool (no hooks)
@@ -127,6 +124,31 @@ const testRoutes: TestRoute[] = [
         poolManager: '0xa0ffb9c1ce1fe56963b0321b32e7a0302114058b',
         fee: '335',
         tickSpacing: 1,
+      },
+    },
+  },
+  {
+    // USDT -> 0x5506...54a1 via CLPool with CLAlphaHook
+    // (hooksRegistration=69, tickSpacing=10)
+    name: 'USDT -> 0x5506...54a1 (zeroForOne=false, CLAlphaHook, tickSpacing=10)',
+    srcToken: '0x55d398326f99059ff775485246999027b3197955',
+    destToken: '0x5506599c722389a60580b5213ea1da60d64754a1',
+    srcDecimals: 18,
+    destDecimals: 18,
+    srcAmount: '10000000000000000000',
+    destAmount: '69267209298029908090',
+    blockNumber: 99762726,
+    side: SwapSide.SELL,
+    zeroForOne: false,
+    pool: {
+      id: '0xce7217a1091a273e0253557f03bde40386935bda4602ab8ab5c966ee664a3295',
+      key: {
+        currency0: '0x5506599c722389a60580b5213ea1da60d64754a1',
+        currency1: '0x55d398326f99059ff775485246999027b3197955',
+        hooks: '0xb0baa371b899950b4ef6a27c21baf5ef7c434d0f',
+        poolManager: '0xa0ffb9c1ce1fe56963b0321b32e7a0302114058b',
+        fee: '67',
+        tickSpacing: 10,
       },
     },
   },

--- a/src/dex/pancakeswap-infinity/pancakeswap-infinity-integration.test.ts
+++ b/src/dex/pancakeswap-infinity/pancakeswap-infinity-integration.test.ts
@@ -17,13 +17,6 @@ const routerAddress =
 const routerIface = new Interface(RouterAbi);
 
 // ERC20/ERC20 pool (no native currency).
-// NOTE: this fixture sets a non-zero `hooks` address, but the encoder
-// reconstructs `parameters` from `tickSpacing` alone and zeroes out the
-// hooks registration bitmap — so the `parameters` bytes32 produced here
-// does not match the real on-chain pool. That's fine for these tests
-// (they only assert router command structure, not poolId correctness),
-// but any on-chain simulation against this pool would revert with
-// `PoolNotInitialized`. See `encodeParameters` in ./encoder.ts.
 const pool: Pool = {
   id: '0x0000000000000000000000000000000000000000000000000000000000000001',
   key: {

--- a/src/dex/pancakeswap-infinity/types.ts
+++ b/src/dex/pancakeswap-infinity/types.ts
@@ -21,12 +21,10 @@ export type SubgraphConnectorPool = {
 
 // PoolKey as consumed by the encoder. The on-chain tuple has a final
 // `bytes32 parameters` field instead of `tickSpacing` — for CL pools it
-// packs `(tickSpacing << 16) | hooksRegistrationBitmap`. We currently
-// reconstruct `parameters` from `tickSpacing` alone and assume the hooks
-// registration bitmap is 0, which is only correct when `hooks ==
-// address(0)` (or the hook contract registers no callbacks). Swaps through
-// pools with registered hook callbacks will revert because the poolId hash
-// won't match. See `encodeParameters` in ./encoder.ts.
+// packs `(tickSpacing << 16) | hooksRegistrationBitmap`. The encoder
+// reconstructs it via `encodeParameters` in ./encoder.ts, resolving the
+// bitmap from a hardcoded `hooks` → bitmap table (defaults to 0 for
+// hookless pools or unknown hooks).
 export type PoolKey = {
   currency0: string;
   currency1: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Modifies on-chain swap calldata encoding for PancakeSwap Infinity CL pools; incorrect or missing hook bitmap mappings can change `poolId` and cause swaps to revert.
> 
> **Overview**
> Updates PancakeSwap Infinity CL pool `parameters` encoding to include the **hooks registration bitmap** (lower 16 bits) alongside `tickSpacing`, using a hardcoded `hooks`→bitmap lookup to match on-chain `poolId` generation and enable swaps through hook-enabled pools.
> 
> Adds an E2E route covering a CLAlphaHook pool and updates test/docs comments accordingly. Bumps package version to `5.0.1` and tweaks Jest config to transform both `ts`/`js` files and not ignore `uuid` in `node_modules`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9075e60f255dedf97eb8af038e2285243e1839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->