### PR TITLE
feat: add Topaz DEX integration (v2 + concentrated liquidity)

### DIFF
--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -69,6 +69,7 @@ import { Native } from './native/native';
 import { Spark } from './spark/spark';
 import { SparkPsm } from './spark/spark-psm';
 import { VelodromeSlipstream } from './uniswap-v3/forks/velodrome-slipstream/velodrome-slipstream';
+import { TopazCL } from './uniswap-v3/forks/topaz-cl/topaz-cl';
 import { AaveV3Stata } from './aave-v3-stata/aave-v3-stata';
 import { AaveV3StataV2 } from './aave-v3-stata-v2/aave-v3-stata-v2';
 import { OSwap } from './oswap/oswap';
@@ -100,6 +101,7 @@ import { MiroMigrator } from './miro-migrator/miro-migrator';
 import { AaveV3PtRollOver } from './aave-v3-pt-roll-over/aave-v3-pt-roll-over';
 import { RingV2 } from './uniswap-v2/ring-v2';
 import { UsdcTransmuter } from './usdc-transmuter/usdc-transmuter';
+import { Topaz } from './solidly/forks-override/topaz';
 import { Blackhole } from './solidly/forks-override/blackhole';
 import { BlackholeCL } from './algebra-integral/forks/blackhole-cl';
 import { dETH } from './deth/dETH';
