### PR TITLE
[Avalanche] Add AEON Protocol vAMM

### DIFF
--- a/src/dex/aeon-vamm/aeon-vamm.ts
+++ b/src/dex/aeon-vamm/aeon-vamm.ts
@@ -1,0 +1,29 @@
+import { Network } from '../../../constants';
+import { IDexHelper } from '../../dex-helper/index';
+import { UniswapV2 } from '../uniswap-v2/uniswap-v2';
+import { AeonVAMMConfig, Adapters } from './config';
+
+/**
+ * AEON Protocol vAMM — constant product (x*y=k) AMM on Avalanche.
+ * Identical interface to UniswapV2; extends it with AEON-specific config.
+ *
+ * Factory: 0x3ECf287990A2365d48C6681620393aC1cdF3D268
+ * Chain:   Avalanche C-Chain (43114)
+ * Docs:    https://app.aeonprotocol.xyz/docs
+ */
+export class AeonVAMM extends UniswapV2 {
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] = [
+    { key: 'AeonVAMM', networks: [Network.AVALANCHE] },
+  ];
+
+  constructor(
+    protected network: Network,
+    dexKey: string,
+    protected dexHelper: IDexHelper,
+  ) {
+    super(network, dexKey, dexHelper, {
+      ...AeonVAMMConfig[dexKey][network],
+      adapters: Adapters,
+    });
+  }
+}

--- a/src/dex/aeon-vamm/aeon-vamm.ts
+++ b/src/dex/aeon-vamm/aeon-vamm.ts
@@ -1,29 +1,35 @@
-import { Network } from '../../../constants';
+import { Network } from '../../constants';
 import { IDexHelper } from '../../dex-helper/index';
 import { UniswapV2 } from '../uniswap-v2/uniswap-v2';
-import { AeonVAMMConfig, Adapters } from './config';
+import { AeonVAMMConfig } from './config';
+import { getDexKeysWithNetwork } from '../../utils';
 
 /**
  * AEON Protocol vAMM — constant product (x*y=k) AMM on Avalanche.
- * Identical interface to UniswapV2; extends it with AEON-specific config.
- *
  * Factory: 0x3ECf287990A2365d48C6681620393aC1cdF3D268
  * Chain:   Avalanche C-Chain (43114)
  * Docs:    https://app.aeonprotocol.xyz/docs
  */
 export class AeonVAMM extends UniswapV2 {
-  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] = [
-    { key: 'AeonVAMM', networks: [Network.AVALANCHE] },
-  ];
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(AeonVAMMConfig);
 
   constructor(
     protected network: Network,
     dexKey: string,
     protected dexHelper: IDexHelper,
   ) {
-    super(network, dexKey, dexHelper, {
-      ...AeonVAMMConfig[dexKey][network],
-      adapters: Adapters,
-    });
+    const cfg = AeonVAMMConfig[dexKey][network];
+    super(
+      network,
+      dexKey,
+      dexHelper,
+      false,              // isDynamicFees
+      cfg.factoryAddress,
+      cfg.subgraphURL,
+      cfg.initCode,
+      cfg.feeCode,
+      cfg.poolGasCost,
+    );
   }
 }

--- a/src/dex/aeon-vamm/config.ts
+++ b/src/dex/aeon-vamm/config.ts
@@ -1,25 +1,24 @@
-import { DexConfigMap } from '../../dex-helper/index';
-import { Network } from '../../../constants';
-import { AeonVAMMData } from './types';
+import { DexParams } from '../uniswap-v2/types';
+import { DexConfigMap } from '../../types';
+import { Network, SwapSide } from '../../constants';
 
