### PR TITLE
feat: add Buffet PropAMM UniswapV4 hook

### DIFF
--- a/src/dex/uniswap-v4/config.ts
+++ b/src/dex/uniswap-v4/config.ts
@@ -2,6 +2,7 @@ import { DexConfigMap } from '../../types';
 import { Network } from '../../constants';
 import { DexParams, SubgraphPool } from './types';
 import { ArenaHook } from './hooks/arena/arena-hook';
+import { BuffetHook } from './hooks/buffet/buffet-hook';
 
 export const UniswapV4Config: DexConfigMap<DexParams> = {
   UniswapV4: {
@@ -22,6 +23,7 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
       stateView: '0xa3c0c9b65bad0b08107aa264b0f3db444b867a71',
       skipPoolsWithUnconventionalFees: true,
       stateMulticall: '0x223c5fc295557f634979827728558424cf879d44',
+      supportedHooks: [BuffetHook],
     },
     [Network.OPTIMISM]: {
       poolManager: '0x9a13f98cb987694c9f086b1f5eb990eea8264ec3',
@@ -77,6 +79,18 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
 
 export const UniswapV4PoolsList: Record<number, SubgraphPool[]> = {
   [Network.BASE]: [
+    {
+      fee: '100',
+      hooks: '0x880bfa436d722bfde337eafc7c22123c17b90088',
+      id: '0xaf36a3b872ece56b04af777bf6867cf79b91cb0212f12c92f27fd1bb27dd25a2',
+      tickSpacing: '1',
+      token0: {
+        address: '0x0000000000000000000000000000000000000000', // symbol: 'ETH',
+      },
+      token1: {
+        address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913', // symbol: 'USDC',
+      },
+    },
     {
       fee: '7',
       hooks: '0x0000000000000000000000000000000000000000',

--- a/src/dex/uniswap-v4/encoder.test.ts
+++ b/src/dex/uniswap-v4/encoder.test.ts
@@ -1,0 +1,114 @@
+import { Interface, defaultAbiCoder } from '@ethersproject/abi';
+import RouterAbi from '../../abi/uniswap-v4/router.abi.json';
+import { NULL_ADDRESS, Network } from '../../constants';
+import { BuffetHookConfig, BASE_USDC } from './hooks/buffet/config';
+import { swapExactInputCalldata, swapExactOutputCalldata } from './encoder';
+import { UniswapV4Data } from './types';
+
+const routerIface = new Interface(RouterAbi);
+
+const WETH = '0x4200000000000000000000000000000000000006';
+const DAI = '0x50c5725949a6f0c72e6c4a641f24049a917db0cb';
+const RECIPIENT = '0x0000000000000000000000000000000000000001';
+
+const decodeV4SwapActionInput = (calldata: string) => {
+  const [, inputs] = routerIface.decodeFunctionData(
+    'execute(bytes,bytes[])',
+    calldata,
+  );
+  const [, actionInputs] = defaultAbiCoder.decode(
+    ['bytes', 'bytes[]'],
+    inputs[0],
+  );
+
+  return actionInputs[0];
+};
+
+const dataWithHookPath: UniswapV4Data = {
+  path: [
+    {
+      tokenIn: BASE_USDC,
+      tokenOut: WETH,
+      zeroForOne: true,
+      pool: {
+        id: BuffetHookConfig[Network.BASE].poolId,
+        key: {
+          currency0: BASE_USDC,
+          currency1: WETH,
+          fee: '100',
+          tickSpacing: 1,
+          hooks: BuffetHookConfig[Network.BASE].hookAddress,
+        },
+      },
+    },
+    {
+      tokenIn: WETH,
+      tokenOut: DAI,
+      zeroForOne: true,
+      pool: {
+        id: '0x0000000000000000000000000000000000000000000000000000000000000002',
+        key: {
+          currency0: WETH,
+          currency1: DAI,
+          fee: '500',
+          tickSpacing: 10,
+          hooks: NULL_ADDRESS,
+        },
+      },
+    },
+  ],
+};
+
+describe('UniswapV4 encoder', () => {
+  it('preserves hook addresses in exact-input multi-hop path keys', () => {
+    const actionInput = decodeV4SwapActionInput(
+      swapExactInputCalldata(
+        BASE_USDC,
+        DAI,
+        dataWithHookPath,
+        100n,
+        90n,
+        RECIPIENT,
+        WETH,
+      ),
+    );
+
+    const [params] = defaultAbiCoder.decode(
+      [
+        'tuple(address currencyIn, (address,uint24,int24,address,bytes)[] path, uint128 amountIn, uint128 amountOutMinimum)',
+      ],
+      actionInput,
+    );
+
+    expect(params.path[0][3].toLowerCase()).toBe(
+      BuffetHookConfig[Network.BASE].hookAddress,
+    );
+    expect(params.path[1][3].toLowerCase()).toBe(NULL_ADDRESS);
+  });
+
+  it('preserves hook addresses in exact-output multi-hop path keys', () => {
+    const actionInput = decodeV4SwapActionInput(
+      swapExactOutputCalldata(
+        BASE_USDC,
+        DAI,
+        dataWithHookPath,
+        100n,
+        90n,
+        RECIPIENT,
+        WETH,
+      ),
+    );
+
+    const [params] = defaultAbiCoder.decode(
+      [
+        'tuple(address currencyOut, (address,uint24,int24,address,bytes)[] path, uint128 amountOut, uint128 amountInMaximum)',
+      ],
+      actionInput,
+    );
+
+    expect(params.path[0][3].toLowerCase()).toBe(
+      BuffetHookConfig[Network.BASE].hookAddress,
+    );
+    expect(params.path[1][3].toLowerCase()).toBe(NULL_ADDRESS);
+  });
+});

--- a/src/dex/uniswap-v4/encoder.ts
+++ b/src/dex/uniswap-v4/encoder.ts
@@ -403,7 +403,7 @@ export function swapExactInputCalldata(
         : path.tokenOut,
       fee: BigInt(path.pool.key.fee),
       tickSpacing: BigInt(path.pool.key.tickSpacing),
-      hooks: NULL_ADDRESS,
+      hooks: path.pool.key.hooks,
       hookData: '0x',
     })),
   };
@@ -566,7 +566,7 @@ export function swapExactOutputCalldata(
         : path.tokenIn,
       fee: BigInt(path.pool.key.fee),
       tickSpacing: BigInt(path.pool.key.tickSpacing),
-      hooks: NULL_ADDRESS,
+      hooks: path.pool.key.hooks,
       hookData: '0x',
     })),
   };

