### PR TITLE
chore: update Aerodrome and WooFi config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/uniswap-v3/config.ts
+++ b/src/dex/uniswap-v3/config.ts
@@ -435,7 +435,7 @@ export const UniswapV3Config: DexConfigMap<DexParams> = {
   AerodromeSlipstreamNewFactory: {
     [Network.BASE]: {
       factory: '0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a',
-      quoter: '0x254cF9E1E6e233aa1AC962CB9B05b2cfeAaE15b0',
+      quoter: '0xfa2CB6D6cea79D6Efa102e527B3D67b2e61E3659',
       router: '0xcbBb8035cAc7D4B3Ca7aBb74cF7BdF900215Ce0D',
       supportedFees: SUPPORTED_FEES,
       tickSpacings: [1n, 10n, 50n, 100n, 200n, 500n, 2000n],

--- a/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
+++ b/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
@@ -2565,7 +2565,7 @@ describe('Slipstream', () => {
         );
         console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
 
-        checkPoolsLiquidity(poolLiquidity, TokenB.address, dexKey);
+        checkPoolsLiquidity(poolLiquidity, TokenA.address, dexKey);
       });
     });
   });

--- a/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
+++ b/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
@@ -1982,336 +1982,6 @@ describe('Retro', () => {
   });
 });
 
