### PR TITLE
Add wstGBP

### DIFF
--- a/src/abi/wstgbp/WsgemDirectAdapter.json
+++ b/src/abi/wstgbp/WsgemDirectAdapter.json
@@ -1,0 +1,56 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenIn", "type": "address" },
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" },
+      { "internalType": "uint256", "name": "minAmountOut", "type": "uint256" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapExactInput",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenIn", "type": "address" },
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" },
+      { "internalType": "uint256", "name": "maxAmountIn", "type": "uint256" },
+      { "internalType": "address", "name": "recipient", "type": "address" },
+      { "internalType": "uint256", "name": "deadline", "type": "uint256" }
+    ],
+    "name": "swapExactOutput",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenIn", "type": "address" },
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" }
+    ],
+    "name": "quoteExactInput",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "tokenIn", "type": "address" },
+      { "internalType": "uint256", "name": "amountOut", "type": "uint256" }
+    ],
+    "name": "quoteExactOutput",
+    "outputs": [
+      { "internalType": "uint256", "name": "amountIn", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/abi/wstgbp/wstGBP.json
+++ b/src/abi/wstgbp/wstGBP.json
@@ -1,0 +1,51 @@
+[
+  {
+    "inputs": [],
+    "name": "mintcost",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "burncost",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "capacity",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "mintable",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "burnable",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cooldown",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -46,6 +46,7 @@ import { CurveV1StableNg } from './curve-v1-stable-ng/curve-v1-stable-ng';
 import { curveV1Merge } from './curve-v1-factory/optimizer';
 import { GenericRFQ } from './generic-rfq/generic-rfq';
 import { WstETH } from './wsteth/wsteth';
+import { WstGBP } from './wstgbp/wstgbp';
 import { ERC4626 } from './erc4626/erc4626';
 import { Camelot } from './camelot/camelot';
 import { Hashflow } from './hashflow/hashflow';
@@ -158,6 +159,7 @@ const Dexes = [
   CurveV1Factory,
   CurveV1StableNg,
   WstETH,
+  WstGBP,
   ERC4626,
   Hashflow,
   Native,

--- a/src/dex/wstgbp/config.ts
+++ b/src/dex/wstgbp/config.ts
@@ -1,0 +1,13 @@
+import { DexParams } from './types';
+import { DexConfigMap } from '../../types';
+import { Network } from '../../constants';
+
+export const WstGBPConfig: DexConfigMap<DexParams> = {
+  wstGBP: {
+    [Network.MAINNET]: {
+      adapterAddress: '0xBE402d34f31133B1Dc00277f24F8ce2d975CBe23',
+      wstGBPAddress: '0x57C3571f10767E49C9d7b60feb6c67804783B7aE',
+      tGBPAddress: '0x27f6c8289550fCE67f6B50BeD1F519966aFE5287',
+    },
+  },
+};

--- a/src/dex/wstgbp/types.ts
+++ b/src/dex/wstgbp/types.ts
@@ -1,0 +1,26 @@
+import { Address } from '../../types';
+
+export type PoolState = {
+  // WAD (1e18) tGBP-per-wstGBP prices read off the wrapper.
+  mintcost: bigint; // ask: a buy of wstGBP executes at this price
+  burncost: bigint; // bid: a sell of wstGBP executes at this price
+  // Depth caps.
+  capacity: bigint; // max wstGBP total supply (buys revert past it)
+  totalSupply: bigint; // current wstGBP supply
+  tGBPReserve: bigint; // wrapper's tGBP balance (sells pay out of this)
+  // Availability gates.
+  mintable: boolean;
+  burnable: boolean;
+  cooldown: bigint; // must be 0 for atomic sells
+};
+
+export type WstGBPData = {};
+
+export type DexParams = {
+  // The swap venue: WsgemDirectAdapter (approve -> swap, direction inferred from tokenIn).
+  adapterAddress: Address;
+  // The wrapper token itself — also the pricing/gating read target.
+  wstGBPAddress: Address;
+  // The wrapper's underlying.
+  tGBPAddress: Address;
+};

--- a/src/dex/wstgbp/wstgbp-e2e.test.ts
+++ b/src/dex/wstgbp/wstgbp-e2e.test.ts
@@ -1,0 +1,91 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { testE2E } from '../../../tests/utils-e2e';
+import { Tokens, Holders } from '../../../tests/constants-e2e';
+import { Network, ContractMethod, SwapSide } from '../../constants';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { generateConfig } from '../../config';
+
+function testForNetwork(
+  network: Network,
+  dexKey: string,
+  tokenASymbol: string,
+  tokenBSymbol: string,
+  tokenAAmount: string,
+  tokenBAmount: string,
+) {
+  const provider = new StaticJsonRpcProvider(
+    generateConfig(network).privateHttpProvider,
+    network,
+  );
+  const tokens = Tokens[network];
+  const holders = Holders[network];
+
+  const sideToContractMethods = new Map([
+    [SwapSide.SELL, [ContractMethod.swapExactAmountIn]],
+    [SwapSide.BUY, [ContractMethod.swapExactAmountOut]],
+  ]);
+
+  describe(`${network}`, () => {
+    sideToContractMethods.forEach((contractMethods, side) =>
+      describe(`${side}`, () => {
+        contractMethods.forEach((contractMethod: ContractMethod) => {
+          describe(`${contractMethod}`, () => {
+            it(`${tokenASymbol} -> ${tokenBSymbol}`, async () => {
+              await testE2E(
+                tokens[tokenASymbol],
+                tokens[tokenBSymbol],
+                holders[tokenASymbol],
+                side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+            it(`${tokenBSymbol} -> ${tokenASymbol}`, async () => {
+              await testE2E(
+                tokens[tokenBSymbol],
+                tokens[tokenASymbol],
+                holders[tokenBSymbol],
+                side === SwapSide.SELL ? tokenBAmount : tokenAAmount,
+                side,
+                dexKey,
+                contractMethod,
+                network,
+                provider,
+              );
+            });
+          });
+        });
+      }),
+    );
+  });
+}
+
+describe('WstGBP E2E', () => {
+  const dexKey = 'wstGBP';
+
+  describe('Mainnet', () => {
+    const network = Network.MAINNET;
+
+    const tokenASymbol: string = 'tGBP';
+    const tokenBSymbol: string = 'wstGBP';
+
+    // Above the wrapper's dust floors (mint >= mintcost ~1.0e18 tGBP in; redeem >= 1e18 wstGBP in)
+    // and small enough to stay inside the sell-side reserve at any realistic fork block.
+    const tokenAAmount: string = '3000000000000000000';
+    const tokenBAmount: string = '3000000000000000000';
+
+    testForNetwork(
+      network,
+      dexKey,
+      tokenASymbol,
+      tokenBSymbol,
+      tokenAAmount,
+      tokenBAmount,
+    );
+  });
+});

--- a/src/dex/wstgbp/wstgbp-gas-estimation.test.ts
+++ b/src/dex/wstgbp/wstgbp-gas-estimation.test.ts
@@ -1,0 +1,67 @@
+/* eslint-disable no-console */
+import 'dotenv/config';
+import { testGasEstimation } from '../../../tests/utils-e2e';
+import { Tokens } from '../../../tests/constants-e2e';
+import { Network, SwapSide } from '../../constants';
+import { ContractMethodV6 } from '@paraswap/core';
+
+describe('WstGBP Gas Estimation', () => {
+  const dexKey = 'wstGBP';
+  const network = Network.MAINNET;
+
+  const tGBP = Tokens[network]['tGBP'];
+  const wstGBP = Tokens[network]['wstGBP'];
+  const amount = 3000000000000000000n;
+
+  describe('swapExactAmountIn', () => {
+    it('mint (buy wstGBP with tGBP)', async () => {
+      await testGasEstimation(
+        network,
+        tGBP,
+        wstGBP,
+        amount,
+        SwapSide.SELL,
+        dexKey,
+        ContractMethodV6.swapExactAmountIn,
+      );
+    });
+
+    it('redeem (sell wstGBP for tGBP)', async () => {
+      await testGasEstimation(
+        network,
+        wstGBP,
+        tGBP,
+        amount,
+        SwapSide.SELL,
+        dexKey,
+        ContractMethodV6.swapExactAmountIn,
+      );
+    });
+  });
+
+  describe('swapExactAmountOut', () => {
+    it('mint (exact wstGBP out)', async () => {
+      await testGasEstimation(
+        network,
+        tGBP,
+        wstGBP,
+        amount,
+        SwapSide.BUY,
+        dexKey,
+        ContractMethodV6.swapExactAmountOut,
+      );
+    });
+
+    it('redeem (exact tGBP out)', async () => {
+      await testGasEstimation(
+        network,
+        wstGBP,
+        tGBP,
+        amount,
+        SwapSide.BUY,
+        dexKey,
+        ContractMethodV6.swapExactAmountOut,
+      );
+    });
+  });
+});

--- a/src/dex/wstgbp/wstgbp-integration.test.ts
+++ b/src/dex/wstgbp/wstgbp-integration.test.ts
@@ -1,0 +1,244 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Interface, Result } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide } from '../../constants';
+import { BI_POWS } from '../../bigint-constants';
+import { WstGBP } from './wstgbp';
+import { WstGBPConfig } from './config';
+import { checkPoolPrices, checkPoolsLiquidity } from '../../../tests/utils';
+import { Tokens } from '../../../tests/constants-e2e';
+
+function getReaderCalldata(
+  exchangeAddress: string,
+  readerIface: Interface,
+  tokenIn: string,
+  amounts: bigint[],
+  funcName: string,
+) {
+  return amounts.map(amount => ({
+    target: exchangeAddress,
+    callData: readerIface.encodeFunctionData(funcName, [tokenIn, amount]),
+  }));
+}
+
+function decodeReaderResult(
+  results: Result,
+  readerIface: Interface,
+  funcName: string,
+) {
+  return results.map(result => {
+    const parsed = readerIface.decodeFunctionResult(funcName, result);
+    return BigInt(parsed[0]._hex);
+  });
+}
+
+// The adapter's view quotes mirror its execution bit-for-bit (same shared library on-chain), so they
+// are the ground truth the pricing must match exactly.
+async function checkOnChainPricing(
+  wstGBP: WstGBP,
+  funcName: 'quoteExactInput' | 'quoteExactOutput',
+  tokenIn: string,
+  blockNumber: number,
+  prices: bigint[],
+  amounts: bigint[],
+) {
+  const exchangeAddress =
+    WstGBPConfig['wstGBP'][Network.MAINNET].adapterAddress;
+
+  const readerIface = WstGBP.adapterIface;
+
+  const readerCallData = getReaderCalldata(
+    exchangeAddress,
+    readerIface,
+    tokenIn,
+    amounts.slice(1),
+    funcName,
+  );
+  const readerResult = (
+    await wstGBP.dexHelper.multiContract.methods
+      .aggregate(readerCallData)
+      .call({}, blockNumber)
+  ).returnData;
+
+  const expectedPrices = [0n].concat(
+    decodeReaderResult(readerResult, readerIface, funcName),
+  );
+  expect(prices).toEqual(expectedPrices);
+}
+
+async function testPricingOnNetwork(
+  wstGBP: WstGBP,
+  network: Network,
+  dexKey: string,
+  blockNumber: number,
+  srcTokenSymbol: string,
+  destTokenSymbol: string,
+  side: SwapSide,
+  amounts: bigint[],
+) {
+  const networkTokens = Tokens[network];
+
+  const pools = await wstGBP.getPoolIdentifiers(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    side,
+    blockNumber,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Identifiers: `,
+    pools,
+  );
+
+  expect(pools.length).toBeGreaterThan(0);
+
+  const poolPrices = await wstGBP.getPricesVolume(
+    networkTokens[srcTokenSymbol],
+    networkTokens[destTokenSymbol],
+    amounts,
+    side,
+    blockNumber,
+    pools,
+  );
+  console.log(
+    `${srcTokenSymbol} <> ${destTokenSymbol} Pool Prices: `,
+    poolPrices,
+  );
+
+  expect(poolPrices).not.toBeNull();
+  checkPoolPrices(poolPrices!, amounts, side, dexKey);
+
+  // On-chain truth: exact-in prices must equal quoteExactInput, exact-out inputs quoteExactOutput,
+  // for the actual input token of the trade (direction is inferred from tokenIn on-chain).
+  const tokenIn = networkTokens[srcTokenSymbol].address;
+  await checkOnChainPricing(
+    wstGBP,
+    side === SwapSide.SELL ? 'quoteExactInput' : 'quoteExactOutput',
+    tokenIn,
+    blockNumber,
+    poolPrices![0].prices,
+    amounts,
+  );
+}
+
+describe('WstGBP', function () {
+  const dexKey = 'wstGBP';
+  let blockNumber: number;
+  let wstGBP: WstGBP;
+
+  describe('Mainnet', () => {
+    const network = Network.MAINNET;
+    const dexHelper = new DummyDexHelper(network);
+
+    const tokens = Tokens[network];
+
+    const tGBPSymbol = 'tGBP';
+    const wstGBPSymbol = 'wstGBP';
+
+    // Above the wrapper's dust floors (mint needs >= mintcost ~1.0e18 tGBP; redeem >= 1e18 wstGBP)
+    // and comfortably inside the depth caps at any realistic fork block. Evenly spaced from the first
+    // non-zero amount: checkPoolPrices compares successive marginal prices, and on a constant-price
+    // venue an uneven first step reads as a (spurious) marginal-price decrease.
+    const amounts = [
+      0n,
+      2n * BI_POWS[18],
+      4n * BI_POWS[18],
+      6n * BI_POWS[18],
+      8n * BI_POWS[18],
+      10n * BI_POWS[18],
+      12n * BI_POWS[18],
+      14n * BI_POWS[18],
+      16n * BI_POWS[18],
+      18n * BI_POWS[18],
+      20n * BI_POWS[18],
+    ];
+
+    beforeAll(async () => {
+      blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      wstGBP = new WstGBP(network, dexKey, dexHelper);
+    });
+
+    it('getPoolIdentifiers and getPricesVolume SELL tGBP->wstGBP (buy at mintcost)', async function () {
+      await testPricingOnNetwork(
+        wstGBP,
+        network,
+        dexKey,
+        blockNumber,
+        tGBPSymbol,
+        wstGBPSymbol,
+        SwapSide.SELL,
+        amounts,
+      );
+    });
+
+    it('getPoolIdentifiers and getPricesVolume SELL wstGBP->tGBP (sell at burncost)', async function () {
+      await testPricingOnNetwork(
+        wstGBP,
+        network,
+        dexKey,
+        blockNumber,
+        wstGBPSymbol,
+        tGBPSymbol,
+        SwapSide.SELL,
+        amounts,
+      );
+    });
+
+    it('getPoolIdentifiers and getPricesVolume BUY tGBP->wstGBP (exact wstGBP out)', async function () {
+      await testPricingOnNetwork(
+        wstGBP,
+        network,
+        dexKey,
+        blockNumber,
+        tGBPSymbol,
+        wstGBPSymbol,
+        SwapSide.BUY,
+        amounts,
+      );
+    });
+
+    it('getPoolIdentifiers and getPricesVolume BUY wstGBP->tGBP (exact tGBP out)', async function () {
+      await testPricingOnNetwork(
+        wstGBP,
+        network,
+        dexKey,
+        blockNumber,
+        wstGBPSymbol,
+        tGBPSymbol,
+        SwapSide.BUY,
+        amounts,
+      );
+    });
+
+    it('getTopPoolsForToken tGBP', async function () {
+      const newWstGBP = new WstGBP(network, dexKey, dexHelper);
+      const poolLiquidity = await newWstGBP.getTopPoolsForToken(
+        tokens[tGBPSymbol].address,
+        10,
+      );
+      console.log(`${tGBPSymbol} Top Pools:`, poolLiquidity);
+
+      checkPoolsLiquidity(
+        poolLiquidity,
+        Tokens[network][tGBPSymbol].address,
+        dexKey,
+      );
+    });
+
+    it('getTopPoolsForToken wstGBP', async function () {
+      const newWstGBP = new WstGBP(network, dexKey, dexHelper);
+      const poolLiquidity = await newWstGBP.getTopPoolsForToken(
+        tokens[wstGBPSymbol].address,
+        10,
+      );
+      console.log(`${wstGBPSymbol} Top Pools:`, poolLiquidity);
+
+      checkPoolsLiquidity(
+        poolLiquidity,
+        Tokens[network][wstGBPSymbol].address,
+        dexKey,
+      );
+    });
+  });
+});

--- a/src/dex/wstgbp/wstgbp-math.test.ts
+++ b/src/dex/wstgbp/wstgbp-math.test.ts
@@ -1,0 +1,238 @@
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide } from '../../constants';
+import { WstGBP } from './wstgbp';
+import { WstGBPConfig } from './config';
+import { PoolState } from './types';
+
+/**
+ * Pure-math regressions with a synthetic PoolState (no network calls — `compute`/`convert` never
+ * touch the RPC). The live integration suite cannot drive the wrapper's capacity or NAV, so the
+ * capacity-boundary and dust-floor edges are pinned here instead.
+ */
+describe('WstGBP math', () => {
+  const dexKey = 'wstGBP';
+  const network = Network.MAINNET;
+  const WAD = 10n ** 18n;
+
+  const dexHelper = new DummyDexHelper(network);
+  const wstGBP = new WstGBP(network, dexKey, dexHelper) as any;
+
+  const baseState = (over: Partial<PoolState>): PoolState => ({
+    mintcost: 1001300000000000000n, // ~1.0013 tGBP per wstGBP (at-par-ish live shape)
+    burncost: 998800000000000000n,
+    capacity: 10n ** 24n,
+    totalSupply: 0n,
+    tGBPReserve: 10n ** 24n,
+    mintable: true,
+    burnable: true,
+    cooldown: 0n,
+    ...over,
+  });
+
+  describe('exact-output buy capacity boundary (minted >= requested)', () => {
+    // Sub-par NAV maximizes the over-mint: mintcost = 0.5 => requesting an odd-wei output rounds
+    // the input up by half a wei of tGBP, which mints one extra wei of wstGBP. The request is far
+    // above the wrapper's mint dust floor (tGBPIn >= mintcost), so capacity is the only gate.
+    const mintcost = 500000000000000000n;
+    const amountOut = 3n * WAD + 1n;
+    const tGBPIn = (3n * WAD) / 2n + 1n; // ceil((3e18+1) * 0.5)
+    const minted = (tGBPIn * WAD) / mintcost; // 3e18 + 2 — one wei MORE than requested
+    const state = baseState({
+      mintcost,
+      capacity: amountOut, // headroom == the requested output exactly
+      totalSupply: 0n,
+    });
+
+    it('quotes unfillable when headroom equals the requested output but the mint would overflow it', () => {
+      // headroom == 3 == amountOut, but mint(2) mints 4 > 3 => on-chain mint reverts on capacity.
+      expect(wstGBP.compute(true, SwapSide.BUY, amountOut, state)).toEqual(0n);
+    });
+
+    it('quotes fillable when headroom covers the minted amount', () => {
+      const roomy = { ...state, capacity: minted };
+      expect(wstGBP.compute(true, SwapSide.BUY, amountOut, roomy)).toEqual(
+        tGBPIn,
+      );
+    });
+
+    it('at-par: fillable at headroom == minted, unfillable one wei below', () => {
+      const st = baseState({});
+      const amount = 5n * WAD;
+      const inAmt = wstGBP.convert(true, SwapSide.BUY, amount, st) as bigint;
+      const minted5 = (inAmt * WAD) / st.mintcost;
+      expect(minted5).toBeGreaterThanOrEqual(amount);
+
+      const exact = { ...st, capacity: st.totalSupply + minted5 };
+      expect(wstGBP.compute(true, SwapSide.BUY, amount, exact)).toEqual(inAmt);
+
+      const short = { ...st, capacity: st.totalSupply + minted5 - 1n };
+      expect(wstGBP.compute(true, SwapSide.BUY, amount, short)).toEqual(0n);
+    });
+  });
+
+  describe('buy exact-in headroom boundary', () => {
+    const state = baseState({});
+    const amountIn = 5n * WAD;
+    const out = wstGBP.convert(true, SwapSide.SELL, amountIn, state) as bigint;
+
+    it('fillable when headroom equals the minted output, unfillable one wei below', () => {
+      const exact = { ...state, capacity: state.totalSupply + out };
+      expect(wstGBP.compute(true, SwapSide.SELL, amountIn, exact)).toEqual(out);
+
+      const short = { ...state, capacity: state.totalSupply + out - 1n };
+      expect(wstGBP.compute(true, SwapSide.SELL, amountIn, short)).toEqual(0n);
+    });
+  });
+
+  describe('sell reserve boundary (the wrapper must fund the full claim)', () => {
+    it('exact-in: fillable when the reserve equals the claim, unfillable one wei below', () => {
+      const state = baseState({});
+      const amountIn = 5n * WAD;
+      const claim = (amountIn * state.burncost) / WAD;
+
+      const exact = { ...state, tGBPReserve: claim };
+      expect(wstGBP.compute(false, SwapSide.SELL, amountIn, exact)).toEqual(
+        claim,
+      );
+
+      const short = { ...state, tGBPReserve: claim - 1n };
+      expect(wstGBP.compute(false, SwapSide.SELL, amountIn, short)).toEqual(0n);
+    });
+
+    it('exact-out: the reserve must cover the claim, which exceeds the requested output (input rounds up)', () => {
+      // burncost > WAD (a premium bid — the live shape today) makes each rounded-up wei of wstGBP
+      // input worth > 1 wei of tGBP, so the wrapper's payout (the claim) overshoots the request.
+      const state = baseState({ burncost: 2n * WAD });
+      // Odd request => the wstGBP input rounds up by half a wei-equivalent; large enough to clear
+      // the redeem dust floor (needs >= 1e18 wstGBP in at this price).
+      const amountOut = 3n * WAD + 1n;
+      const wstGBPIn = wstGBP.convert(false, SwapSide.BUY, amountOut, state);
+      const claim = (wstGBPIn * state.burncost) / WAD;
+      expect(claim).toBeGreaterThan(amountOut);
+
+      const exact = { ...state, tGBPReserve: claim };
+      expect(wstGBP.compute(false, SwapSide.BUY, amountOut, exact)).toEqual(
+        wstGBPIn,
+      );
+
+      // Reserve covers the requested output but not the claim => on-chain redeem underpays => 0.
+      const short = { ...state, tGBPReserve: claim - 1n };
+      expect(wstGBP.compute(false, SwapSide.BUY, amountOut, short)).toEqual(0n);
+    });
+  });
+
+  describe('dust floors', () => {
+    const state = baseState({});
+
+    it('sell exact-in: redeem needs >= 1e18 wstGBP in', () => {
+      expect(wstGBP.compute(false, SwapSide.SELL, WAD - 1n, state)).toEqual(0n);
+      expect(wstGBP.compute(false, SwapSide.SELL, WAD, state)).toEqual(
+        state.burncost,
+      );
+    });
+
+    it('sell exact-out: unfillable when the required wstGBP input is below 1e18', () => {
+      // amountOut = burncost - 1 needs ceil((burncost-1)/burncost * 1e18) = 1e18 - 1 wstGBP in.
+      expect(
+        wstGBP.compute(false, SwapSide.BUY, state.burncost - 1n, state),
+      ).toEqual(0n);
+      // amountOut = burncost needs exactly 1e18 in — right at the floor.
+      expect(
+        wstGBP.compute(false, SwapSide.BUY, state.burncost, state),
+      ).toEqual(WAD);
+    });
+
+    it('buy exact-out: unfillable when the required tGBP input is below mintcost', () => {
+      // amountOut = 1e18 - 1 needs mintcost - 1 tGBP in — one wei under the mint dust floor.
+      expect(wstGBP.compute(true, SwapSide.BUY, WAD - 1n, state)).toEqual(0n);
+      // amountOut = 1e18 needs exactly mintcost in — right at the floor.
+      expect(wstGBP.compute(true, SwapSide.BUY, WAD, state)).toEqual(
+        state.mintcost,
+      );
+    });
+  });
+
+  describe('availability gates in getPricesVolume', () => {
+    const { tGBPAddress, wstGBPAddress } = WstGBPConfig[dexKey][network];
+    const tGBP = { address: tGBPAddress, decimals: 18 };
+    const wstGBPToken = { address: wstGBPAddress, decimals: 18 };
+    const amounts = [0n, 5n * WAD];
+
+    const withState = (over: Partial<PoolState>) => {
+      const dex = new WstGBP(network, dexKey, dexHelper) as any;
+      dex.getState = async () => ({ blockNumber: 1, ...baseState(over) });
+      return dex;
+    };
+
+    const buyPrices = (dex: any) =>
+      dex.getPricesVolume(tGBP, wstGBPToken, amounts, SwapSide.SELL, 1);
+    const sellPrices = (dex: any) =>
+      dex.getPricesVolume(wstGBPToken, tGBP, amounts, SwapSide.SELL, 1);
+
+    it('prices both directions when fully live', async () => {
+      const dex = withState({});
+      await expect(buyPrices(dex)).resolves.not.toBeNull();
+      await expect(sellPrices(dex)).resolves.not.toBeNull();
+    });
+
+    it('mintable=false kills buys only', async () => {
+      const dex = withState({ mintable: false });
+      await expect(buyPrices(dex)).resolves.toBeNull();
+      await expect(sellPrices(dex)).resolves.not.toBeNull();
+    });
+
+    it('burnable=false kills sells only', async () => {
+      const dex = withState({ burnable: false });
+      await expect(sellPrices(dex)).resolves.toBeNull();
+      await expect(buyPrices(dex)).resolves.not.toBeNull();
+    });
+
+    it('non-zero redemption cooldown kills sells only (payout would be deferred)', async () => {
+      const dex = withState({ cooldown: 3600n });
+      await expect(sellPrices(dex)).resolves.toBeNull();
+      await expect(buyPrices(dex)).resolves.not.toBeNull();
+    });
+
+    it('paused oracle (mintcost=0, burncost=0) kills both directions', async () => {
+      const dex = withState({ mintcost: 0n, burncost: 0n });
+      await expect(buyPrices(dex)).resolves.toBeNull();
+      await expect(sellPrices(dex)).resolves.toBeNull();
+    });
+
+    it('burncost=0 alone (100% exit fee at a live NAV) kills sells only', async () => {
+      const dex = withState({ burncost: 0n });
+      await expect(sellPrices(dex)).resolves.toBeNull();
+      await expect(buyPrices(dex)).resolves.not.toBeNull();
+    });
+  });
+
+  describe('unit is the ungated marginal rate', () => {
+    const state = baseState({});
+
+    it('buy exact-in unit is non-zero even though 1e18 tGBP is below the mint dust floor', () => {
+      expect(state.mintcost).toBeGreaterThan(WAD); // the 1e18 probe IS below the dust floor
+      expect(wstGBP.compute(true, SwapSide.SELL, WAD, state)).toEqual(0n); // gated: unfillable
+      expect(wstGBP.convert(true, SwapSide.SELL, WAD, state)).toEqual(
+        (WAD * WAD) / state.mintcost, // ungated unit: the true marginal rate
+      );
+    });
+
+    it('all four units equal their pure oracle-price conversions', () => {
+      expect(wstGBP.convert(true, SwapSide.SELL, WAD, state)).toEqual(
+        (WAD * WAD) / state.mintcost,
+      );
+      expect(wstGBP.convert(true, SwapSide.BUY, WAD, state)).toEqual(
+        state.mintcost,
+      );
+      expect(wstGBP.convert(false, SwapSide.SELL, WAD, state)).toEqual(
+        state.burncost,
+      );
+      expect(wstGBP.convert(false, SwapSide.BUY, WAD, state)).toEqual(
+        (WAD * WAD + state.burncost - 1n) / state.burncost,
+      );
+    });
+  });
+});

--- a/src/dex/wstgbp/wstgbp.ts
+++ b/src/dex/wstgbp/wstgbp.ts
@@ -1,0 +1,396 @@
+import { Interface } from '@ethersproject/abi';
+import {
+  Token,
+  Address,
+  ExchangePrices,
+  PoolPrices,
+  AdapterExchangeParam,
+  PoolLiquidity,
+  Logger,
+  NumberAsString,
+  DexExchangeParam,
+} from '../../types';
+import { SwapSide, Network, MAX_UINT } from '../../constants';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+import { getDexKeysWithNetwork } from '../../utils';
+import { IDex } from '../../dex/idex';
+import { IDexHelper } from '../../dex-helper/idex-helper';
+import { WstGBPData, PoolState, DexParams } from './types';
+import { SimpleExchange } from '../simple-exchange';
+import { WstGBPConfig } from './config';
+import { uint256ToBigInt, booleanDecode } from '../../lib/decoders';
+import { Utils } from '../../utils';
+import WsgemAdapterABI from '../../abi/wstgbp/WsgemDirectAdapter.json';
+import WstGBPWrapperABI from '../../abi/wstgbp/wstGBP.json';
+import ERC20ABI from '../../abi/erc20.json';
+import { extractReturnAmountPosition } from '../../executor/utils';
+
+const WAD = 1000000000000000000n;
+const ceilDiv = (a: bigint, b: bigint) => (a + b - 1n) / b;
+
+/**
+ * WstGBP — the tGBP <-> wstGBP atomic wrapper venue, PSM-like: a constant-price market at the wrapper
+ * protocol's own oracle prices. Buys of wstGBP execute at `mintcost()` (ask), sells at `burncost()`
+ * (bid, ~25bps below); prices ratchet up slowly (weekly NAV steps) and are size-independent within the
+ * caps.
+ *
+ * Swaps route through the ownerless, inventory-free `WsgemDirectAdapter` (plain approve -> swap with a
+ * recipient param; direction inferred from tokenIn; exact-in and exact-out; the adapter's own view
+ * quotes mirror execution bit-for-bit). Depth caps: buys are limited by the wrapper's remaining supply
+ * capacity, sells by the wrapper's tGBP reserve. There are no events to track — state is a handful of
+ * view reads, refreshed per pricing tick like wstETH.
+ */
+export class WstGBP extends SimpleExchange implements IDex<WstGBPData> {
+  static readonly adapterIface = new Interface(WsgemAdapterABI);
+  static readonly wrapperIface = new Interface(WstGBPWrapperABI);
+  static readonly erc20Iface = new Interface(ERC20ABI);
+
+  protected config: DexParams;
+
+  readonly hasConstantPriceLargeAmounts = true;
+
+  readonly needWrapNative = false;
+
+  readonly isFeeOnTransferSupported = false;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(WstGBPConfig);
+
+  logger: Logger;
+
+  private state: { blockNumber: number } & PoolState = {
+    blockNumber: 0,
+    mintcost: 0n,
+    burncost: 0n,
+    capacity: 0n,
+    totalSupply: 0n,
+    tGBPReserve: 0n,
+    mintable: false,
+    burnable: false,
+    cooldown: 0n,
+  };
+
+  constructor(
+    readonly network: Network,
+    readonly dexKey: string,
+    readonly dexHelper: IDexHelper,
+  ) {
+    super(dexHelper, dexKey);
+    const config = WstGBPConfig[dexKey][network];
+    this.config = {
+      adapterAddress: config.adapterAddress.toLowerCase(),
+      wstGBPAddress: config.wstGBPAddress.toLowerCase(),
+      tGBPAddress: config.tGBPAddress.toLowerCase(),
+    };
+    this.logger = dexHelper.getLogger(dexKey);
+  }
+
+  // v6-only integration: no Augustus v5 adapter contracts.
+  getAdapters(_side: SwapSide): { name: string; index: number }[] | null {
+    return null;
+  }
+
+  /** true = buy wstGBP (tGBP in / mint), false = sell wstGBP (wstGBP in / redeem), null = not our pair. */
+  protected direction(srcToken: Token, destToken: Token): boolean | null {
+    const src = srcToken.address.toLowerCase();
+    const dest = destToken.address.toLowerCase();
+    if (src === this.config.tGBPAddress && dest === this.config.wstGBPAddress)
+      return true;
+    if (src === this.config.wstGBPAddress && dest === this.config.tGBPAddress)
+      return false;
+    return null;
+  }
+
+  // Not relevant for hasConstantPriceLargeAmounts exchanges: one virtual pool.
+  async getPoolIdentifiers(
+    srcToken: Token,
+    destToken: Token,
+    _side: SwapSide,
+    _blockNumber: number,
+  ): Promise<string[]> {
+    if (this.direction(srcToken, destToken) === null) return [];
+    return [this.dexKey];
+  }
+
+  protected async getState(
+    blockNumber: number,
+  ): Promise<{ blockNumber: number } & PoolState> {
+    if (blockNumber <= this.state.blockNumber) return this.state;
+
+    const cached = await this.dexHelper.cache.get(
+      this.dexKey,
+      this.network,
+      'state',
+    );
+    if (cached) {
+      this.state = Utils.Parse(cached);
+      if (blockNumber <= this.state.blockNumber) return this.state;
+    }
+
+    const wrapper = this.config.wstGBPAddress;
+    const calls = [
+      ...['mintcost', 'burncost', 'capacity', 'totalSupply', 'cooldown'].map(
+        fn => ({
+          target: wrapper,
+          callData: WstGBP.wrapperIface.encodeFunctionData(fn),
+          decodeFunction: uint256ToBigInt,
+        }),
+      ),
+      ...['mintable', 'burnable'].map(fn => ({
+        target: wrapper,
+        callData: WstGBP.wrapperIface.encodeFunctionData(fn),
+        decodeFunction: booleanDecode,
+      })),
+      {
+        target: this.config.tGBPAddress,
+        callData: WstGBP.erc20Iface.encodeFunctionData('balanceOf', [wrapper]),
+        decodeFunction: uint256ToBigInt,
+      },
+    ];
+    const results = await this.dexHelper.multiWrapper.tryAggregate<
+      bigint | boolean
+    >(true, calls, blockNumber);
+
+    this.state = {
+      blockNumber,
+      mintcost: results[0].returnData as bigint,
+      burncost: results[1].returnData as bigint,
+      capacity: results[2].returnData as bigint,
+      totalSupply: results[3].returnData as bigint,
+      cooldown: results[4].returnData as bigint,
+      mintable: results[5].returnData as boolean,
+      burnable: results[6].returnData as boolean,
+      tGBPReserve: results[7].returnData as bigint,
+    };
+    this.dexHelper.cache.setex(
+      this.dexKey,
+      this.network,
+      'state',
+      60,
+      Utils.Serialize(this.state),
+    );
+    return this.state;
+  }
+
+  /**
+   * Pure conversion at the oracle price — the exact wrapper math, no size gating (mirrors the
+   * on-chain venue bit-for-bit):
+   * - buy exact-in:   wstGBPOut = tGBPIn * 1e18 / mintcost         (floor)
+   * - buy exact-out:  tGBPIn    = ceil(wstGBPOut * mintcost / 1e18)
+   * - sell exact-in:  tGBPOut   = wstGBPIn * burncost / 1e18       (floor)
+   * - sell exact-out: wstGBPIn  = ceil(tGBPOut * 1e18 / burncost)
+   */
+  protected convert(
+    buy: boolean,
+    side: SwapSide,
+    amount: bigint,
+    state: PoolState,
+  ): bigint {
+    if (buy) {
+      return side === SwapSide.SELL
+        ? (amount * WAD) / state.mintcost
+        : ceilDiv(amount * state.mintcost, WAD);
+    }
+    return side === SwapSide.SELL
+      ? (amount * state.burncost) / WAD
+      : ceilDiv(amount * WAD, state.burncost);
+  }
+
+  /**
+   * `convert`, gated by the wrapper's dust floors and depth caps: amounts the on-chain venue would
+   * revert on price to 0 (unfillable).
+   */
+  protected compute(
+    buy: boolean,
+    side: SwapSide,
+    amount: bigint,
+    state: PoolState,
+  ): bigint {
+    if (amount === 0n) return 0n;
+    const headroom =
+      state.capacity > state.totalSupply
+        ? state.capacity - state.totalSupply
+        : 0n;
+    if (buy) {
+      if (side === SwapSide.SELL) {
+        // Wrapper dust floor: mint reverts below one wstGBP-worth of tGBP.
+        if (amount < state.mintcost) return 0n;
+        const out = this.convert(buy, side, amount, state);
+        return out <= headroom ? out : 0n;
+      }
+      const tGBPIn = this.convert(buy, side, amount, state);
+      if (tGBPIn < state.mintcost) return 0n;
+      // `mint(tGBPIn)` mints tGBPIn*1e18/mintcost, which is >= the requested output (the input was
+      // rounded up). The wrapper's capacity gate applies to that minted amount, so check it — not
+      // the requested output — or the quote could read fillable while the mint reverts at the
+      // capacity boundary.
+      const minted = (tGBPIn * WAD) / state.mintcost;
+      return minted <= headroom ? tGBPIn : 0n;
+    }
+    if (side === SwapSide.SELL) {
+      // Wrapper dust floor: redeem reverts below 1 wstGBP.
+      if (amount < WAD) return 0n;
+      const out = this.convert(buy, side, amount, state);
+      return out <= state.tGBPReserve ? out : 0n;
+    }
+    const wstGBPIn = this.convert(buy, side, amount, state);
+    if (wstGBPIn < WAD) return 0n;
+    // The wrapper pays claim = wstGBPIn * burncost / 1e18 (>= amount); it must be fully funded.
+    const claim = (wstGBPIn * state.burncost) / WAD;
+    return claim <= state.tGBPReserve ? wstGBPIn : 0n;
+  }
+
+  // Returns pool prices for amounts. limitPools ignored (hasConstantPriceLargeAmounts).
+  async getPricesVolume(
+    srcToken: Token,
+    destToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    _limitPools?: string[],
+  ): Promise<null | ExchangePrices<WstGBPData>> {
+    const buy = this.direction(srcToken, destToken);
+    if (buy === null) return null;
+
+    const state = await this.getState(blockNumber);
+
+    // Availability gates: time-gated markets, paused oracle (price == 0), and — for sells — a
+    // non-zero redemption cooldown would defer the payout, so the venue is unusable.
+    if (buy) {
+      if (!state.mintable || state.mintcost === 0n) return null;
+    } else {
+      if (!state.burnable || state.burncost === 0n || state.cooldown !== 0n)
+        return null;
+    }
+
+    // `unit` is the marginal-rate reference (rate for exactly 1e18), so it uses the ungated
+    // conversion: the 1e18 probe can sit below the wrapper's mint dust floor (mintcost > 1e18)
+    // even when the venue is fully live, and a 0 unit would read as unpriceable.
+    const unit = this.convert(buy, side, WAD, state);
+    const prices = amounts.map(a => this.compute(buy, side, a, state));
+
+    return [
+      {
+        unit,
+        prices,
+        data: {},
+        poolAddresses: [this.config.adapterAddress],
+        exchange: this.dexKey,
+        // Fork-measured end-to-end: mint ~141k, redeem ~213k.
+        gasCost: buy ? 150_000 : 220_000,
+        poolIdentifiers: [this.dexKey],
+      },
+    ];
+  }
+
+  // Returns estimated gas cost of calldata for this DEX in multiSwap.
+  getCalldataGasCost(_poolPrices: PoolPrices<WstGBPData>): number | number[] {
+    // swapExactInput/Output: selector + (tokenIn, amount, bound, recipient, deadline).
+    return (
+      CALLDATA_GAS_COST.DEX_OVERHEAD +
+      CALLDATA_GAS_COST.LENGTH_SMALL +
+      CALLDATA_GAS_COST.ADDRESS +
+      CALLDATA_GAS_COST.AMOUNT +
+      CALLDATA_GAS_COST.AMOUNT +
+      CALLDATA_GAS_COST.ADDRESS +
+      CALLDATA_GAS_COST.FULL_WORD
+    );
+  }
+
+  // Augustus v5 path is not supported (v6-only integration).
+  getAdapterParam(
+    _srcToken: string,
+    _destToken: string,
+    _srcAmount: string,
+    _destAmount: string,
+    _data: WstGBPData,
+    _side: SwapSide,
+  ): AdapterExchangeParam {
+    return {
+      targetExchange: this.config.adapterAddress,
+      payload: '0x',
+      networkFee: '0',
+    };
+  }
+
+  async getDexParam(
+    srcToken: Address,
+    _destToken: Address,
+    srcAmount: NumberAsString,
+    destAmount: NumberAsString,
+    recipient: Address,
+    _data: WstGBPData,
+    side: SwapSide,
+  ): Promise<DexExchangeParam> {
+    // Direction is inferred on-chain from tokenIn; slippage is enforced by Augustus on the final
+    // received amount, so the venue-level bounds are the loosest valid ones. The adapter's deadline
+    // guard is satisfied with MAX_UINT (Augustus applies the order deadline).
+    const exchangeData =
+      side === SwapSide.SELL
+        ? WstGBP.adapterIface.encodeFunctionData('swapExactInput', [
+            srcToken,
+            srcAmount,
+            '1',
+            recipient,
+            MAX_UINT,
+          ])
+        : WstGBP.adapterIface.encodeFunctionData('swapExactOutput', [
+            srcToken,
+            destAmount,
+            srcAmount,
+            recipient,
+            MAX_UINT,
+          ]);
+
+    return {
+      needWrapNative: this.needWrapNative,
+      dexFuncHasRecipient: true,
+      exchangeData,
+      targetExchange: this.config.adapterAddress,
+      spender: this.config.adapterAddress,
+      returnAmountPos:
+        side === SwapSide.SELL
+          ? extractReturnAmountPosition(WstGBP.adapterIface, 'swapExactInput')
+          : undefined,
+    };
+  }
+
+  // Returns the single virtual pool when the token is one of the pair.
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    _limit: number,
+  ): Promise<PoolLiquidity[]> {
+    const token = tokenAddress.toLowerCase();
+    const { tGBPAddress, wstGBPAddress } = this.config;
+    if (token !== tGBPAddress && token !== wstGBPAddress) return [];
+
+    const blockNumber = await this.dexHelper.web3Provider.eth.getBlockNumber();
+    const state = await this.getState(blockNumber);
+
+    // Depth in tGBP terms: buys limited by remaining wstGBP capacity (valued at mintcost), sells by
+    // the wrapper's tGBP reserve. Follow the PSM convention of 2x the min side; tGBP is a GBP stable,
+    // so tGBP ~= USD understates liquidity slightly (conservative).
+    const headroom =
+      state.capacity > state.totalSupply
+        ? state.capacity - state.totalSupply
+        : 0n;
+    const buyDepthTGBP = (headroom * state.mintcost) / WAD;
+    const minSide =
+      buyDepthTGBP < state.tGBPReserve ? buyDepthTGBP : state.tGBPReserve;
+    const liquidityUSD = 2 * (Number(minSide) / Number(WAD));
+
+    return [
+      {
+        exchange: this.dexKey,
+        address: this.config.adapterAddress,
+        connectorTokens: [
+          {
+            decimals: 18,
+            address: token === tGBPAddress ? wstGBPAddress : tGBPAddress,
+          },
+        ],
+        liquidityUSD,
+      },
+    ];
+  }
+}

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -219,6 +219,14 @@ export const Tokens: {
       address: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84',
       decimals: 18,
     },
+    tGBP: {
+      address: '0x27f6c8289550fCE67f6B50BeD1F519966aFE5287',
+      decimals: 18,
+    },
+    wstGBP: {
+      address: '0x57C3571f10767E49C9d7b60feb6c67804783B7aE',
+      decimals: 18,
+    },
     SDEX: {
       address: '0x5DE8ab7E27f6E7A1fFf3E5B337584Aa43961BEeF',
       decimals: 18,
@@ -2071,6 +2079,8 @@ export const Holders: {
     STETH: '0x6663613FbD927cE78abBF7F5Ca7e2c3FE0d96d18',
     SUSHI: '0x8a108e4761386c94b8d2f98A5fFe13E472cFE76a',
     wstETH: '0x3c22ec75ea5D745c78fc84762F7F1E6D82a2c5BF',
+    tGBP: '0x3361b8223d8463354AC9a8d7c650C55477F9965b',
+    wstGBP: '0x7500c95cC6f6c9eDe82d4043F9337715360D6B6a',
     WETH: '0x6B44ba0a126a2A1a8aa6cD1AdeeD002e141Bcd44',
     USDT: '0xAf64555DDD61FcF7D094824dd9B4eBea165aFc5b',
     XAUT: '0xc4e161e8d8a4bc4ac762ab33a28bbac5474203d7',


### PR DESCRIPTION
## Description

Adds **wstGBP**, an atomic tGBP ↔ wstGBP wrapper venue on Ethereum mainnet (dex key: `wstGBP`).

### Background

wstGBP is a yield-bearing wrapper over tGBP (a GBP stablecoin). The wrapper is a
PSM-like, constant-price market: buys of wstGBP execute at the wrapper's `mintcost()`
(ask) and sells at `burncost()` (bid), both WAD-scaled tGBP-per-wstGBP prices read
from the protocol's own oracle. Prices are size-independent within the depth caps and
ratchet slowly (weekly NAV steps).

Swaps route through the ownerless, inventory-free `WsgemDirectAdapter`
(plain approve → swap with a recipient param; direction inferred from `tokenIn`;
exact-in and exact-out supported).

### Pricing logic

- **Buy exact-in:** `wstGBPOut = tGBPIn * 1e18 / mintcost` (floor)
- **Buy exact-out:** `tGBPIn = ceil(wstGBPOut * mintcost / 1e18)`
- **Sell exact-in:** `tGBPOut = wstGBPIn * burncost / 1e18` (floor)
- **Sell exact-out:** `wstGBPIn = ceil(tGBPOut * 1e18 / burncost)`

Amounts are gated by the wrapper's on-chain constraints, so quotes are never
fillable-but-reverting:
- mint dust floor (`tGBPIn >= mintcost`) and redeem dust floor (`wstGBPIn >= 1e18`)
- buy depth capped by remaining supply capacity — checked against the *minted*
  amount (≥ requested on exact-out, since input rounds up)
- sell depth capped by the wrapper's tGBP reserve (full claim must be funded)
- availability gates: `mintable` / `burnable` flags, paused oracle (price = 0),
  and non-zero redemption `cooldown` disables sells (payout would be deferred)

State is a handful of view reads refreshed per pricing tick with a 60s shared cache
(same pattern as wstETH). No events to track. v6-only integration (no v5 adapters).

### Contract addresses (mainnet)

| Contract | Address |
|---|---|
| WsgemDirectAdapter (swap venue) | `0xBE402d34f31133B1Dc00277f24F8ce2d975CBe23` |
| wstGBP (wrapper token) | `0x57C3571f10767E49C9d7b60feb6c67804783B7aE` |
| tGBP (underlying) | `0x27f6c8289550fCE67f6B50BeD1F519966aFE5287` |

All contracts are verified. The adapter's `quoteExactInput`/`quoteExactOutput` views
mirror execution exactly and are used as ground truth in the integration tests.

### Protocol documentation

- https://docs.wstgbp.com

### Tests

- `wstgbp-integration.test.ts` — passing against live mainnet; prices match the
  adapter's on-chain quotes exactly for all four quadrants (buy/sell × exact-in/out)
- `wstgbp-math.test.ts` — offline unit tests pinning capacity-boundary, reserve,
  dust-floor, and availability-gate edge cases (17 cases)
- `wstgbp-e2e.test.ts` / `wstgbp-gas-estimation.test.ts` — standard Tenderly-based
  suites (require simulator credentials)

Run with: `pnpm test-integration wstgbp`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New swap venue with custom pricing and fillability rules; incorrect quotes or gates could misroute trades or show fillable quotes that revert on-chain, though scope is isolated to one pair and mainnet.
> 
> **Overview**
> Adds a new **`wstGBP`** DEX on Ethereum mainnet so ParaSwap can route **tGBP ↔ wstGBP** through the **WsgemDirectAdapter**, alongside existing wrapper-style venues like wstETH.
> 
> Pricing mirrors the on-chain wrapper: **mintcost** / **burncost** oracle rates with **convert** + **compute** gating (dust floors, supply **capacity**, tGBP **reserve**, **mintable** / **burnable**, zero prices, redemption **cooldown**). State comes from batched view reads with a 60s cache. Swaps are **v6-only** via `swapExactInput` / `swapExactOutput` on the adapter (`getAdapters` returns null).
> 
> **`WstGBP`** is registered in `src/dex/index.ts`. Mainnet contract addresses and **tGBP** / **wstGBP** e2e token + holder entries are added. Coverage includes integration tests against adapter quotes, offline math edge cases, and standard e2e / gas suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c90ade0e33e041b32ec51cdd5e5edd6c7af4cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->