### PR TITLE
feat(config): add AerodromeSlipstreamFactory3 fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/uniswap-v3/config.ts
+++ b/src/dex/uniswap-v3/config.ts
@@ -462,6 +462,34 @@ export const UniswapV3Config: DexConfigMap<DexParams> = {
       liquidityField: 'liquidity',
     },
   },
+  AerodromeSlipstreamFactory3: {
+    [Network.BASE]: {
+      factory: '0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef',
+      quoter: '0x86D33DCbEC9c75897c6Ce521f33CF84009c4272e',
+      router: '0x33a47A122De0B5c429Ba79E6d17965B0e841c60e',
+      supportedFees: SUPPORTED_FEES,
+      tickSpacings: [1n, 10n, 50n, 100n, 200n, 500n, 2000n],
+      tickSpacingsToFees: {
+        '1': 100n,
+        '10': 500n,
+        '50': 500n,
+        '100': 500n,
+        '200': 3000n,
+        '500': 20000n,
+        '2000': 10000n,
+      },
+      stateMulticall: '0x736518161516c1cfBD5bf5e7049FCBDC9b933987',
+      stateMultiCallAbi: VelodromeSlipstreamMulticallABi as AbiItem[],
+      eventPoolImplementation: VelodromeSlipstreamEventPool,
+      factoryImplementation: VelodromeSlipstreamFactory,
+      decodeStateMultiCallResultWithRelativeBitmaps:
+        decodeStateMultiCallResultWithRelativeBitmapsForVelodromeSlipstream,
+      uniswapMulticall: '0x091e99cb1C49331a94dD62755D168E941AbD0693',
+      chunksCount: 10,
+      initRetryFrequency: 10,
+      initHash: '0xc770898522D2A9c8Da7A10D63989b6b58305B665', // pool implementation address from factory contract is used instead of initHash here
+    },
+  },
   PangolinV3: {
     [Network.AVALANCHE]: {
       factory: '0x1128F23D0bc0A8396E9FBC3c0c68f5EA228B8256',

--- a/src/dex/uniswap-v3/forks/velodrome-slipstream/velodrome-slipstream.ts
+++ b/src/dex/uniswap-v3/forks/velodrome-slipstream/velodrome-slipstream.ts
@@ -67,6 +67,7 @@ export class VelodromeSlipstream extends UniswapV3 {
         'VelodromeSlipstreamNewFactory',
         'AerodromeSlipstream',
         'AerodromeSlipstreamNewFactory',
+        'AerodromeSlipstreamFactory3',
       ]),
     );
 

--- a/src/dex/uniswap-v3/uniswap-v3-e2e.test.ts
+++ b/src/dex/uniswap-v3/uniswap-v3-e2e.test.ts
@@ -1033,6 +1033,30 @@ describe('UniswapV3 E2E', () => {
         );
       });
     });
+
+    describe('AerodromeSlipstreamFactory3', () => {
+      const dexKey = 'AerodromeSlipstreamFactory3';
+      describe('Base', () => {
+        const network = Network.BASE;
+
+        const tokenASymbol: string = 'USDC';
+        const tokenBSymbol: string = 'WETH';
+
+        const tokenAAmount: string = '11000000';
+        const tokenBAmount: string = '1100000000000000';
+        const nativeTokenAmount = '1100000000000000';
+
+        testForNetwork(
+          network,
+          dexKey,
+          tokenASymbol,
+          tokenBSymbol,
+          tokenAAmount,
+          tokenBAmount,
+          nativeTokenAmount,
+        );
+      });
+    });
   });
 
   describe('PharaohV3', () => {

--- a/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
+++ b/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
@@ -2570,6 +2570,144 @@ describe('Slipstream', () => {
     });
   });
 