-describe('BaseswapV3', () => {
-  const dexKey = 'BaseswapV3';
-
-  describe('Base', () => {
-    const network = Network.BASE;
-    const dexHelper = new DummyDexHelper(network);
-
-    let blockNumber: number;
-    let baseswapV3: UniswapV3;
-
-    const TokenASymbol = 'USDC';
-    const TokenA = Tokens[network][TokenASymbol];
-
-    const TokenBSymbol = 'WETH';
-    const TokenB = Tokens[network][TokenBSymbol];
-
-    const QuoterV2 = UniswapV3Config[dexKey][network].quoter;
-
-    const amountsBuy = [
-      0n,
-      6000000n,
-      12000000n,
-      18000000n,
-      24000000n,
-      30000000n,
-      36000000n,
-      42000000n,
-      48000000n,
-      54000000n,
-      60000000n,
-      66000000n,
-      72000000n,
-      78000000n,
-      84000000n,
-      90000000n,
-      96000000n,
-      102000000n,
-      108000000n,
-      114000000n,
-      120000000n,
-      126000000n,
-      132000000n,
-      138000000n,
-      144000000n,
-      150000000n,
-      156000000n,
-      162000000n,
-      168000000n,
-      174000000n,
-      180000000n,
-      186000000n,
-      192000000n,
-      198000000n,
-      204000000n,
-      210000000n,
-      216000000n,
-      222000000n,
-      228000000n,
-      234000000n,
-      240000000n,
-      246000000n,
-      252000000n,
-      258000000n,
-      264000000n,
-      270000000n,
-      276000000n,
-      282000000n,
-      288000000n,
-      294000000n,
-      300000000n,
-    ];
-
-    beforeEach(async () => {
-      blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
-      baseswapV3 = new UniswapV3(network, dexKey, dexHelper);
-    });
-
-    it('getPoolIdentifiers and getPricesVolume SELL', async function () {
-      const pools = await baseswapV3.getPoolIdentifiers(
-        TokenA,
-        TokenB,
-        SwapSide.SELL,
-        blockNumber,
-      );
-      console.log(
-        `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
-        pools,
-      );
-
-      expect(pools.length).toBeGreaterThan(0);
-
-      const poolPrices = await baseswapV3.getPricesVolume(
-        TokenA,
-        TokenB,
-        amounts,
-        SwapSide.SELL,
-        blockNumber,
-        pools,
-      );
-      console.log(
-        `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
-        poolPrices,
-      );
-
-      expect(poolPrices).not.toBeNull();
-      checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
-
-      let falseChecksCounter = 0;
-      await Promise.all(
-        poolPrices!.map(async price => {
-          const fee = baseswapV3.eventPools[price.poolIdentifiers![0]]!.feeCode;
-          const res = await checkOnChainPricing(
-            dexHelper,
-            baseswapV3,
-            'quoteExactInputSingle',
-            blockNumber,
-            QuoterV2,
-            price.prices,
-            TokenA.address,
-            TokenB.address,
-            fee,
-            amounts,
-          );
-          if (res === false) falseChecksCounter++;
-        }),
-      );
-
-      expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
-    });
-
-    it('getPoolIdentifiers and getPricesVolume BUY', async function () {
-      const amountsBuy = [
-        0n,
-        1n * BI_POWS[18],
-        2n * BI_POWS[18],
-        3n * BI_POWS[18],
-      ];
-
-      const pools = await baseswapV3.getPoolIdentifiers(
-        TokenA,
-        TokenB,
-        SwapSide.BUY,
-        blockNumber,
-      );
-      console.log(
-        `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
-        pools,
-      );
-
-      expect(pools.length).toBeGreaterThan(0);
-
-      const poolPrices = await baseswapV3.getPricesVolume(
-        TokenA,
-        TokenB,
-        amountsBuy,
-        SwapSide.BUY,
-        blockNumber,
-        pools,
-      );
-      console.log(
-        `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
-        poolPrices,
-      );
-
-      expect(poolPrices).not.toBeNull();
-      checkPoolPrices(poolPrices!, amountsBuy, SwapSide.BUY, dexKey);
-
-      // Check if onchain pricing equals to calculated ones
-      let falseChecksCounter = 0;
-      await Promise.all(
-        poolPrices!.map(async price => {
-          const fee = baseswapV3.eventPools[price.poolIdentifiers![0]]!.feeCode;
-          const res = await checkOnChainPricing(
-            dexHelper,
-            baseswapV3,
-            'quoteExactOutputSingle',
-            blockNumber,
-            QuoterV2,
-            price.prices,
-            TokenA.address,
-            TokenB.address,
-            fee,
-            amountsBuy,
-          );
-          if (res === false) falseChecksCounter++;
-        }),
-      );
-      expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
-    });
-
-    it('getPoolIdentifiers and getPricesVolume SELL stable pairs', async function () {
-      const TokenASymbol = 'USDbC';
-      const TokenA = Tokens[network][TokenASymbol];
-
-      const TokenBSymbol = 'USDC';
-      const TokenB = Tokens[network][TokenBSymbol];
-
-      const pools = await baseswapV3.getPoolIdentifiers(
-        TokenA,
-        TokenB,
-        SwapSide.SELL,
-        blockNumber,
-      );
-      console.log(
-        `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
-        pools,
-      );
-
-      expect(pools.length).toBeGreaterThan(0);
-
-      const poolPrices = await baseswapV3.getPricesVolume(
-        TokenA,
-        TokenB,
-        amountsBuy,
-        SwapSide.SELL,
-        blockNumber,
-        pools,
-      );
-      console.log(
-        `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
-        poolPrices,
-      );
-
-      expect(poolPrices).not.toBeNull();
-      checkPoolPrices(
-        poolPrices!.filter(pp => pp.unit !== 0n),
-        amountsBuy,
-        SwapSide.SELL,
-        dexKey,
-      );
-
-      // Check if onchain pricing equals to calculated ones
-      let falseChecksCounter = 0;
-      await Promise.all(
-        poolPrices!.map(async price => {
-          const fee = baseswapV3.eventPools[price.poolIdentifiers![0]]!.feeCode;
-          const res = await checkOnChainPricing(
-            dexHelper,
-            baseswapV3,
-            'quoteExactInputSingle',
-            blockNumber,
-            QuoterV2,
-            price.prices,
-            TokenA.address,
-            TokenB.address,
-            fee,
-            amountsBuy,
-          );
-          if (res === false) falseChecksCounter++;
-        }),
-      );
-      expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
-    });
-
-    it('getPoolIdentifiers and getPricesVolume BUY stable pairs', async function () {
-      const TokenASymbol = 'DAI';
-      const TokenA = Tokens[network][TokenASymbol];
-
-      const TokenBSymbol = 'USDC';
-      const TokenB = Tokens[network][TokenBSymbol];
-
-      const pools = await baseswapV3.getPoolIdentifiers(
-        TokenA,
-        TokenB,
-        SwapSide.BUY,
-        blockNumber,
-      );
-      console.log(
-        `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
-        pools,
-      );
-
-      expect(pools.length).toBeGreaterThan(0);
-
-      const poolPrices = await baseswapV3.getPricesVolume(
-        TokenA,
-        TokenB,
-        amountsBuy,
-        SwapSide.BUY,
-        blockNumber,
-        pools,
-      );
-      console.log(
-        `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
-        poolPrices,
-      );
-
-      expect(poolPrices).not.toBeNull();
-      checkPoolPrices(
-        poolPrices!.filter(pp => pp.unit !== 0n),
-        amountsBuy,
-        SwapSide.BUY,
-        dexKey,
-      );
-
-      // Check if onchain pricing equals to calculated ones
-      let falseChecksCounter = 0;
-      await Promise.all(
-        poolPrices!.map(async price => {
-          const fee = baseswapV3.eventPools[price.poolIdentifiers![0]]!.feeCode;
-          const res = await checkOnChainPricing(
-            dexHelper,
-            baseswapV3,
-            'quoteExactOutputSingle',
-            blockNumber,
-            QuoterV2,
-            price.prices,
-            TokenA.address,
-            TokenB.address,
-            fee,
-            amountsBuy,
-          );
-          if (res === false) falseChecksCounter++;
-        }),
-      );
-      expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
-    });
-
-    it('getTopPoolsForToken', async function () {
-      const poolLiquidity = await baseswapV3.getTopPoolsForToken(
-        TokenB.address,
-        10,
-      );
-      console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
-
-      checkPoolsLiquidity(poolLiquidity, TokenB.address, dexKey);
-    });
-  });
-});
-
 describe('SpookySwapV3', () => {
   const dexKey = 'SpookySwapV3';
 
@@ -2748,6 +2418,154 @@ describe('Slipstream', () => {
         console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
 
         expect(poolLiquidity).toEqual([]); // no subgraph
+      });
+    });
+  });
+
+  describe('AerodromeSlipstreamNewFactory', () => {
+    const dexKey = 'AerodromeSlipstreamNewFactory';
+
+    describe('Base', () => {
+      let blockNumber: number;
+      let slipstream: VelodromeSlipstream;
+
+      const network = Network.BASE;
+      const dexHelper = new DummyDexHelper(network);
+      const TokenASymbol = 'wstETH';
+      const TokenA = Tokens[network][TokenASymbol];
+
+      const TokenBSymbol = 'rETH';
+      const TokenB = Tokens[network][TokenBSymbol];
+
+      const QuoterV2 = UniswapV3Config[dexKey][network].quoter;
+
+      beforeEach(async () => {
+        blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+        slipstream = new VelodromeSlipstream(network, dexKey, dexHelper);
+      });
+
+      it('getPoolIdentifiers and getPricesVolume SELL', async () => {
+        const amounts = [0n, BI_POWS[15], BI_POWS[15] * 2n];
+
+        const pools = await slipstream.getPoolIdentifiers(
+          TokenA,
+          TokenB,
+          SwapSide.SELL,
+          blockNumber,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+          pools,
+        );
+
+        expect(pools.length).toBeGreaterThan(0);
+
+        const poolPrices = await slipstream.getPricesVolume(
+          TokenA,
+          TokenB,
+          amounts,
+          SwapSide.SELL,
+          blockNumber,
+          pools,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+          poolPrices,
+        );
+
+        expect(poolPrices).not.toBeNull();
+        checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+        let falseChecksCounter = 0;
+        await Promise.all(
+          poolPrices!.map(async price => {
+            const tickSpacing =
+              slipstream.eventPools[price.poolIdentifiers![0]]!.tickSpacing!;
+            const res = await checkOnChainPricing(
+              dexHelper,
+              slipstream,
+              'quoteExactInputSingle',
+              blockNumber,
+              QuoterV2,
+              price.prices,
+              TokenA.address,
+              TokenB.address,
+              tickSpacing,
+              amounts,
+              velodromeQuoterIface,
+            );
+            if (res === false) falseChecksCounter++;
+          }),
+        );
+
+        expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
+      });
+
+      it('getPoolIdentifiers and getPricesVolume BUY', async () => {
+        const amounts = [0n, BI_POWS[15], BI_POWS[15] * 2n];
+
+        const pools = await slipstream.getPoolIdentifiers(
+          TokenA,
+          TokenB,
+          SwapSide.BUY,
+          blockNumber,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+          pools,
+        );
+
+        expect(pools.length).toBeGreaterThan(0);
+
+        const poolPrices = await slipstream.getPricesVolume(
+          TokenA,
+          TokenB,
+          amounts,
+          SwapSide.BUY,
+          blockNumber,
+          pools,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+          poolPrices,
+        );
+
+        expect(poolPrices).not.toBeNull();
+        checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+        let falseChecksCounter = 0;
+        await Promise.all(
+          poolPrices!.map(async price => {
+            const tickSpacing =
+              slipstream.eventPools[price.poolIdentifiers![0]]!.tickSpacing!;
+            const res = await checkOnChainPricing(
+              dexHelper,
+              slipstream,
+              'quoteExactOutputSingle',
+              blockNumber,
+              QuoterV2,
+              price.prices,
+              TokenA.address,
+              TokenB.address,
+              tickSpacing,
+              amounts,
+              velodromeQuoterIface,
+            );
+            if (res === false) falseChecksCounter++;
+          }),
+        );
+
+        expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
+      });
+
+      it('getTopPoolsForToken', async () => {
+        const poolLiquidity = await slipstream.getTopPoolsForToken(
+          TokenA.address,
+          10,
+        );
+        console.log(`${TokenASymbol} Top Pools:`, poolLiquidity);
+
+        checkPoolsLiquidity(poolLiquidity, TokenB.address, dexKey);
       });
     });
   });

