### PR TITLE
fix: use POSIX sh syntax in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-if ! command -v git-secrets &> /dev/null
+if ! command -v git-secrets > /dev/null 2>&1
 then
     echo "git-secrets is not installed. Please run 'brew install git-secrets' or visit https://github.com/awslabs/git-secrets#installing-git-secrets"
     exit 1
@@ -9,7 +9,7 @@ fi
 
 
 HOOK_FLAG=".husky/.git-secrets-installed"
-if [[ ! -f "$HOOK_FLAG" ]]; then
+if [ ! -f "$HOOK_FLAG" ]; then
     git-secrets --register-aws > /dev/null
     git secrets --add -- 'ghp_[A-Za-z0-9_]\{36\}'
     git secrets --add -- 'github_pat_[A-Za-z0-9_]\{36\}'


### PR DESCRIPTION
The pre-commit hook declares `#!/bin/sh` but uses two bash-only constructs (`&>` redirection and `[[ ]]`). On macOS, /bin/sh is bash so this works; on Debian/Ubuntu, `/bin/sh` is dash, which misparses `command -v git-secrets &> /dev/null` as a background job — so every commit fails with a spurious "git-secrets is not installed" even when it's installed. (Husky v8 also re-executes hooks with `sh -e`, so Linux users can't work around it by changing the shebang.) This replaces both constructs with POSIX equivalents; behavior on macOS is unchanged.
 
Note for reviewers committing changes to this file: the registered 'BEGIN' pattern matches its own registration line, so committing edits to .husky/pre-commit requires a one-time git secrets --add --allowed -- '\.husky/pre-commit:.*BEGIN' (or --no-verify).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell portability fix in a dev hook only; no runtime app, auth, or data-path changes.
> 
> **Overview**
> The **`.husky/pre-commit`** hook is declared as `#!/bin/sh` but previously used bash-only syntax. On Linux (where `sh` is often **dash**), `command -v git-secrets &> /dev/null` was misparsed as a background job, causing false **"git-secrets is not installed"** failures on every commit even when git-secrets was present.
> 
> This change swaps **`&>`** for **`> /dev/null 2>&1`** and **`[[ ! -f ... ]]`** for **`[ ! -f ... ]`**. Behavior on macOS is unchanged; Linux/Husky `sh -e` execution should now run the hook correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f94fb073b5484db8f8720b1be04b88769faf3fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->