+  describe('AerodromeSlipstreamFactory3', () => {
+    const dexKey = 'AerodromeSlipstreamFactory3';
+
+    describe('Base', () => {
+      let blockNumber: number;
+      let slipstream: VelodromeSlipstream;
+
+      const network = Network.BASE;
+      const dexHelper = new DummyDexHelper(network);
+      const TokenASymbol = 'USDC';
+      const TokenA = Tokens[network][TokenASymbol];
+
+      const TokenBSymbol = 'WETH';
+      const TokenB = Tokens[network][TokenBSymbol];
+
+      const QuoterV2 = UniswapV3Config[dexKey][network].quoter;
+
+      beforeEach(async () => {
+        blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+        slipstream = new VelodromeSlipstream(network, dexKey, dexHelper);
+      });
+
+      it('getPoolIdentifiers and getPricesVolume SELL', async () => {
+        const amounts = [0n, BI_POWS[6], BI_POWS[6] * 2n];
+
+        const pools = await slipstream.getPoolIdentifiers(
+          TokenA,
+          TokenB,
+          SwapSide.SELL,
+          blockNumber,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+          pools,
+        );
+
+        expect(pools.length).toBeGreaterThan(0);
+
+        const poolPrices = await slipstream.getPricesVolume(
+          TokenA,
+          TokenB,
+          amounts,
+          SwapSide.SELL,
+          blockNumber,
+          pools,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+          poolPrices,
+        );
+
+        expect(poolPrices).not.toBeNull();
+        checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+        let falseChecksCounter = 0;
+        await Promise.all(
+          poolPrices!.map(async price => {
+            const tickSpacing =
+              slipstream.eventPools[price.poolIdentifiers![0]]!.tickSpacing!;
+            const res = await checkOnChainPricing(
+              dexHelper,
+              slipstream,
+              'quoteExactInputSingle',
+              blockNumber,
+              QuoterV2,
+              price.prices,
+              TokenA.address,
+              TokenB.address,
+              tickSpacing,
+              amounts,
+              velodromeQuoterIface,
+            );
+            if (res === false) falseChecksCounter++;
+          }),
+        );
+
+        expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
+      });
+
+      it('getPoolIdentifiers and getPricesVolume BUY', async () => {
+        const amounts = [0n, BI_POWS[15], BI_POWS[15] * 2n];
+
+        const pools = await slipstream.getPoolIdentifiers(
+          TokenA,
+          TokenB,
+          SwapSide.BUY,
+          blockNumber,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+          pools,
+        );
+
+        expect(pools.length).toBeGreaterThan(0);
+
+        const poolPrices = await slipstream.getPricesVolume(
+          TokenA,
+          TokenB,
+          amounts,
+          SwapSide.BUY,
+          blockNumber,
+          pools,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+          poolPrices,
+        );
+
+        expect(poolPrices).not.toBeNull();
+        checkPoolPrices(poolPrices!, amounts, SwapSide.BUY, dexKey);
+
+        let falseChecksCounter = 0;
+        await Promise.all(
+          poolPrices!.map(async price => {
+            const tickSpacing =
+              slipstream.eventPools[price.poolIdentifiers![0]]!.tickSpacing!;
+            const res = await checkOnChainPricing(
+              dexHelper,
+              slipstream,
+              'quoteExactOutputSingle',
+              blockNumber,
+              QuoterV2,
+              price.prices,
+              TokenA.address,
+              TokenB.address,
+              tickSpacing,
+              amounts,
+              velodromeQuoterIface,
+            );
+            if (res === false) falseChecksCounter++;
+          }),
+        );
+
+        expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
+      });
+    });
+  });
+
   describe('VelodromeSlipstream', () => {
     const dexKey = 'VelodromeSlipstream';
 


### PR DESCRIPTION
## Description

Adds `AerodromeSlipstreamFactory3` as a separate UniswapV3/VelodromeSlipstream fork for the new Aerodrome Slipstream factory deployment on Base (config-only change, same pattern as `AerodromeSlipstreamNewFactory` in #1117).

## Contract addresses (Base)

- Factory: `0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef`
- Quoter: `0x86D33DCbEC9c75897c6Ce521f33CF84009c4272e`
- Router: `0x33a47A122De0B5c429Ba79E6d17965B0e841c60e`
- Pool implementation (used instead of initHash): `0xc770898522D2A9c8Da7A10D63989b6b58305B665`

## Config notes

- Tick spacings: `[1, 10, 50, 100, 200, 500, 2000]`, with tick spacing `500 → 20000` fee (differs from `AerodromeSlipstreamNewFactory`, which maps `500 → 10000`)
- No subgraph exists for this factory yet, so `subgraphURL` is omitted and `getTopPoolsForToken` returns an empty list for this fork until one is available

## Tests

- Integration tests (USDC/WETH on Base): SELL and BUY pass, prices match the on-chain quoter exactly
- E2E test block added (USDC/WETH on Base)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only fork following existing Aerodrome Slipstream patterns; no subgraph limits pool ranking but does not change swap pricing paths covered by tests.
> 
> **Overview**
> Adds **`AerodromeSlipstreamFactory3`** as a new Velodrome Slipstream–style dex key on **Base**, wiring factory/quoter/router addresses and tick-spacing→fee mappings (notably tick spacing **500 → 20000** fee, unlike `AerodromeSlipstreamNewFactory`’s 500 → 10000). Reuses existing Slipstream pool/factory/multicall implementations; **`subgraphURL` is omitted**, so top-pool discovery stays empty until a subgraph exists.
> 
> Registers the key in **`VelodromeSlipstream.dexKeysWithNetwork`** and adds **integration** (USDC/WETH, SELL/BUY vs on-chain quoter) and **e2e** coverage on Base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1ee9e87c80b0c195344ea5679f82721929f226a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->