--- a/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
+++ b/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
@@ -2531,7 +2531,7 @@ describe('Slipstream', () => {
         );
 
         expect(poolPrices).not.toBeNull();
-        checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+        checkPoolPrices(poolPrices!, amounts, SwapSide.BUY, dexKey);
 
         let falseChecksCounter = 0;
         await Promise.all(

--- a/src/dex/woo-fi-v2/config.ts
+++ b/src/dex/woo-fi-v2/config.ts
@@ -2,11 +2,13 @@ import { DexParams } from './types';
 import { DexConfigMap, AdapterMappings } from '../../types';
 import { Network, SwapSide } from '../../constants';
 
+const WOO_ORACLE_V2_ADDRESS = '0xf9b0c8Ee13AE2fC0665764ecbdB417685dEa8081';
+
 export const WooFiV2Config: DexConfigMap<DexParams> = {
   WooFiV2: {
     [Network.OPTIMISM]: {
       wooPPV2Address: '0x5520385bFcf07Ec87C4c53A7d8d65595Dff69FA4',
-      wooOracleV2Address: '0xA43305Ce0164D87d7B2368f91a1dcC4eBdA75127',
+      wooOracleV2Address: WOO_ORACLE_V2_ADDRESS,
       integrationHelperAddress: '0x96329d66074EB8386Ae8bFD6698B2E3FDA87e15E',
       // USDC
       quoteToken: {
@@ -16,7 +18,7 @@ export const WooFiV2Config: DexConfigMap<DexParams> = {
     },
     [Network.BSC]: {
       wooPPV2Address: '0x5520385bFcf07Ec87C4c53A7d8d65595Dff69FA4',
-      wooOracleV2Address: '0x2A375567f5E13F6bd74fDa7627Df3b1Af6BfA5a6',
+      wooOracleV2Address: WOO_ORACLE_V2_ADDRESS,
       integrationHelperAddress: '0xAA9c15cd603428cA8ddD45e933F8EfE3Afbcc173',
       // USDT
       quoteToken: {
@@ -26,7 +28,7 @@ export const WooFiV2Config: DexConfigMap<DexParams> = {
     },
     [Network.POLYGON]: {
       wooPPV2Address: '0x5520385bFcf07Ec87C4c53A7d8d65595Dff69FA4',
-      wooOracleV2Address: '0x2A8Ede62D0717C8C92b88639ecf603FDF31A8428',
+      wooOracleV2Address: WOO_ORACLE_V2_ADDRESS,
       integrationHelperAddress: '0x7Ba560eB735AbDCf9a3a5692272652A0cc81850d',
       // USDC
       quoteToken: {
@@ -36,7 +38,7 @@ export const WooFiV2Config: DexConfigMap<DexParams> = {
     },
     [Network.SONIC]: {
       wooPPV2Address: '0x5520385bFcf07Ec87C4c53A7d8d65595Dff69FA4',
-      wooOracleV2Address: '0x2A375567f5E13F6bd74fDa7627Df3b1Af6BfA5a6',
+      wooOracleV2Address: WOO_ORACLE_V2_ADDRESS,
       integrationHelperAddress: '0xc8521e41DE46036A61c562062862681f0060CD7E',
       // USDC
       quoteToken: {
@@ -46,7 +48,7 @@ export const WooFiV2Config: DexConfigMap<DexParams> = {
     },
     [Network.ARBITRUM]: {
       wooPPV2Address: '0x5520385bFcf07Ec87C4c53A7d8d65595Dff69FA4',
-      wooOracleV2Address: '0xCf4EA1688bc23DD93D933edA535F8B72FC8934Ec',
+      wooOracleV2Address: WOO_ORACLE_V2_ADDRESS,
       integrationHelperAddress: '0x28D2B949024FE50627f1EbC5f0Ca3Ca721148E40',
       // USDC
       quoteToken: {
@@ -56,7 +58,7 @@ export const WooFiV2Config: DexConfigMap<DexParams> = {
     },
     [Network.AVALANCHE]: {
       wooPPV2Address: '0x5520385bFcf07Ec87C4c53A7d8d65595Dff69FA4',
-      wooOracleV2Address: '0x2A375567f5E13F6bd74fDa7627Df3b1Af6BfA5a6',
+      wooOracleV2Address: WOO_ORACLE_V2_ADDRESS,
       integrationHelperAddress: '0x020630613E296c3E9b06186f630D1bF97A2B6Ad1',
       // USDC
       quoteToken: {
@@ -66,7 +68,7 @@ export const WooFiV2Config: DexConfigMap<DexParams> = {
     },
     [Network.BASE]: {
       wooPPV2Address: '0x5520385bFcf07Ec87C4c53A7d8d65595Dff69FA4',
-      wooOracleV2Address: '0x2A375567f5E13F6bd74fDa7627Df3b1Af6BfA5a6',
+      wooOracleV2Address: WOO_ORACLE_V2_ADDRESS,
       integrationHelperAddress: '0xC4E9B633685461E7B7A807D12a246C81f96F31B8',
       // USDbC
       quoteToken: {

--- a/src/dex/woo-fi-v2/woo-fi-v2-integration.test.ts
+++ b/src/dex/woo-fi-v2/woo-fi-v2-integration.test.ts
@@ -128,7 +128,7 @@ async function testPricingForPair(
   if (wooFiV2.hasConstantPriceLargeAmounts) {
     checkConstantPoolPrices(poolPrices!, amounts, dexKey);
   } else {
-    checkPoolPrices(poolPrices!, amounts, side, dexKey);
+    checkPoolPrices(poolPrices!, amounts, side, dexKey, false);
   }
 
   // Check if onchain pricing equals to calculated ones
@@ -390,7 +390,7 @@ describe('WooFiV2', function () {
     });
 
     const baseATokenSymbol = 'WMATIC';
-    const quoteTokenSymbol = 'USDC';
+    const quoteTokenSymbol = 'USDCn';
     const baseBTokenSymbol = 'WETH';
     const untradableSymbol = 'POPS';
 
@@ -431,6 +431,7 @@ describe('WooFiV2', function () {
       baseBTokenSymbol,
       untradableSymbol,
       pricingCheckFuncName,
+      3,
     );
   });
 
@@ -460,6 +461,7 @@ describe('WooFiV2', function () {
       baseBTokenSymbol,
       untradableSymbol,
       pricingCheckFuncName,
+      4,
     );
   });
 
@@ -480,6 +482,36 @@ describe('WooFiV2', function () {
     const quoteTokenSymbol = 'USDC';
     const baseBTokenSymbol = 'BTCb';
     const untradableSymbol = 'POPS';
+
+    runTestsForChain(
+      dexHelper,
+      initProps,
+      baseATokenSymbol,
+      quoteTokenSymbol,
+      baseBTokenSymbol,
+      untradableSymbol,
+      pricingCheckFuncName,
+      3,
+    );
+  });
+
+  describe('Base', () => {
+    const network = Network.BASE;
+    const dexHelper = new DummyDexHelper(network);
+    const initProps: { dex: WooFiV2; blockNumber: number } = {
+      dex: new WooFiV2(network, dexKey, dexHelper),
+      blockNumber: 0,
+    };
+
+    beforeAll(async () => {
+      initProps.blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      await initProps.dex.initializePricing(initProps.blockNumber);
+    });
+
+    const baseATokenSymbol = 'WETH';
+    const quoteTokenSymbol = 'USDC';
+    const baseBTokenSymbol = 'cbBTC';
+    const untradableSymbol = 'DOG';
 
     runTestsForChain(
       dexHelper,


### PR DESCRIPTION
## Summary
- update AerodromeSlipstreamNewFactory Base quoter and add config-driven integration coverage
- remove stale BaseswapV3 integration suite that referenced missing config
- update WooFiV2 oracle address across configured chains and refresh integration coverage for Polygon, Arbitrum, Avalanche, and Base

## Tests
- ./node_modules/.bin/jest src/dex/uniswap-v3/uniswap-v3-integration.test.ts -t "AerodromeSlipstreamNewFactory" --runInBand --forceExit
- ./node_modules/.bin/jest src/dex/woo-fi-v2/woo-fi-v2-integration.test.ts -t "WooFiV2.*(Polygon|Arbitrum|Avalanche|Base)" --runInBand --forceExit
- pnpm checks via commit hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Quoter and oracle contract address changes directly affect off-chain pricing accuracy; misconfiguration would break or skew swap quotes across Base and all WooFi V2 chains.
> 
> **Overview**
> Bumps **`@paraswap/dex-lib`** to **5.0.5** and refreshes DEX config plus integration tests.
> 
> **Aerodrome (Base):** Updates **`AerodromeSlipstreamNewFactory`** Base **quoter** to `0xfa2CB6D6cea79D6Efa102e527B3D67b2e61E3659`. Adds Base integration coverage (SELL/BUY/on-chain quoter via tick spacing, top pools). Removes the stale **`BaseswapV3`** test block that pointed at missing config.
> 
> **WooFi V2:** Replaces per-chain **`wooOracleV2Address`** values with one shared oracle (`0xf9b0c8Ee13AE2fC0665764ecbdB417685dEa8081`) on all configured networks. Tests: relaxed **`checkPoolPrices`** strictness, Polygon quote token **`USDCn`**, adjusted trade amount scaling on Sonic/Arbitrum/Avalanche, and a new **Base** integration suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c746691411e2320aa8f56ec1d2749a5afb5a2c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->