### PR TITLE
fix: encode is128 flag for executors 01 and 02

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/config.ts
+++ b/src/config.ts
@@ -55,8 +55,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     privateHttpProvider: process.env.HTTP_PROVIDER_1,
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
-      Executor02: '0x00C600b30fb0400701010F4b080409018B9006E0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     adapterAddresses: {
@@ -154,8 +154,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     bebopAuthName: process.env.API_KEY_BEBOP_AUTH_NAME || '',
     bebopAuthToken: process.env.API_KEY_BEBOP_AUTH_TOKEN || '',
     executorsAddresses: {
-      Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
-      Executor02: '0x00C600b30fb0400701010F4b080409018B9006E0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
@@ -191,8 +191,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     privateHttpProvider: process.env.HTTP_PROVIDER_137,
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
-      Executor02: '0x00C600b30fb0400701010F4b080409018B9006E0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     bebopAuthName: process.env.API_KEY_BEBOP_AUTH_NAME || '',
@@ -236,8 +236,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     dexalotAuthToken: process.env.API_KEY_DEXALOT_AUTH_TOKEN || '',
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
-      Executor02: '0x00C600b30fb0400701010F4b080409018B9006E0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     adapterAddresses: {
@@ -271,8 +271,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
       process.env[`HASHFLOW_DISABLED_MMS_146`]?.split(',') || [],
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x67dd00d00d000003a383b096091f0a3060000d08',
-      Executor02: '0x700602C7b720200a09000f38B0d00Ee00c54f000',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     adapterAddresses: {},
@@ -303,8 +303,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
       process.env[`HASHFLOW_DISABLED_MMS_42161`]?.split(',') || [],
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
-      Executor02: '0x00C600b30fb0400701010F4b080409018B9006E0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     dexalotAuthToken: process.env.API_KEY_DEXALOT_AUTH_TOKEN || '',
@@ -340,8 +340,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     privateHttpProvider: process.env.HTTP_PROVIDER_10,
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
-      Executor02: '0x00C600b30fb0400701010F4b080409018B9006E0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     hashFlowAuthToken: process.env.API_KEY_HASHFLOW_AUTH_TOKEN || '',
@@ -379,8 +379,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     augustusRFQAddress: '0x92EaD5bACf6F0E995FA46Ad8215A9b11f67ca241',
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x000010036c0190e009a000d0fc3541100a07380a',
-      Executor02: '0x00c600b30fb0400701010f4b080409018b9006e0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     rpcPollingMaxAllowedStateDelayInBlocks: 0,
@@ -414,8 +414,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     hashFlowDisabledMMs: [],
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
-      Executor02: '0x00C600b30fb0400701010F4b080409018B9006E0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     adapterAddresses: {
@@ -447,8 +447,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     augustusRFQAddress: '0x92EaD5bACf6F0E995FA46Ad8215A9b11f67ca241',
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
-      Executor02: '0x00C600b30fb0400701010F4b080409018B9006E0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     rpcPollingMaxAllowedStateDelayInBlocks: 0,
@@ -478,8 +478,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     rfqConfigs: {},
     hashFlowDisabledMMs: [],
     executorsAddresses: {
-      Executor01: '0x000010036c0190e009a000d0fc3541100a07380a',
-      Executor02: '0x00c600b30fb0400701010f4b080409018b9006e0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     uniswapV2ExchangeRouterAddress:
@@ -505,8 +505,8 @@ const baseConfigs: { [network: number]: BaseConfig } = {
     augustusRFQAddress: '0x92EaD5bACf6F0E995FA46Ad8215A9b11f67ca241',
     augustusV6Address: '0x6a000f20005980200259b80c5102003040001068',
     executorsAddresses: {
-      Executor01: '0x000010036C0190E009a000d0fc3541100A07380A',
-      Executor02: '0x00C600b30fb0400701010F4b080409018B9006E0',
+      Executor01: '0x8faa0000c10015610005ca010ee000d006e0e820',
+      Executor02: '0x6f0538001f90d0a5f0000060d01d34c002030900',
       Executor03: '0xa000b020c290d000020aac04026b5306d60050f0',
     },
     rpcPollingMaxAllowedStateDelayInBlocks: 0,

--- a/src/executor/Executor01BytecodeBuilder.ts
+++ b/src/executor/Executor01BytecodeBuilder.ts
@@ -395,7 +395,11 @@ export class Executor01BytecodeBuilder extends ExecutorBytecodeBuilder<
     const insertFromAmount = flag % 4 === 3 || flag % 4 === 2;
     const exchangeParam = exchangeParams[exchangeParamIndex];
     const swap = priceRoute.bestRoute[routeIndex].swaps[swapIndex];
-    let { exchangeData, specialDexFlag } = exchangeParam;
+    let {
+      exchangeData,
+      specialDexFlag,
+      amountsPacked128 = false,
+    } = exchangeParam;
 
     const returnAmountPos =
       exchangeParam.returnAmountPos !== undefined
@@ -423,21 +427,23 @@ export class Executor01BytecodeBuilder extends ExecutorBytecodeBuilder<
       if (exchangeParam.insertFromAmountPos) {
         fromAmountPos = exchangeParam.insertFromAmountPos;
       } else {
-        const fromAmount = ethers.utils.defaultAbiCoder.encode(
-          ['uint256'],
-          [swap.swapExchanges[swapExchangeIndex].srcAmount],
+        fromAmountPos = this.findAmountPosWithFallback(
+          exchangeData,
+          swap.swapExchanges[swapExchangeIndex].srcAmount,
+          amountsPacked128,
         );
-
-        fromAmountPos = this.findAmountPosInCalldata(exchangeData, fromAmount);
       }
     }
+
+    const finalFlag = amountsPacked128 ? this.applyIs128(flag) : flag;
+
     return this.buildCallData(
       exchangeParam.targetExchange,
       exchangeData,
       fromAmountPos,
       destTokenPos,
       specialDexFlag || SpecialDex.DEFAULT,
-      flag,
+      finalFlag as Flag,
       undefined,
       returnAmountPos,
     );

--- a/src/executor/Executor02BytecodeBuilder.ts
+++ b/src/executor/Executor02BytecodeBuilder.ts
@@ -319,8 +319,13 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
 
     const swap = priceRoute.bestRoute[routeIndex].swaps[swapIndex];
     const exchangeParam = exchangeParams[exchangeParamIndex];
-    let { exchangeData, specialDexFlag, targetExchange, needWrapNative } =
-      exchangeParam;
+    let {
+      exchangeData,
+      specialDexFlag,
+      targetExchange,
+      needWrapNative,
+      amountsPacked128 = false,
+    } = exchangeParam;
 
     const routeNeedsRootUnwrapEth = this.doesRouteNeedsRootUnwrapEth(
       priceRoute,
@@ -395,14 +400,15 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
       if (exchangeParam.insertFromAmountPos) {
         fromAmountPos = exchangeParam.insertFromAmountPos;
       } else {
-        const fromAmount = ethers.utils.defaultAbiCoder.encode(
-          ['uint256'],
-          [swapExchange.srcAmount],
+        fromAmountPos = this.findAmountPosWithFallback(
+          exchangeData,
+          swapExchange.srcAmount,
+          amountsPacked128,
         );
-
-        fromAmountPos = this.findAmountPosInCalldata(exchangeData, fromAmount);
       }
     }
+
+    const finalFlag = amountsPacked128 ? this.applyIs128(flag) : flag;
 
     return this.buildCallData(
       targetExchange,
@@ -410,7 +416,7 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
       fromAmountPos,
       destTokenPos,
       specialDexFlag || SpecialDex.DEFAULT,
-      flag,
+      finalFlag as Flag,
       undefined,
       returnAmountPos,
     );

--- a/src/executor/Executor03BytecodeBuilder.ts
+++ b/src/executor/Executor03BytecodeBuilder.ts
@@ -1,4 +1,4 @@
-import { ethers, BigNumber } from 'ethers';
+import { ethers } from 'ethers';
 import { DexExchangeBuildParam } from '../types';
 import {
   Address,
@@ -19,11 +19,6 @@ import {
 const {
   utils: { hexlify, hexDataLength, hexConcat, hexZeroPad, solidityPack },
 } = ethers;
-
-/** Set bit 15 (uint128 write mode) on an Executor03 flag. */
-function applyIs128(flag: number): number {
-  return flag | 0x8000;
-}
 
 export type Executor03SingleSwapCallDataParams = {
   swap: OptimalSwap;
@@ -423,7 +418,7 @@ export class Executor03BytecodeBuilder extends ExecutorBytecodeBuilder<
       );
     }
 
-    const finalFlag = amountsPacked128 ? applyIs128(flag) : flag;
+    const finalFlag = amountsPacked128 ? this.applyIs128(flag) : flag;
 
     return this.buildCallData(
       exchangeParam.targetExchange,
@@ -503,94 +498,6 @@ export class Executor03BytecodeBuilder extends ExecutorBytecodeBuilder<
         swapsCalldata, // // calldata
       ],
     );
-  }
-
-  /**
-   * Find the position of an amount in calldata, trying both positive and
-   * negative encodings. For uint128 mode (is128), searches for 16-byte
-   * int128 patterns and returns the 32-byte slot position for mstore.
-   */
-  private findAmountPosWithFallback(
-    exchangeData: string,
-    amount: string,
-    is128: boolean,
-  ): number {
-    if (is128) {
-      return this.findAmount128PosInCalldata(exchangeData, amount);
-    }
-
-    // uint256 mode: try positive encoding first
-    const positiveEncoded = ethers.utils.defaultAbiCoder.encode(
-      ['uint256'],
-      [amount],
-    );
-    let pos = this.findAmountPosInCalldata(exchangeData, positiveEncoded);
-
-    // If not found, try negative int256 encoding
-    if (pos >= exchangeData.length / 2) {
-      const negativeEncoded = ethers.utils.defaultAbiCoder.encode(
-        ['int256'],
-        [BigNumber.from(amount).mul(-1)],
-      );
-      pos = this.findAmountPosInCalldata(exchangeData, negativeEncoded);
-    }
-
-    return pos;
-  }
-
-  /**
-   * Find the byte position of a 128-bit amount in calldata.
-   * Searches for both positive and negative int128 encodings.
-   * Returns the 32-byte slot position (16 bytes before the int128 value)
-   * so that mstore with uint128 mode writes to the correct lower 16 bytes.
-   */
-  private findAmount128PosInCalldata(
-    exchangeData: string,
-    amount: string,
-  ): number {
-    const rawCalldata = exchangeData.replace('0x', '');
-    const amountBN = BigNumber.from(amount);
-
-    // Try positive int128 encoding (32 hex chars = 16 bytes)
-    const positiveHex = hexZeroPad(
-      amountBN.toTwos(128).toHexString(),
-      16,
-    ).replace('0x', '');
-    let idx = this.findByteAligned(rawCalldata, positiveHex);
-
-    // Try negative int128 encoding if positive not found
-    if (idx === -1) {
-      const negativeHex = hexZeroPad(
-        amountBN.mul(-1).toTwos(128).toHexString(),
-        16,
-      ).replace('0x', '');
-      idx = this.findByteAligned(rawCalldata, negativeHex);
-    }
-
-    if (idx !== -1) {
-      // The int128 value starts at byte position idx/2.
-      // mstore with uint128 mode writes lower 16 bytes of a 32-byte slot,
-      // so the slot position is 16 bytes before the int128 value.
-      const slotPos = idx / 2 - 16;
-      if (slotPos >= 0) {
-        return slotPos;
-      }
-    }
-
-    // Not found — return past end of calldata (harmless write)
-    return exchangeData.length / 2;
-  }
-
-  /** Find a hex pattern in calldata, only accepting byte-aligned matches. */
-  private findByteAligned(rawCalldata: string, pattern: string): number {
-    for (
-      let idx = rawCalldata.indexOf(pattern);
-      idx !== -1;
-      idx = rawCalldata.indexOf(pattern, idx + 1)
-    ) {
-      if (idx % 2 === 0) return idx;
-    }
-    return -1;
   }
 
   private addMetadata(

--- a/src/executor/ExecutorBytecodeBuilder.ts
+++ b/src/executor/ExecutorBytecodeBuilder.ts
@@ -2,7 +2,7 @@ import { Interface } from '@ethersproject/abi';
 import { IDexHelper } from '../dex-helper';
 import ERC20ABI from '../abi/erc20.json';
 import Permit2Abi from '../abi/permit2.json';
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import {
   Address,
   OptimalRate,
@@ -278,6 +278,78 @@ export abstract class ExecutorBytecodeBuilder<S = {}, D = {}> {
     }
 
     return (amountIndex !== -1 ? amountIndex : exchangeData.length) / 2;
+  }
+
+  protected applyIs128(flag: number): number {
+    return flag | 0x8000;
+  }
+
+  protected findAmountPosWithFallback(
+    exchangeData: string,
+    amount: string,
+    is128: boolean,
+  ): number {
+    if (is128) {
+      return this.findAmount128PosInCalldata(exchangeData, amount);
+    }
+
+    const positiveEncoded = ethers.utils.defaultAbiCoder.encode(
+      ['uint256'],
+      [amount],
+    );
+    let pos = this.findAmountPosInCalldata(exchangeData, positiveEncoded);
+
+    if (pos >= exchangeData.length / 2) {
+      const negativeEncoded = ethers.utils.defaultAbiCoder.encode(
+        ['int256'],
+        [BigNumber.from(amount).mul(-1)],
+      );
+      pos = this.findAmountPosInCalldata(exchangeData, negativeEncoded);
+    }
+
+    return pos;
+  }
+
+  private findAmount128PosInCalldata(
+    exchangeData: string,
+    amount: string,
+  ): number {
+    const rawCalldata = exchangeData.replace('0x', '');
+    const amountBN = BigNumber.from(amount);
+
+    const positiveHex = hexZeroPad(
+      amountBN.toTwos(128).toHexString(),
+      16,
+    ).replace('0x', '');
+    let idx = this.findByteAligned(rawCalldata, positiveHex);
+
+    if (idx === -1) {
+      const negativeHex = hexZeroPad(
+        amountBN.mul(-1).toTwos(128).toHexString(),
+        16,
+      ).replace('0x', '');
+      idx = this.findByteAligned(rawCalldata, negativeHex);
+    }
+
+    if (idx !== -1) {
+      const slotPos = idx / 2 - 16;
+      if (slotPos >= 0) {
+        return slotPos;
+      }
+    }
+
+    return exchangeData.length / 2;
+  }
+
+  private findByteAligned(rawCalldata: string, pattern: string): number {
+    for (
+      let idx = rawCalldata.indexOf(pattern);
+      idx !== -1;
+      idx = rawCalldata.indexOf(pattern, idx + 1)
+    ) {
+      if (idx % 2 === 0) return idx;
+    }
+    return -1;
   }
 
   protected buildWrapEthCallData(


### PR DESCRIPTION
## Summary
- move packed int128 amount-position detection and is128 flag encoding into the shared executor bytecode builder
- apply the is128 flag path to Executor01 and Executor02, keeping Executor03 on the shared helper
- update Executor01 to 0x8faa0000c10015610005ca010ee000d006e0e820 and Executor02 to 0x6f0538001f90d0a5f0000060d01d34c002030900 on all configured chains

## Tests
- pnpm exec eslint src/config.ts src/executor/ExecutorBytecodeBuilder.ts src/executor/Executor01BytecodeBuilder.ts src/executor/Executor02BytecodeBuilder.ts src/executor/Executor03BytecodeBuilder.ts
- CI=true pnpm test src/dex/ekubo-v3/ekubo-v3-insert-amounts.test.ts --runInBand --forceExit

Ekubo V3 SELL simulations:
- Baseline: https://dashboard.tenderly.co/paraswap/paraswap/simulator/ed2fe9ff-0d14-4fe2-970f-8ef165e061d0
- Tweaked: https://dashboard.tenderly.co/paraswap/paraswap/simulator/6424cb2c-519f-40fb-9955-3df35b48cce7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Network-wide executor address changes and altered on-chain swap calldata/flags affect live routing and swaps; misconfiguration could break trades until deployments match config.
> 
> **Overview**
> Bumps **@paraswap/dex-lib** to **5.0.2** and rolls out new **Executor01** / **Executor02** contract addresses on every configured network in `src/config.ts`.
> 
> **Executor bytecode** now treats **int128-packed** swap amounts the same on all three executors: shared helpers (`applyIs128`, `findAmountPosWithFallback`, and 128-bit calldata search) live on `ExecutorBytecodeBuilder`, and **Executor01** / **Executor02** honor `amountsPacked128` on exchange params—setting the **is128** flag bit and locating amounts via the shared fallback instead of only **uint256** ABI encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5023cbf752c965a7a2a89f396886c985cb9e8ac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->