### PR TITLE
fix: remove beneficiary optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/generic-swap-transaction-builder.ts
+++ b/src/generic-swap-transaction-builder.ts
@@ -618,12 +618,7 @@ export class GenericSwapTransactionBuilder {
       ? priceRoute.destAmount
       : priceRoute.srcAmount;
 
-    // if beneficiary is not defined, then in smart contract it will be replaced to msg.sender
-    const _beneficiary =
-      beneficiary !== NULL_ADDRESS &&
-      beneficiary.toLowerCase() !== userAddress.toLowerCase()
-        ? beneficiary
-        : NULL_ADDRESS;
+    const _beneficiary = beneficiary;
 
     let encoder: (...params: any[]) => string;
     let params: (string | string[])[];


### PR DESCRIPTION
## Description

Removes the beneficiary optimization in `generic-swap-transaction-builder.ts` that replaced the beneficiary with `NULL_ADDRESS` when it matched `userAddress` (relying on the smart contract substituting `msg.sender`).

This optimization breaks execution when a wrong `userAddress` is passed, since the resulting transaction would send funds to the wrong recipient. The beneficiary is now always passed through unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how swap output recipient is encoded on-chain; fixes mis-routing when userAddress is wrong but still affects all V6 swap builds.
> 
> **Overview**
> **Swap transaction encoding** no longer rewrites the beneficiary to `NULL_ADDRESS` when it equals `userAddress` (previously assuming Augustus would substitute `msg.sender`). The caller-supplied **beneficiary is always forwarded** into V6 direct and executor swap params.
> 
> Package version bumps **5.0.3 → 5.0.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed78fc800f85515c03d7e96336a5049486353eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->