@@ -140,6 +142,7 @@ const Dexes = [
   PancakeSwapV2,
   PancakeswapV3,
   VelodromeSlipstream,
+  TopazCL,
   BiSwap,
   AaveV3,
   Weth,
@@ -198,6 +201,7 @@ const Dexes = [
   AaveV3PtRollOver,
   RingV2,
   UsdcTransmuter,
+  Topaz,
   Blackhole,
   BlackholeCL,
   Cap,

--- a/src/dex/solidly/config.ts
+++ b/src/dex/solidly/config.ts
@@ -93,6 +93,18 @@ export const SolidlyConfig: DexConfigMap<DexParams> = {
       poolGasCost: 180 * 1000,
     },
   },
+  Topaz: {
+    [Network.BSC]: {
+      factoryAddress: '0x65E6cD0eF5D3467030103cf3d433034E570b5784',
+      router: '0x1E98c8226e7d452e1888e3d3d2F929346321c6c3',
+      initCode:
+        '0xc90b102edcdcb0be645cc77159a870ae92733f16dc519083b819105dfa107f2c',
+      poolGasCost: 180 * 1000,
+      feeCode: 0,
+      factoryAbi: AerodromeFactoryABI as AbiItem[],
+      getPairMethodName: 'getPool',
+    },
+  },
   Blackhole: {
     [Network.AVALANCHE]: {
       // RPC pool tracker is used

--- a/src/dex/solidly/forks-override/topaz-integration.test.ts
+++ b/src/dex/solidly/forks-override/topaz-integration.test.ts
@@ -1,0 +1,204 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { DummyDexHelper } from '../../../dex-helper';
+import { Network, SwapSide } from '../../../constants';
+import { checkPoolPrices, checkPoolsLiquidity } from '../../../../tests/utils';
+import { BI_POWS } from '../../../bigint-constants';
+import { Tokens } from '../../../../tests/constants-e2e';
+import { Interface, Result } from '@ethersproject/abi';
+import solidlyPairABI from '../../../abi/solidly/SolidlyPair.json';
+import { Topaz } from './topaz';
+
+const amounts18 = [0n, BI_POWS[18], 2000000000000000000n];
+
+function getReaderCalldata(
+  exchangeAddress: string,
+  readerIface: Interface,
+  amounts: bigint[],
+  funcName: string,
+  tokenIn: string,
+) {
+  return amounts.map(amount => ({
+    target: exchangeAddress,
+    callData: readerIface.encodeFunctionData(funcName, [amount, tokenIn]),
+  }));
+}
+
+function decodeReaderResult(
+  results: Result,
+  readerIface: Interface,
+  funcName: string,
+) {
+  return results.map(result => {
+    const parsed = readerIface.decodeFunctionResult(funcName, result);
+    return BigInt(parsed[0]._hex);
+  });
+}
+
+const constructCheckOnChainPricing =
+  (dexHelper: DummyDexHelper) =>
+  async (
+    topaz: Topaz,
+    funcName: string,
+    blockNumber: number,
+    prices: bigint[],
+    exchangeAddress: string,
+    tokenIn: string,
+    amounts: bigint[],
+  ) => {
+    const readerIface = new Interface(solidlyPairABI as any);
+
+    const readerCallData = getReaderCalldata(
+      exchangeAddress,
+      readerIface,
+      amounts.slice(1),
+      funcName,
+      tokenIn,
+    );
+
+    const readerResult = (
+      await dexHelper.multiContract.methods
+        .aggregate(readerCallData)
+        .call({}, blockNumber)
+    ).returnData;
+    const expectedPrices = [0n].concat(
+      decodeReaderResult(readerResult, readerIface, funcName),
+    );
+
+    console.log('ON-CHAIN PRICES: ', expectedPrices);
+    console.log('  CACHED PRICES: ', prices);
+
+    expect(prices.map(p => p.toString())).toEqual(
+      expectedPrices.map(p => p.toString()),
+    );
+  };
+
+describe('Topaz V2 integration tests', () => {
+  const network = Network.BSC;
+  const dexHelper = new DummyDexHelper(network);
+  const checkOnChainPricing = constructCheckOnChainPricing(dexHelper);
+
+  const dexKey = 'Topaz';
+
+  describe('Volatile pool', () => {
+    const TokenASymbol = 'WBNB';
+    const tokenA = Tokens[network][TokenASymbol];
+    const TokenBSymbol = 'USDT';
+    const tokenB = Tokens[network][TokenBSymbol];
+
+    it('getPoolIdentifiers and getPricesVolume SELL', async () => {
+      const topaz = new Topaz(network, dexKey, dexHelper);
+      const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      const pools = await topaz.getPoolIdentifiers(
+        tokenA,
+        tokenB,
+        SwapSide.SELL,
+        blocknumber,
+      );
+      console.log(
+        `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+        pools,
+      );
+
+      expect(pools.length).toBeGreaterThan(0);
+
+      const poolPrices = await topaz.getPricesVolume(
+        tokenA,
+        tokenB,
+        amounts18,
+        SwapSide.SELL,
+        blocknumber,
+        pools,
+      );
+      console.log(
+        `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+        poolPrices,
+      );
+
+      expect(poolPrices).not.toBeNull();
+      checkPoolPrices(poolPrices!, amounts18, SwapSide.SELL, dexKey);
+
+      for (const poolPrice of poolPrices || []) {
+        await checkOnChainPricing(
+          topaz,
+          'getAmountOut',
+          blocknumber,
+          poolPrice.prices,
+          poolPrice.poolAddresses![0],
+          tokenA.address,
+          amounts18,
+        );
+      }
+    });
+  });
+
+  describe('Stable pool', () => {
+    const TokenASymbol = 'USDT';
+    const tokenA = Tokens[network][TokenASymbol];
+    const TokenBSymbol = 'USDC';
+    const tokenB = Tokens[network][TokenBSymbol];
+
+    it('getPoolIdentifiers and getPricesVolume SELL', async () => {
+      const topaz = new Topaz(network, dexKey, dexHelper);
+      const blocknumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      const pools = await topaz.getPoolIdentifiers(
+        tokenA,
+        tokenB,
+        SwapSide.SELL,
+        blocknumber,
+      );
+      console.log(
+        `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+        pools,
+      );
+
+      expect(pools.length).toBeGreaterThan(0);
+
+      const poolPrices = await topaz.getPricesVolume(
+        tokenA,
+        tokenB,
+        amounts18,
+        SwapSide.SELL,
+        blocknumber,
+        pools,
+      );
+      console.log(
+        `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+        poolPrices,
+      );
+
+      expect(poolPrices).not.toBeNull();
+      checkPoolPrices(poolPrices!, amounts18, SwapSide.SELL, dexKey);
+
+      for (const poolPrice of poolPrices || []) {
+        await checkOnChainPricing(
+          topaz,
+          'getAmountOut',
+          blocknumber,
+          poolPrice.prices,
+          poolPrice.poolAddresses![0],
+          tokenA.address,
+          amounts18,
+        );
+      }
+    });
+  });
+
+  describe('getTopPoolsForToken', () => {
+    it('should return top pools for WBNB', async () => {
+      const topaz = new Topaz(network, dexKey, dexHelper);
+      const tokenA = Tokens[network]['WBNB'];
+      const poolLiquidity = await topaz.getTopPoolsForToken(tokenA.address, 10);
+      console.log(
+        `${dexKey} Top Pools for WBNB:`,
+        JSON.stringify(poolLiquidity, null, 2),
+      );
+
+      if (poolLiquidity.length > 0) {
+        checkPoolsLiquidity(poolLiquidity, tokenA.address, dexKey);
+      }
+    });
+  });
+});

--- a/src/dex/solidly/forks-override/topaz.ts
+++ b/src/dex/solidly/forks-override/topaz.ts
@@ -1,0 +1,87 @@
+import { Network } from '../../../constants';
+import { getDexKeysWithNetwork } from '../../../utils';
+import { SolidlyConfig } from '../config';
+import _ from 'lodash';
+import { SolidlyPair } from '../types';
+import { Interface } from '@ethersproject/abi';
+import { IDexHelper } from '../../../dex-helper';
+import { addressDecode, uint256DecodeToNumber } from '../../../lib/decoders';
+import { MultiCallParams } from '../../../lib/multi-wrapper';
+import { SolidlyRpcPoolTracker } from '../rpc-pool-tracker';
+
+const TopazFactoryABI = [
+  {
+    inputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    name: 'allPools',
+    outputs: [{ internalType: 'address', name: '', type: 'address' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'allPoolsLength',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'address', name: 'pool', type: 'address' },
+      { internalType: 'bool', name: '_stable', type: 'bool' },
+    ],
+    name: 'getFee',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+];
+
+const topazFactoryIface = new Interface(TopazFactoryABI);
+
+export class Topaz extends SolidlyRpcPoolTracker {
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(_.pick(SolidlyConfig, ['Topaz']));
+
+  constructor(
+    protected network: Network,
+    dexKey: string,
+    protected dexHelper: IDexHelper,
+  ) {
+    super(network, dexKey, dexHelper, true);
+  }
+
+  protected getFeesMultiCallData(pair: SolidlyPair) {
+    const callEntry = {
+      target: this.factoryAddress,
+      callData: topazFactoryIface.encodeFunctionData('getFee', [
+        pair.exchange,
+        pair.stable,
+      ]),
+    };
+    const callDecoder = (values: any[]) =>
+      parseInt(
+        topazFactoryIface.decodeFunctionResult('getFee', values)[0].toString(),
+      );
+
+    return {
+      callEntry,
+      callDecoder,
+    };
+  }
+
+  protected getAllPoolsCallData(): MultiCallParams<number> {
+    return {
+      target: this.factoryAddress,
+      callData: topazFactoryIface.encodeFunctionData('allPoolsLength', []),
+      decodeFunction: uint256DecodeToNumber,
+    };
+  }
+
+  protected getPoolCallData(index: number): MultiCallParams<string> {
+    return {
+      target: this.factoryAddress,
+      callData: topazFactoryIface.encodeFunctionData('allPools', [index]),
+      decodeFunction: addressDecode,
+    };
+  }
+}

--- a/src/dex/solidly/solidly.ts
+++ b/src/dex/solidly/solidly.ts
@@ -90,6 +90,7 @@ export class Solidly extends UniswapV2 {
         'Velocimeter',
         'Usdfi',
         'PharaohV1',
+        'Topaz',
         'Blackhole',
       ]),
     );

--- a/src/dex/uniswap-v3/config.ts
+++ b/src/dex/uniswap-v3/config.ts
@@ -462,6 +462,34 @@ export const UniswapV3Config: DexConfigMap<DexParams> = {
       liquidityField: 'liquidity',
     },
   },
+  TopazCL: {
+    [Network.BSC]: {
+      factory: '0x73DC984D9490286E735548f61dfCCec67Af82ed9',
+      quoter: '0x7CCB89bB9BdEF68688F39a2c22d249fD1D9759f1',
+      router: '0x9B63CA87919617d042A89663492dB3c8686e0CaE',
+      supportedFees: SUPPORTED_FEES,
+      tickSpacings: [1n, 50n, 100n, 200n, 2000n],
+      tickSpacingsToFees: {
+        '1': 100n,
+        '50': 500n,
+        '100': 1000n,
+        '200': 3000n,
+        '2000': 10000n,
+      },
+      stateMulticall: '0xa1941194be7c2607FfbC27DE23B1aCA357C45e3D',
+      stateMultiCallAbi: VelodromeSlipstreamMulticallABi as AbiItem[],
+      eventPoolImplementation: VelodromeSlipstreamEventPool,
+      factoryImplementation: VelodromeSlipstreamFactory,
+      decodeStateMultiCallResultWithRelativeBitmaps:
+        decodeStateMultiCallResultWithRelativeBitmapsForVelodromeSlipstream,
+      uniswapMulticall: '0x963Df249eD09c358A4819E39d9Cd5736c3087184',
+      chunksCount: 10,
+      initRetryFrequency: 10,
+      initHash: '0x18e68051d1b1fb44cb539ca4436f112d28577af7',
+      subgraphURL:
+        'https://api.goldsky.com/api/public/project_cmgzljqwl006c5np2gnao4li4/subgraphs/topaz-v3/v0.0.1/gn',
+    },
+  },
   PangolinV3: {
     [Network.AVALANCHE]: {
       factory: '0x1128F23D0bc0A8396E9FBC3c0c68f5EA228B8256',

--- a/src/dex/uniswap-v3/forks/topaz-cl/topaz-cl-integration.test.ts
+++ b/src/dex/uniswap-v3/forks/topaz-cl/topaz-cl-integration.test.ts
@@ -1,0 +1,221 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Interface, Result } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../../../dex-helper/index';
+import { Network, SwapSide } from '../../../../constants';
+import { BI_POWS } from '../../../../bigint-constants';
+import {
+  checkPoolPrices,
+  checkPoolsLiquidity,
+} from '../../../../../tests/utils';
+import { Tokens } from '../../../../../tests/constants-e2e';
+import VelodromeSlipstreamQuoterV2ABI from '../../../../abi/velodrome-slipstream/VelodromeSlipstreamQuoterV2.abi.json';
+import { Address } from '@paraswap/core';
+import { TopazCL } from './topaz-cl';
+
+const network = Network.BSC;
+const dexKey = 'TopazCL';
+const quoterAddress = '0x7CCB89bB9BdEF68688F39a2c22d249fD1D9759f1';
+const velodromeQuoterIface = new Interface(VelodromeSlipstreamQuoterV2ABI);
+
+function getReaderCalldata(
+  exchangeAddress: string,
+  readerIface: Interface,
+  amounts: bigint[],
+  funcName: string,
+  tokenIn: Address,
+  tokenOut: Address,
+  tickSpacing: bigint,
+) {
+  return amounts.map(amount => ({
+    target: exchangeAddress,
+    callData: readerIface.encodeFunctionData(funcName, [
+      [tokenIn, tokenOut, amount.toString(), tickSpacing.toString(), 0],
+    ]),
+  }));
+}
+
+function decodeReaderResult(
+  results: Result,
+  readerIface: Interface,
+  funcName: string,
+) {
+  return results.map(result => {
+    const parsed = readerIface.decodeFunctionResult(funcName, result);
+    return BigInt(parsed[0]._hex);
+  });
+}
+
+async function checkOnChainPricing(
+  dexHelper: DummyDexHelper,
+  topazCL: TopazCL,
+  funcName: string,
+  blockNumber: number,
+  prices: bigint[],
+  tokenIn: Address,
+  tokenOut: Address,
+  tickSpacing: bigint,
+  _amounts: bigint[],
+) {
+  const sum = prices.reduce((acc, curr) => (acc += curr), 0n);
+
+  if (sum === 0n) {
+    console.log(
+      `Prices were not calculated for tokenIn=${tokenIn}, tokenOut=${tokenOut}, tickSpacing=${tickSpacing}. Most likely price impact is too big for requested amount`,
+    );
+    return false;
+  }
+
+  const readerCallData = getReaderCalldata(
+    quoterAddress,
+    velodromeQuoterIface,
+    _amounts.slice(1),
+    funcName,
+    tokenIn,
+    tokenOut,
+    tickSpacing,
+  );
+
+  let readerResult;
+  try {
+    readerResult = (
+      await dexHelper.multiContract.methods
+        .aggregate(readerCallData)
+        .call({}, blockNumber)
+    ).returnData;
+  } catch (e) {
+    console.log(
+      `Can not fetch on-chain pricing for tickSpacing ${tickSpacing}. It happens for low liquidity pools`,
+      e,
+    );
+    return false;
+  }
+
+  const expectedPrices = [0n].concat(
+    decodeReaderResult(readerResult, velodromeQuoterIface, funcName),
+  );
+
+  console.log('ON-CHAIN PRICES: ', expectedPrices);
+  console.log('  CACHED PRICES: ', prices);
+
+  let maxDiffPercent = 0;
+  for (let i = 1; i < prices.length; i++) {
+    if (expectedPrices[i] === 0n) continue;
+    const diff =
+      Number(((prices[i] - expectedPrices[i]) * 10000n) / expectedPrices[i]) /
+      100;
+    console.log(`  Amount ${_amounts[i]}: diff = ${diff}%`);
+    maxDiffPercent = Math.max(maxDiffPercent, Math.abs(diff));
+  }
+
+  expect(maxDiffPercent).toBeLessThan(1);
+  return true;
+}
+
+describe('TopazCL Integration Tests', () => {
+  const dexHelper = new DummyDexHelper(network);
+  let topazCL: TopazCL;
+  let blockNumber: number;
+
+  const TokenASymbol = 'USDT';
+  const TokenA = Tokens[network][TokenASymbol];
+
+  const TokenBSymbol = 'WBNB';
+  const TokenB = Tokens[network][TokenBSymbol];
+
+  beforeEach(async () => {
+    blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+    topazCL = new TopazCL(network, dexKey, dexHelper);
+  });
+
+  it('getPoolIdentifiers and getPricesVolume SELL', async () => {
+    const amounts = [0n, BI_POWS[18], BI_POWS[18] * 2n];
+
+    const pools = await topazCL.getPoolIdentifiers(
+      TokenA,
+      TokenB,
+      SwapSide.SELL,
+      blockNumber,
+    );
+    console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `, pools);
+
+    expect(pools.length).toBeGreaterThan(0);
+
+    const poolPrices = await topazCL.getPricesVolume(
+      TokenA,
+      TokenB,
+      amounts,
+      SwapSide.SELL,
+      blockNumber,
+      pools,
+    );
+    console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `, poolPrices);
+
+    expect(poolPrices).not.toBeNull();
+    checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+    let falseChecksCounter = 0;
+    await Promise.all(
+      poolPrices!.map(async price => {
+        const tickSpacing =
+          topazCL.eventPools[price.poolIdentifiers![0]]!.tickSpacing!;
+        const res = await checkOnChainPricing(
+          dexHelper,
+          topazCL,
+          'quoteExactInputSingle',
+          blockNumber,
+          price.prices,
+          TokenA.address,
+          TokenB.address,
+          tickSpacing,
+          amounts,
+        );
+        if (res === false) falseChecksCounter++;
+      }),
+    );
+
+    expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
+  });
+
+  it('getPoolIdentifiers and getPricesVolume BUY', async () => {
+    const amounts = [0n, BI_POWS[18], BI_POWS[18] * 2n];
+
+    const pools = await topazCL.getPoolIdentifiers(
+      TokenA,
+      TokenB,
+      SwapSide.BUY,
+      blockNumber,
+    );
+    console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `, pools);
+
+    expect(pools.length).toBeGreaterThan(0);
+
+    const poolPrices = await topazCL.getPricesVolume(
+      TokenA,
+      TokenB,
+      amounts,
+      SwapSide.BUY,
+      blockNumber,
+      pools,
+    );
+    console.log(`${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `, poolPrices);
+
+    expect(poolPrices).not.toBeNull();
+    checkPoolPrices(poolPrices!, amounts, SwapSide.BUY, dexKey);
+  });
+
+  it('getTopPoolsForToken', async () => {
+    const tokenA = Tokens[network]['WBNB'];
+    const poolLiquidity = await topazCL.getTopPoolsForToken(tokenA.address, 10);
+    console.log(
+      `${dexKey} Top Pools for WBNB:`,
+      JSON.stringify(poolLiquidity, null, 2),
+    );
+
+    if (poolLiquidity.length > 0) {
+      checkPoolsLiquidity(poolLiquidity, tokenA.address, dexKey);
+    }
+  });
+});

--- a/src/dex/uniswap-v3/forks/topaz-cl/topaz-cl.ts
+++ b/src/dex/uniswap-v3/forks/topaz-cl/topaz-cl.ts
@@ -1,0 +1,10 @@
+import { VelodromeSlipstream } from '../velodrome-slipstream/velodrome-slipstream';
+import { Network } from '../../../../constants';
+import { getDexKeysWithNetwork } from '../../../../utils';
+import { UniswapV3Config } from '../../config';
+import _ from 'lodash';
+
+export class TopazCL extends VelodromeSlipstream {
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(_.pick(UniswapV3Config, ['TopazCL']));
+}


### PR DESCRIPTION
Add Topaz v2 (Solidly fork) and TopazCL (VelodromeSlipstream fork) DEX integrations on BSC with integration tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New swap liquidity sources affect BSC quote accuracy and route selection; implementation follows existing fork patterns with integration tests but no new adapter mapping entries visible in the diff.
> 
> **Overview**
> Adds **Topaz** on BSC as a Solidly-style v2 venue and **TopazCL** as a concentrated-liquidity venue, both wired into the global DEX registry so routing can use them on that chain.
> 
> **Topaz (v2)** registers BSC factory/router/init code in `SolidlyConfig`, implements `Topaz` on `SolidlyRpcPoolTracker` with dynamic fees via factory `getFee` and pool discovery via `allPools` / `getPool` (Aerodrome-style ABI), and excludes `Topaz` from the generic `Solidly` dex key list so it is a separate adapter. **TopazCL** adds a thin `TopazCL` class extending `VelodromeSlipstream` with BSC addresses, tick spacing → fee mapping, Velodrome slipstream multicall/pool plumbing, and a Goldsky subgraph URL.
> 
> Integration tests cover volatile/stable v2 pricing against on-chain `getAmountOut`, CL SELL/BUY quotes vs the configured quoter, and `getTopPoolsForToken` for WBNB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 139b2c553b6034e215856fbe4b243dfceaea78dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->