--- a/src/dex/uniswap-v4/hooks/arena/arena-hook.ts
+++ b/src/dex/uniswap-v4/hooks/arena/arena-hook.ts
@@ -40,8 +40,9 @@ export class ArenaHook implements IBaseHook {
     );
   }
 
-  registerPool(poolId: string, _poolKey: PoolKey) {
+  registerPool(poolId: string, _poolKey: PoolKey): boolean {
     this.arenaFeeHelper.addPoolId(poolId.toLowerCase());
+    return true;
   }
 
   async initialize(blockNumber: number) {

--- a/src/dex/uniswap-v4/hooks/buffet/buffet-hook.test.ts
+++ b/src/dex/uniswap-v4/hooks/buffet/buffet-hook.test.ts
@@ -1,0 +1,99 @@
+import { BuffetHook, getBuffetHookAmount, getBuffetQuote } from './buffet-hook';
+import { BASE_USDC, BuffetHookConfig } from './config';
+import { Network, NULL_ADDRESS } from '../../../../constants';
+import { BuffetEngineState } from './types';
+
+const WAD = 10n ** 18n;
+
+const baseState: BuffetEngineState = {
+  priceE6: 1632150671n,
+  depth: 50000000000000n,
+  expiryTs: 200n,
+  ethBal: 10n * WAD,
+  usdcBal: 16321506710n,
+  blockTs: 100n,
+};
+
+describe('BuffetHook math', () => {
+  it('only registers the configured Buffet PropAMM pool', () => {
+    const config = BuffetHookConfig[Network.BASE];
+    const dexHelper = {
+      config: {
+        data: {
+          wrappedNativeTokenAddress:
+            '0x4200000000000000000000000000000000000006',
+        },
+      },
+    } as any;
+    const logger = { debug: jest.fn() } as any;
+    const hook = new BuffetHook(dexHelper, Network.BASE, logger);
+    const poolKey = {
+      currency0: config.token0,
+      currency1: config.token1,
+      fee: config.fee,
+      tickSpacing: Number(config.tickSpacing),
+      hooks: config.hookAddress,
+    };
+
+    expect(hook.registerPool(config.poolId, poolKey)).toBe(true);
+    expect(
+      hook.registerPool(config.poolId, {
+        ...poolKey,
+        fee: '500',
+      }),
+    ).toBe(false);
+  });
+
+  it('quotes ETH -> USDC exact input with spread-on path', () => {
+    const price = getBuffetQuote(NULL_ADDRESS, WAD, true, baseState);
+    expect(price).toEqual(1632036428n);
+    expect(getBuffetHookAmount(true, true, WAD, price!)).toEqual(1632036428n);
+  });
+
+  it('quotes USDC -> ETH exact input with spread-on path', () => {
+    const price = getBuffetQuote(BASE_USDC, 1000n * 10n ** 6n, true, baseState);
+    expect(price).toEqual(1632252279n);
+    expect(getBuffetHookAmount(false, true, 1000n * 10n ** 6n, price!)).toEqual(
+      612650392874715661n,
+    );
+  });
+
+  it('quotes ETH -> USDC exact output with ceil input rounding', () => {
+    const price = getBuffetQuote(
+      NULL_ADDRESS,
+      1000n * 10n ** 6n,
+      false,
+      baseState,
+    );
+    expect(price).toEqual(1632049069n);
+    expect(getBuffetHookAmount(true, false, 1000n * 10n ** 6n, price!)).toEqual(
+      612726675315422150n,
+    );
+  });
+
+  it('quotes USDC -> ETH exact output with ceil input rounding', () => {
+    const price = getBuffetQuote(BASE_USDC, WAD, false, baseState);
+    expect(price).toEqual(1632264922n);
+    expect(getBuffetHookAmount(false, false, WAD, price!)).toEqual(1632264922n);
+  });
+
+  it('applies inventory impact when the hook is long ETH', () => {
+    const price = getBuffetQuote(NULL_ADDRESS, WAD, true, {
+      ...baseState,
+      ethBal: 20n * WAD,
+      usdcBal: 5000n * 10n ** 6n,
+    });
+
+    expect(price).toEqual(1631796767n);
+    expect(getBuffetHookAmount(true, true, WAD, price!)).toEqual(1631796767n);
+  });
+
+  it('rejects expired engine state', () => {
+    expect(
+      getBuffetQuote(NULL_ADDRESS, WAD, true, {
+        ...baseState,
+        blockTs: baseState.expiryTs,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/dex/uniswap-v4/hooks/buffet/buffet-hook.ts
+++ b/src/dex/uniswap-v4/hooks/buffet/buffet-hook.ts
@@ -1,0 +1,359 @@
+import { BytesLike, Interface } from 'ethers/lib/utils';
+import { SwapSide } from '@paraswap/core';
+import { IDexHelper } from '../../../../dex-helper';
+import { ETHER_ADDRESS, Network, NULL_ADDRESS } from '../../../../constants';
+import { Logger, PoolLiquidity } from '../../../../types';
+import UniswapV4PoolManagerABI from '../../../../abi/uniswap-v4/pool-manager.abi.json';
+import { MultiResult } from '../../../../lib/multi-wrapper';
+import { uint256ToBigInt } from '../../../../lib/decoders';
+import { Pool, PoolKey } from '../../types';
+import { HooksPermissions, IBaseHook } from '../types';
+import { BASE_USDC, BuffetHookConfig } from './config';
+import { BuffetEngineState } from './types';
+
+const WAD = 10n ** 18n;
+const DECAY_NUM = 100000000000000n;
+const DECAY_DEN = 5000000000000000000n;
+const SLIP_CAP = 200000000000000n;
+const MIN_EXACT_IN_PRICE = 10n * 10n ** 6n;
+const MAX_EXACT_IN_PRICE = 50000n * 10n ** 6n;
+const UINT64_MASK = (1n << 64n) - 1n;
+const UINT128_MASK = (1n << 128n) - 1n;
+
+function mulDiv(x: bigint, y: bigint, d: bigint, roundUp = false): bigint {
+  if (d === 0n) {
+    throw new Error('division by zero');
+  }
+
+  const product = x * y;
+  const result = product / d;
+  return roundUp && product % d !== 0n ? result + 1n : result;
+}
+
+function decodeSlot5(
+  slot5: string,
+): Pick<BuffetEngineState, 'priceE6' | 'depth' | 'expiryTs'> {
+  const packed = BigInt(slot5);
+
+  return {
+    priceE6: packed & UINT128_MASK,
+    depth: (packed >> 128n) & UINT64_MASK,
+    expiryTs: packed >> 192n,
+  };
+}
+
+export function getBuffetQuote(
+  token: string,
+  amount: bigint,
+  exactIn: boolean,
+  state: BuffetEngineState,
+): bigint | null {
+  const isEth = token.toLowerCase() !== BASE_USDC;
+  const { priceE6, depth, expiryTs, ethBal, usdcBal, blockTs } = state;
+
+  if (priceE6 === 0n || blockTs >= expiryTs) {
+    return null;
+  }
+
+  let q: bigint;
+  if (exactIn) {
+    q = isEth ? amount : mulDiv(amount, WAD, priceE6, true);
+  } else {
+    q = isEth ? mulDiv(amount, WAD, priceE6, true) : amount;
+  }
+
+  const spread = depth + mulDiv(q, DECAY_NUM, DECAY_DEN, true);
+  const usdcInEth = mulDiv(usdcBal, WAD, priceE6);
+  const total = ethBal + usdcInEth;
+  const mid = total / 2n;
+
+  if (mid === 0n) {
+    return null;
+  }
+
+  let impactPrice: bigint;
+  if (ethBal > usdcInEth) {
+    const imbalance = ethBal - mid;
+    const slip = (imbalance * SLIP_CAP) / mid;
+    impactPrice = mulDiv(
+      priceE6,
+      WAD,
+      WAD + (slip > SLIP_CAP ? SLIP_CAP : slip),
+    );
+  } else {
+    const imbalance = usdcInEth - mid;
+    const slip = (imbalance * SLIP_CAP) / mid;
+    impactPrice = mulDiv(
+      priceE6,
+      WAD + (slip > SLIP_CAP ? SLIP_CAP : slip),
+      WAD,
+    );
+  }
+
+  return isEth
+    ? mulDiv(impactPrice, WAD, WAD + spread)
+    : mulDiv(impactPrice, WAD + spread, WAD, true);
+}
+
+export function getBuffetHookAmount(
+  zeroForOne: boolean,
+  exactIn: boolean,
+  amount: bigint,
+  price: bigint,
+): bigint | null {
+  if (price === 0n) {
+    return null;
+  }
+
+  if (zeroForOne) {
+    return exactIn
+      ? mulDiv(amount, price, WAD)
+      : mulDiv(amount, WAD, price, true);
+  }
+
+  return exactIn
+    ? mulDiv(amount, WAD, price)
+    : mulDiv(amount, price, WAD, true);
+}
+
+export class BuffetHook implements IBaseHook {
+  readonly name = this.constructor.name;
+  readonly address: string;
+
+  private readonly poolManagerIface = new Interface(UniswapV4PoolManagerABI);
+  private readonly poolIds = new Set<string>();
+  private readonly wethAddress: string;
+
+  constructor(
+    readonly dexHelper: IDexHelper,
+    readonly network: Network,
+    readonly logger: Logger,
+  ) {
+    this.address = BuffetHookConfig[network].hookAddress.toLowerCase();
+    this.wethAddress =
+      this.dexHelper.config.data.wrappedNativeTokenAddress.toLowerCase();
+  }
+
+  registerPool(poolId: string, poolKey: PoolKey): boolean {
+    const config = BuffetHookConfig[this.network];
+
+    if (
+      poolId.toLowerCase() === config.poolId &&
+      poolKey.currency0.toLowerCase() === config.token0 &&
+      poolKey.currency1.toLowerCase() === config.token1 &&
+      poolKey.fee === config.fee &&
+      poolKey.tickSpacing.toString() === config.tickSpacing
+    ) {
+      this.poolIds.add(poolId.toLowerCase());
+      return true;
+    }
+
+    return false;
+  }
+
+  initialize(_blockNumber: number): Promise<void> {
+    return Promise.resolve();
+  }
+
+  getHookPermissions(): HooksPermissions {
+    return {
+      beforeInitialize: false,
+      afterInitialize: false,
+      beforeAddLiquidity: false,
+      afterAddLiquidity: false,
+      beforeRemoveLiquidity: false,
+      afterRemoveLiquidity: false,
+      beforeSwap: true,
+      afterSwap: false,
+      beforeDonate: false,
+      afterDonate: false,
+      beforeSwapReturnDelta: true,
+      afterSwapReturnDelta: false,
+      afterAddLiquidityReturnDelta: false,
+      afterRemoveLiquidityReturnDelta: false,
+    };
+  }
+
+  async getPricesVolume({
+    pool,
+    amounts,
+    zeroForOne,
+    side,
+    blockNumber,
+  }: {
+    pool: Pool;
+    amounts: bigint[];
+    zeroForOne: boolean;
+    side: SwapSide;
+    blockNumber: number;
+    routerAddress: string;
+  }): Promise<bigint[] | null> {
+    if (!this.poolIds.has(pool.id.toLowerCase())) {
+      return null;
+    }
+
+    try {
+      const state = await this.getEngineState(blockNumber);
+      if (!state) {
+        return null;
+      }
+
+      const isSell = side === SwapSide.SELL;
+      const outputBalance = zeroForOne ? state.usdcBal : state.ethBal;
+      const token = zeroForOne ? NULL_ADDRESS : BASE_USDC;
+
+      return amounts.map(amount => {
+        if (amount === 0n) {
+          return 0n;
+        }
+
+        if (!isSell && amount > outputBalance) {
+          return 0n;
+        }
+
+        const price = getBuffetQuote(token, amount, isSell, state);
+        if (price === null) {
+          return 0n;
+        }
+
+        if (
+          isSell &&
+          (price <= MIN_EXACT_IN_PRICE || price >= MAX_EXACT_IN_PRICE)
+        ) {
+          return 0n;
+        }
+
+        const quoteAmount = getBuffetHookAmount(
+          zeroForOne,
+          isSell,
+          amount,
+          price,
+        );
+
+        if (quoteAmount === null) {
+          return 0n;
+        }
+
+        if (isSell && quoteAmount > outputBalance) {
+          return 0n;
+        }
+
+        return quoteAmount;
+      });
+    } catch (e) {
+      this.logger.debug(`${this.name}: failed to price Buffet hook`, e);
+      return null;
+    }
+  }
+
+  async getTopPoolsForToken(
+    tokenAddress: string,
+    limit: number,
+    blockNumber: number,
+    dexKey: string,
+  ): Promise<PoolLiquidity[]> {
+    if (limit <= 0) {
+      return [];
+    }
+
+    const token = tokenAddress.toLowerCase();
+    const isNative =
+      token === NULL_ADDRESS ||
+      token === ETHER_ADDRESS ||
+      token === this.wethAddress;
+    const isUsdc = token === BASE_USDC;
+
+    if (!isNative && !isUsdc) {
+      return [];
+    }
+
+    try {
+      const state = await this.getEngineState(blockNumber);
+      if (!state) {
+        return [];
+      }
+
+      const [ethUsd, usdcUsd] = await this.dexHelper.getUsdTokenAmounts([
+        [ETHER_ADDRESS, state.ethBal],
+        [BASE_USDC, state.usdcBal],
+      ]);
+
+      const config = BuffetHookConfig[this.network];
+
+      return [
+        {
+          exchange: dexKey,
+          address: config.poolId,
+          poolIdentifier: config.poolId,
+          liquidityUSD: isNative ? usdcUsd : ethUsd,
+          connectorTokens: [
+            {
+              address: isNative ? BASE_USDC : ETHER_ADDRESS,
+              decimals: isNative ? 6 : 18,
+              liquidityUSD: isNative ? ethUsd : usdcUsd,
+            },
+          ],
+        },
+      ];
+    } catch (e) {
+      this.logger.debug(`${this.name}: failed to load Buffet top pool`, e);
+      return [];
+    }
+  }
+
+  private async getEngineState(
+    blockNumber: number,
+  ): Promise<BuffetEngineState | null> {
+    const config = BuffetHookConfig[this.network];
+    const [slot5, block, balances] = await Promise.all([
+      this.dexHelper.provider.getStorageAt(config.priceEngine, 5, blockNumber),
+      this.dexHelper.provider.getBlock(blockNumber),
+      this.getBalances(blockNumber),
+    ]);
+
+    if (!block || balances === null) {
+      return null;
+    }
+
+    return {
+      ...decodeSlot5(slot5),
+      ethBal: balances.ethBal,
+      usdcBal: balances.usdcBal,
+      blockTs: BigInt(block.timestamp),
+    };
+  }
+
+  private async getBalances(
+    blockNumber: number,
+  ): Promise<{ ethBal: bigint; usdcBal: bigint } | null> {
+    const config = BuffetHookConfig[this.network];
+
+    const calls = [0n, BigInt(BASE_USDC)].map(currencyId => ({
+      target: config.poolManager,
+      callData: this.poolManagerIface.encodeFunctionData('balanceOf', [
+        config.hookAddress,
+        currencyId.toString(),
+      ]),
+      decodeFunction: (result: MultiResult<BytesLike> | BytesLike): bigint =>
+        uint256ToBigInt(result),
+    }));
+
+    const [ethBal, usdcBal] =
+      await this.dexHelper.multiWrapper.tryAggregate<bigint>(
+        false,
+        calls,
+        blockNumber,
+        this.dexHelper.multiWrapper.defaultBatchSize,
+        false,
+      );
+
+    if (!ethBal.success || !usdcBal.success) {
+      return null;
+    }
+
+    return {
+      ethBal: ethBal.returnData,
+      usdcBal: usdcBal.returnData,
+    };
+  }
+}

--- a/src/dex/uniswap-v4/hooks/buffet/config.ts
+++ b/src/dex/uniswap-v4/hooks/buffet/config.ts
@@ -1,0 +1,19 @@
+import { Network, NULL_ADDRESS } from '../../../../constants';
+import { HookConfig } from '../types';
+import { HookParams } from './types';
+
+export const BASE_USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+
+export const BuffetHookConfig: HookConfig<HookParams> = {
+  [Network.BASE]: {
+    hookAddress: '0x880bfa436d722bfde337eafc7c22123c17b90088',
+    priceEngine: '0xf57fe1e9a830126e5239fe07589e6995e4a35a36',
+    poolManager: '0x498581ff718922c3f8e6a244956af099b2652b2b',
+    poolId:
+      '0xaf36a3b872ece56b04af777bf6867cf79b91cb0212f12c92f27fd1bb27dd25a2',
+    token0: NULL_ADDRESS,
+    token1: BASE_USDC,
+    fee: '100',
+    tickSpacing: '1',
+  },
+};

--- a/src/dex/uniswap-v4/hooks/buffet/types.ts
+++ b/src/dex/uniswap-v4/hooks/buffet/types.ts
@@ -1,0 +1,21 @@
+import { Address } from '@paraswap/core';
+
+export type HookParams = {
+  hookAddress: Address;
+  priceEngine: Address;
+  poolManager: Address;
+  poolId: string;
+  token0: Address;
+  token1: Address;
+  fee: string;
+  tickSpacing: string;
+};
+
+export type BuffetEngineState = {
+  priceE6: bigint;
+  depth: bigint;
+  expiryTs: bigint;
+  ethBal: bigint;
+  usdcBal: bigint;
+  blockTs: bigint;
+};

--- a/src/dex/uniswap-v4/hooks/types.ts
+++ b/src/dex/uniswap-v4/hooks/types.ts
@@ -1,7 +1,8 @@
-import { PoolKey } from '../types';
+import { Pool, PoolKey } from '../types';
 import { IDexHelper } from '../../../dex-helper';
 import { Network } from '../../../constants';
-import { Logger } from '../../../types';
+import { Logger, PoolLiquidity } from '../../../types';
+import { SwapSide } from '@paraswap/core';
 
 export type HookConfig<HookParams> = {
   [network: number]: HookParams;
@@ -54,9 +55,25 @@ export interface IBaseHook {
 
   getHookPermissions(): HooksPermissions;
 
-  registerPool(poolId: string, poolKey: PoolKey): void;
+  registerPool(poolId: string, poolKey: PoolKey): boolean;
 
   initialize(blockNumber: number): Promise<void>;
+
+  getPricesVolume?(params: {
+    pool: Pool;
+    amounts: bigint[];
+    zeroForOne: boolean;
+    side: SwapSide;
+    blockNumber: number;
+    routerAddress: string;
+  }): Promise<bigint[] | null>;
+
+  getTopPoolsForToken?(
+    tokenAddress: string,
+    limit: number,
+    blockNumber: number,
+    dexKey: string,
+  ): Promise<PoolLiquidity[]>;
 
   beforeInitialize?(sender: string, key: PoolKey, sqrtPriceX96: string): string; // bytes4
 

--- a/src/dex/uniswap-v4/uniswap-v4-pool-manager.ts
+++ b/src/dex/uniswap-v4/uniswap-v4-pool-manager.ts
@@ -475,8 +475,7 @@ export class UniswapV4PoolManager extends StatefulEventSubscriber<PoolManagerSta
       return undefined;
     }
 
-    hook.registerPool(poolId, poolKey);
-    return hook;
+    return hook.registerPool(poolId, poolKey) ? hook : undefined;
   }
 
   private getBitmapRange() {

--- a/src/dex/uniswap-v4/uniswap-v4.test.ts
+++ b/src/dex/uniswap-v4/uniswap-v4.test.ts
@@ -1,0 +1,145 @@
+import { SwapSide } from '@paraswap/core';
+import { ETHER_ADDRESS, Network, NULL_ADDRESS } from '../../constants';
+import { UniswapV4 } from './uniswap-v4';
+import { Pool, PoolState } from './types';
+import { BASE_USDC, BuffetHookConfig } from './hooks/buffet/config';
+import { queryAvailablePoolsForToken } from './subgraph';
+
+jest.mock('./subgraph', () => ({
+  queryAvailablePoolsForToken: jest.fn(),
+}));
+
+jest.mock('./liquidity', () => ({
+  calculateTotalPoolLiquidity: jest.fn(() => ({
+    totalAmount0: 100n,
+    totalAmount1: 200n,
+  })),
+}));
+
+const WETH = '0x4200000000000000000000000000000000000006';
+const POOL_ID = BuffetHookConfig[Network.BASE].poolId;
+
+function makeUniswapV4(overrides: Record<string, any> = {}) {
+  return Object.assign(Object.create(UniswapV4.prototype), {
+    network: Network.BASE,
+    dexKey: 'UniswapV4',
+    routerAddress: '0x0000000000000000000000000000000000000001',
+    poolManagerAddress: '0x0000000000000000000000000000000000000002',
+    wethAddress: WETH,
+    logger: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      debug: jest.fn(),
+    },
+    ...overrides,
+  }) as UniswapV4;
+}
+
+describe('UniswapV4 hook integration', () => {
+  it('drops hook BUY prices when the largest requested tier is unavailable', async () => {
+    const pool: Pool = {
+      id: POOL_ID,
+      key: {
+        currency0: NULL_ADDRESS,
+        currency1: BASE_USDC,
+        fee: '100',
+        tickSpacing: 1,
+        hooks: BuffetHookConfig[Network.BASE].hookAddress,
+      },
+    };
+    const getPricesVolume = jest.fn().mockResolvedValue([0n, 10n, 0n]);
+    const uniswapV4 = makeUniswapV4({
+      poolManager: {
+        getAvailablePoolsForPair: jest.fn().mockResolvedValue([pool]),
+        getEventPool: jest.fn().mockResolvedValue({
+          hook: { getPricesVolume },
+          getState: jest.fn().mockResolvedValue(null),
+        }),
+      },
+    });
+
+    const prices = await uniswapV4.getPricesVolume(
+      { address: BASE_USDC, decimals: 6 },
+      { address: ETHER_ADDRESS, decimals: 18 },
+      [0n, 1n, 2n],
+      SwapSide.BUY,
+      1,
+    );
+
+    expect(prices).toEqual([]);
+  });
+
+  it('prefers hook top-pool liquidity over duplicate subgraph liquidity', async () => {
+    const hookPool = {
+      exchange: 'UniswapV4',
+      address: POOL_ID,
+      poolIdentifier: POOL_ID,
+      liquidityUSD: 999,
+      connectorTokens: [
+        {
+          address: BASE_USDC,
+          decimals: 6,
+          liquidityUSD: 999,
+        },
+      ],
+    };
+    const poolState: PoolState = {
+      id: POOL_ID,
+      token0: NULL_ADDRESS,
+      token1: BASE_USDC,
+      fee: '100',
+      hooks: BuffetHookConfig[Network.BASE].hookAddress,
+      feeGrowthGlobal0X128: 0n,
+      feeGrowthGlobal1X128: 0n,
+      liquidity: 0n,
+      slot0: {
+        sqrtPriceX96: 1n,
+        tick: 0n,
+        protocolFee: 0n,
+        lpFee: 0n,
+      },
+      tickSpacing: 1,
+      ticks: {},
+      tickBitmap: {},
+      isValid: true,
+    };
+
+    (queryAvailablePoolsForToken as jest.Mock).mockResolvedValue({
+      pools0: [
+        {
+          id: POOL_ID,
+          fee: '100',
+          volumeUSD: '1',
+          tickSpacing: '1',
+          hooks: BuffetHookConfig[Network.BASE].hookAddress,
+          token0: { address: NULL_ADDRESS, decimals: '18' },
+          token1: { address: BASE_USDC, decimals: '6' },
+        },
+      ],
+      pools1: [],
+    });
+
+    const uniswapV4 = makeUniswapV4({
+      dexHelper: {
+        provider: {
+          getBlockNumber: jest.fn().mockResolvedValue(1),
+        },
+        getUsdTokenAmounts: jest.fn().mockResolvedValue([1, 2]),
+      },
+      supportedHooks: [
+        {
+          address: BuffetHookConfig[Network.BASE].hookAddress,
+          getTopPoolsForToken: jest.fn().mockResolvedValue([hookPool]),
+        },
+      ],
+      poolManager: {
+        generateMultiplePoolStates: jest.fn().mockResolvedValue([poolState]),
+      },
+    });
+
+    const pools = await uniswapV4.getTopPoolsForToken(ETHER_ADDRESS, 10);
+
+    expect(pools).toHaveLength(1);
+    expect(pools[0]).toBe(hookPool);
+  });
+});

--- a/src/dex/uniswap-v4/uniswap-v4.ts
+++ b/src/dex/uniswap-v4/uniswap-v4.ts
@@ -225,7 +225,16 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
       const poolState = (await eventPool?.getState(blockNumber)) || null;
 
       let prices: bigint[] | null;
-      if (poolState !== null && poolState.isValid) {
+      if (eventPool?.hook?.getPricesVolume) {
+        prices = await eventPool.hook.getPricesVolume({
+          pool,
+          amounts,
+          zeroForOne,
+          side,
+          blockNumber,
+          routerAddress: this.routerAddress,
+        });
+      } else if (poolState !== null && poolState.isValid) {
         prices = this._getOutputs(
           pool,
           poolState,
@@ -351,8 +360,24 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
     _tokenAddress: Address,
     limit: number,
   ): Promise<PoolLiquidity[]> {
+    const blockNumber = await this.dexHelper.provider.getBlockNumber();
     let tokenAddress = _tokenAddress.toLowerCase();
     if (isETHAddress(tokenAddress)) tokenAddress = NULL_ADDRESS;
+
+    const hookLiquidityPools = (
+      await Promise.all(
+        this.supportedHooks.map(hook =>
+          hook.getTopPoolsForToken
+            ? hook.getTopPoolsForToken(
+                _tokenAddress.toLowerCase(),
+                limit,
+                blockNumber,
+                this.dexKey,
+              )
+            : [],
+        ),
+      )
+    ).flat();
 
     const poolIds = UniswapV4PoolsList[this.network]?.map(p => p.id);
 
@@ -360,29 +385,42 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
       .map(hook => hook.address.toLowerCase())
       .concat(NULL_ADDRESS);
 
-    const { pools0, pools1 } = await queryAvailablePoolsForToken(
-      this.dexHelper,
-      this.logger,
-      this.dexKey,
-      UniswapV4Config[this.dexKey][this.network].subgraphURL,
-      tokenAddress,
-      limit,
-      poolIds,
-      hooksToQuery,
-    );
+    let pools0: Awaited<
+      ReturnType<typeof queryAvailablePoolsForToken>
+    >['pools0'];
+    let pools1: Awaited<
+      ReturnType<typeof queryAvailablePoolsForToken>
+    >['pools1'];
+
+    try {
+      ({ pools0, pools1 } = await queryAvailablePoolsForToken(
+        this.dexHelper,
+        this.logger,
+        this.dexKey,
+        UniswapV4Config[this.dexKey][this.network].subgraphURL,
+        tokenAddress,
+        limit,
+        poolIds,
+        hooksToQuery,
+      ));
+    } catch (e) {
+      this.logger.error(
+        `Error_${this.dexKey}_Subgraph: couldn't fetch the pools from the subgraph`,
+        e,
+      );
+      return hookLiquidityPools.slice(0, limit);
+    }
 
     if (!(pools0 || pools1)) {
       this.logger.error(
         `Error_${this.dexKey}_Subgraph: couldn't fetch the pools from the subgraph`,
       );
-      return [];
+      return hookLiquidityPools.slice(0, limit);
     }
 
     if (pools0.length === 0 && pools1.length === 0) {
-      return [];
+      return hookLiquidityPools.slice(0, limit);
     }
-
-    const blockNumber = await this.dexHelper.provider.getBlockNumber();
 
     const pools = pools0.concat(pools1);
     const poolStates = await this.poolManager.generateMultiplePoolStates(
@@ -441,9 +479,16 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
       });
     }
 
-    liquidityPools.sort((a, b) => b.liquidityUSD - a.liquidityUSD);
+    liquidityPools.push(...hookLiquidityPools);
 
-    return liquidityPools.slice(0, limit);
+    const uniqueLiquidityPools = _.uniqBy(
+      liquidityPools,
+      pool => pool.poolIdentifier ?? pool.address,
+    );
+
+    uniqueLiquidityPools.sort((a, b) => b.liquidityUSD - a.liquidityUSD);
+
+    return uniqueLiquidityPools.slice(0, limit);
   }
 
   async queryPriceFromRpc(

--- a/src/dex/uniswap-v4/uniswap-v4.ts
+++ b/src/dex/uniswap-v4/uniswap-v4.ts
@@ -260,6 +260,14 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
         return null;
       }
 
+      if (
+        side === SwapSide.BUY &&
+        prices.length > 0 &&
+        prices[prices.length - 1] === 0n
+      ) {
+        return null;
+      }
+
       if (prices?.every(price => price === 0n || price === 1n)) {
         return null;
       }
@@ -479,10 +487,8 @@ export class UniswapV4 extends SimpleExchange implements IDex<UniswapV4Data> {
       });
     }
 
-    liquidityPools.push(...hookLiquidityPools);
-
     const uniqueLiquidityPools = _.uniqBy(
-      liquidityPools,
+      hookLiquidityPools.concat(liquidityPools),
       pool => pool.poolIdentifier ?? pool.address,
     );
 


### PR DESCRIPTION
## Summary
- add Base Buffet PropAMM support as a UniswapV4 hook
- add hook-aware pricing/top-pool handling for the configured ETH/USDC PropAMM pool
- preserve hook addresses in multi-hop UniswapV4 calldata
- tighten hook pool registration so unsupported same-hook pools fall back safely

## Verification
- PATH=/tmp/codex-node22/bin:$PATH ./node_modules/.bin/jest src/dex/uniswap-v4/encoder.test.ts src/dex/uniswap-v4/hooks/buffet/buffet-hook.test.ts --runInBand
- PATH=/tmp/codex-node22/bin:$PATH ./node_modules/.bin/tsc --noEmit
- PATH=/tmp/codex-node22/bin:$PATH ./node_modules/.bin/eslint "src/**/*.ts" --ignore-pattern="*.test.ts"
- PATH=/tmp/codex-node22/bin:$PATH ./node_modules/.bin/prettier --check <changed files>
- git diff --check
- Base smoke test against https://mainnet.base.org: PropAMM pool discovered and ETH/USDC quote directions returned non-zero prices with hook address preserved

Note: local Husky pre-commit could not run because git-secrets is not installed in this environment, so equivalent checks were run manually.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap quoting, routing liquidity, and on-chain calldata for hook pools on Base; incorrect hook math or registration could misprice or break multi-hop Buffet routes.
> 
> **Overview**
> Adds **Buffet PropAMM** on Base as a Uniswap V4 hook for the configured native ETH/USDC pool, with off-chain quoting from the price engine and hook balances instead of standard tick math.
> 
> **UniswapV4** now uses optional `getPricesVolume` / `getTopPoolsForToken` on hooks when present, rejects BUY quotes when the largest amount tier is zero, and merges hook-reported liquidity with subgraph results (deduped, hook-only fallback if subgraph fails). **Hook registration** returns a boolean so only the exact Buffet pool key is tied to `BuffetHook`; other pools sharing the hook address are ignored. **Multi-hop swap encoding** writes each hop’s `hooks` from the path key (previously forced to zero), which hook swaps require.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d5d85d4ff443daabdaa5e53a0d4f0e4d074a36e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->