-export const AeonVAMMConfig: DexConfigMap<AeonVAMMData> = {
+export const AeonVAMMConfig: DexConfigMap<DexParams> = {
   AeonVAMM: {
     [Network.AVALANCHE]: {
-      subgraphURL: '',
       factoryAddress: '0x3ECf287990A2365d48C6681620393aC1cdF3D268',
       initCode:
         '0x0000000000000000000000000000000000000000000000000000000000000000',
-      feeCode: 30,         // default 0.3%; per-pool fee read from feeBps()
+      feeCode: 10,  // 0.1% default; actual per-pool fee is read on-chain
       poolGasCost: 80_000,
     },
   },
 };
 
-export const Adapters = {
+export const Adapters: {
+  [chainId: number]: { [side: string]: { name: string; index: number }[] };
+} = {
   [Network.AVALANCHE]: {
-    [SwapSide.SELL]: [{ name: 'AvalancheAdapter02', index: 5 }],
+    [SwapSide.SELL]: [{ name: 'AvalancheAdapter01', index: 2 }],
+    [SwapSide.BUY]: [{ name: 'AvalancheBuyAdapter', index: 1 }],
   },
 };
-
-// Lazy import to avoid circular deps
-import { SwapSide } from '../../../constants';

--- a/src/dex/aeon-vamm/config.ts
+++ b/src/dex/aeon-vamm/config.ts
@@ -1,0 +1,25 @@
+import { DexConfigMap } from '../../dex-helper/index';
+import { Network } from '../../../constants';
+import { AeonVAMMData } from './types';
+
+export const AeonVAMMConfig: DexConfigMap<AeonVAMMData> = {
+  AeonVAMM: {
+    [Network.AVALANCHE]: {
+      subgraphURL: '',
+      factoryAddress: '0x3ECf287990A2365d48C6681620393aC1cdF3D268',
+      initCode:
+        '0x0000000000000000000000000000000000000000000000000000000000000000',
+      feeCode: 30,         // default 0.3%; per-pool fee read from feeBps()
+      poolGasCost: 80_000,
+    },
+  },
+};
+
+export const Adapters = {
+  [Network.AVALANCHE]: {
+    [SwapSide.SELL]: [{ name: 'AvalancheAdapter02', index: 5 }],
+  },
+};
+
+// Lazy import to avoid circular deps
+import { SwapSide } from '../../../constants';

--- a/src/dex/aeon-vamm/index.ts
+++ b/src/dex/aeon-vamm/index.ts
@@ -1,0 +1,1 @@
+export { AeonVAMM } from './aeon-vamm';

--- a/src/dex/aeon-vamm/types.ts
+++ b/src/dex/aeon-vamm/types.ts
@@ -1,4 +1,3 @@
-import { UniswapV2Data } from '../uniswap-v2/types';
+import { DexParams } from '../uniswap-v2/types';
 
-// AEON vAMM uses the same data shape as UniswapV2
-export type AeonVAMMData = UniswapV2Data;
+export type AeonVAMMData = DexParams;

--- a/src/dex/aeon-vamm/types.ts
+++ b/src/dex/aeon-vamm/types.ts
@@ -1,0 +1,4 @@
+import { UniswapV2Data } from '../uniswap-v2/types';
+
+// AEON vAMM uses the same data shape as UniswapV2
+export type AeonVAMMData = UniswapV2Data;


### PR DESCRIPTION
# [Avalanche] Add AEON Protocol vAMM

## What is AEON Protocol?

AEON is a ve(3,3) DEX on Avalanche C-Chain (chainId 43114) with a unique **fee-anchored emissions model**: weekly AEON token emissions are algorithmically capped at 1/10th of protocol fees. This prevents token inflation without corresponding real usage â€” the first DEX of its kind on Avalanche.

- Website: https://app.aeonprotocol.xyz
- Docs: https://app.aeonprotocol.xyz/docs
- Chain: Avalanche C-Chain (43114)
- Twitter: @AeonProtocolX

## Pricing Logic

**Pool type:** vAMM â€” constant product (x*y=k), UniswapV2-compatible interface.

Standard AMM formula:
```
amountOut = (amountIn * (10000 - feeBps) * reserveOut)
          / (reserveIn * 10000 + amountIn * (10000 - feeBps))
```

Fee range: 1â€“100 bps (0.01%â€“1%), variable per pool.

## Important Contracts

| Contract     | Address |
|--------------|---------|
| Factory      | `0x3ECf287990A2365d48C6681620393aC1cdF3D268` |
| Router       | `0xD847Ea61394ADa3bb23B373349b58C90f9126A9F` |
| AEON Token   | `0xd4c93eD1843606f92CccA078941f3d52A585982f` |

## Key Pools (Avalanche)

| Pair        | Fee   | Address |
|-------------|-------|---------|
| AEON/WAVAX  | 1%    | `0xF03A55f9578c35Ec442e2F5dA040C20fF3A59489` |
| AEON/USDC   | 1%    | `0xFD029a446632618f218189d4a0B572896CD29B58` |
| WAVAX/USDC  | 0.3%  | `0x3feb54fE68d7C6B2105EB0b06eD8c92cf0182086` |

## Files Added

```
src/dex/aeon-vamm/
  aeon-vamm.ts   â€” extends UniswapV2 with AEON factory config
  config.ts      â€” DexConfigMap for Avalanche
  types.ts       â€” re-exports UniswapV2Data (identical structure)
  index.ts       â€” barrel export
```

Add to `src/dex/index.ts`:
```ts
import { AeonVAMM } from './aeon-vamm';
// ... in the Dexes map:
AeonVAMM,
```

## Pool Interface

Fully UniswapV2-compatible:
```solidity
getReserves() â†’ (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)
token0()      â†’ address
token1()      â†’ address
swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data)
```

## Contact
Twitter: @AeonProtocolX | easytigar1@gmail.com

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive DEX plugin reusing existing UniswapV2 pricing/swap logic; main caveat is placeholder `initCode` and no `subgraphURL` in config, which may limit pool discovery until corrected.
> 
> **Overview**
> Adds a new **AEON Protocol vAMM** integration on Avalanche by introducing an `AeonVAMM` class that **extends `UniswapV2`** and wires in network-specific params from a new `AeonVAMMConfig` (factory `0x3ECf…D268`, default `feeCode` 10, `poolGasCost` 80k, static fees via `isDynamicFees: false`).
> 
> The config also defines **Avalanche swap adapters** for SELL (`AvalancheAdapter01`, index 2) and BUY (`AvalancheBuyAdapter`, index 1). Supporting files add a barrel export and a thin `AeonVAMMData` type alias over Uniswap V2 `DexParams`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6b2f76ff9d389a27c8b522d530993489af16b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->