### PR TITLE
fix(DEXLIB-193): cap quoted output by real adjusted supply (TokenReservesTooLow mirror) for FluidDexLite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/fluid-dex-lite/fluid-dex-lite-math.ts
+++ b/src/dex/fluid-dex-lite/fluid-dex-lite-math.ts
@@ -524,7 +524,7 @@ export function calculateSwap(
 }
 
 // Calculate swap for exact input (SELL side)
-function calculateSwapIn(
+export function calculateSwapIn(
   amountIn: bigint,
   swap0To1: boolean,
   unpackedVars: UnpackedDexVariables,
@@ -585,6 +585,19 @@ function calculateSwapIn(
     amountOut = numerator / denominator;
   }
 
+  // The pool can only pay out what it actually holds: imaginary reserves (the
+  // concentrated-curve extension) can vastly exceed the real adjusted
+  // supplies, and the contract rejects such swaps with
+  // TokenReservesTooLow(amountOut, tokenAdjustedSupply) — see fluid-contracts
+  // dexLite/core/coreInternals.sol. Mirror it so we never quote an unfillable
+  // swap (both amounts are in the adjusted precision here).
+  const outTotalSupplyAdjusted = swap0To1
+    ? unpackedVars.token1TotalSupplyAdjusted
+    : unpackedVars.token0TotalSupplyAdjusted;
+  if (amountOut > outTotalSupplyAdjusted) {
+    throw new FluidDexLiteMathError('Token reserves too low');
+  }
+
   // Apply decimal adjustments to output
   if (swap0To1) {
     const token1Decimals = unpackedVars.token1Decimals;
@@ -613,7 +626,7 @@ function calculateSwapIn(
 }
 
 // Calculate swap for exact output (BUY side)
-function calculateSwapOut(
+export function calculateSwapOut(
   amountOut: bigint,
   swap0To1: boolean,
   unpackedVars: UnpackedDexVariables,
@@ -654,6 +667,17 @@ function calculateSwapOut(
     : token0ImaginaryReserves;
   if (adjustedAmountOut > relevantReserves / 2n) {
     throw new FluidDexLiteMathError('Excessive swap amount');
+  }
+
+  // The pool can only pay out what it actually holds — matches the contract's
+  // TokenReservesTooLow(amountOut, tokenAdjustedSupply) check (fluid-contracts
+  // dexLite/core/coreInternals.sol); imaginary reserves can vastly exceed the
+  // real adjusted supplies.
+  const outTotalSupplyAdjusted = swap0To1
+    ? unpackedVars.token1TotalSupplyAdjusted
+    : unpackedVars.token0TotalSupplyAdjusted;
+  if (adjustedAmountOut > outTotalSupplyAdjusted) {
+    throw new FluidDexLiteMathError('Token reserves too low');
   }
 
   // Reverse constant product formula: amountIn = (amountOut * reserveIn) / (reserveOut - amountOut)

--- a/src/dex/fluid-dex-lite/fluid-dex-lite-reserves-cap.test.ts
+++ b/src/dex/fluid-dex-lite/fluid-dex-lite-reserves-cap.test.ts
@@ -1,0 +1,89 @@
+/**
+ * FluidDexLite pricing must not quote swaps whose output exceeds the pool's
+ * real (adjusted) token supply: imaginary reserves — the concentrated-curve
+ * extension — can vastly exceed what the pool actually holds, and the contract
+ * rejects such swaps with TokenReservesTooLow(amountOut, tokenAdjustedSupply)
+ * (fluid-contracts dexLite/core/coreInternals.sol).
+ *
+ * Regression for a prod route (mainnet USDT->USDC, ~$800k) that was quoted at
+ * an 87% ratio and reverted on-chain with TokenReservesTooLow.
+ */
+import { SwapSide } from '../../constants';
+import {
+  calculateSwapIn,
+  calculateSwapOut,
+  FluidDexLiteMathError,
+} from './fluid-dex-lite-math';
+import { UnpackedDexVariables } from './types';
+
+const baseVars = (overrides: Partial<UnpackedDexVariables>) =>
+  ({
+    fee: 0n,
+    revenueCut: 0n,
+    rebalancingStatus: 0n,
+    centerPriceShiftActive: false,
+    centerPrice: 0n,
+    centerPriceContractAddress: 0n,
+    rangePercentShiftActive: false,
+    upperPercent: 0n,
+    lowerPercent: 0n,
+    thresholdPercentShiftActive: false,
+    upperShiftThresholdPercent: 0n,
+    lowerShiftThresholdPercent: 0n,
+    token0Decimals: 6n,
+    token1Decimals: 6n,
+    token0TotalSupplyAdjusted: 10n ** 15n,
+    token1TotalSupplyAdjusted: 10n ** 15n,
+    ...overrides,
+  } as UnpackedDexVariables);
+
+// Deep, concentrated curve: imaginary reserves far above real supplies.
+const IMAGINARY = 10n ** 18n;
+
+// 10 tokens at 6 decimals -> 1e10 in the 9-decimals adjusted precision.
+const AMOUNT_RAW = 10n * 10n ** 6n;
+
+describe('FluidDexLite reserves cap (TokenReservesTooLow mirror)', () => {
+  describe('calculateSwapIn (SELL)', () => {
+    it('throws when the computed output exceeds the output token supply', () => {
+      const vars = baseVars({ token1TotalSupplyAdjusted: 10n ** 9n }); // 1 token
+      expect(() =>
+        calculateSwapIn(AMOUNT_RAW, true, vars, IMAGINARY, IMAGINARY),
+      ).toThrow(new FluidDexLiteMathError('Token reserves too low'));
+    });
+
+    it('checks the OTHER side for 1->0 swaps', () => {
+      const vars = baseVars({ token0TotalSupplyAdjusted: 10n ** 9n });
+      expect(() =>
+        calculateSwapIn(AMOUNT_RAW, false, vars, IMAGINARY, IMAGINARY),
+      ).toThrow(new FluidDexLiteMathError('Token reserves too low'));
+    });
+
+    it('quotes normally when the pool holds enough', () => {
+      const vars = baseVars({});
+      const res = calculateSwapIn(AMOUNT_RAW, true, vars, IMAGINARY, IMAGINARY);
+      expect(res.amountOut).toBeGreaterThan(0n);
+    });
+  });
+
+  describe('calculateSwapOut (BUY)', () => {
+    it('throws when the requested output exceeds the output token supply', () => {
+      const vars = baseVars({ token1TotalSupplyAdjusted: 10n ** 9n });
+      expect(() =>
+        calculateSwapOut(AMOUNT_RAW, true, vars, IMAGINARY, IMAGINARY),
+      ).toThrow(new FluidDexLiteMathError('Token reserves too low'));
+    });
+
+    it('quotes normally when the pool holds enough', () => {
+      const vars = baseVars({});
+      const res = calculateSwapOut(
+        AMOUNT_RAW,
+        true,
+        vars,
+        IMAGINARY,
+        IMAGINARY,
+      );
+      expect(res.amountIn).toBeGreaterThan(0n);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

FluidDexLite pricing quotes swaps the pool cannot actually fill: the math caps swap size against **imaginary reserves** (the concentrated-curve extension) but never checks the computed output against the pool's **real adjusted token supply**. Since imaginary reserves can vastly exceed real holdings, a large swap prices "fine" off-chain and then reverts on-chain with `TokenReservesTooLow(amountOut, tokenAdjustedSupply)` — the check in `fluid-contracts` `dexLite/core/coreInternals.sol`:

```solidity
if (token1AdjustedSupply_ < amountOut_) {
    revert TokenReservesTooLow(amountOut_, token1AdjustedSupply_);
}
```

Found via the revertable-fallback replay campaign: a stored mainnet route carried a FluidDexLite quote for ~$800k USDT→USDC (at an 87% output ratio — already deep into draining the pool) that reverted with exactly this error when executed (Tenderly: [force-revert sim](https://dashboard.tenderly.co/paraswap/paraswap/simulator/e3844f36-0881-40eb-bafd-cba61cf0afc5), revert data `0x473f499f…`, decoded `TokenReservesTooLow`).

## Change

`fluid-dex-lite-math.ts`: after computing the swap output in the adjusted precision, throw `FluidDexLiteMathError('Token reserves too low')` when it exceeds the output token's `TotalSupplyAdjusted` — in both `calculateSwapIn` (SELL) and `calculateSwapOut` (BUY), mirroring the contract exactly (both sides compared in adjusted units, supply taken before the swap's own inflow is added, same as the contract). Oversized amounts now price to null instead of producing unfillable quotes.

`calculateSwapIn`/`calculateSwapOut` are exported for direct unit testing.

## Tests

- New `fluid-dex-lite-reserves-cap.test.ts`: 5 unit tests — output-over-supply throws for both directions (SELL) and for BUY, and ample-supply pools still quote normally.
- Existing `fluid-dex-lite-insert-amounts` + `fluid-dex-lite-integration` suites: unchanged results. (One pre-existing integration flake — `should handle swap simulation when pools exist` asserts stablecoin output ≤ input, but the live USDC/USDT pool currently quotes 1.000562; fails identically without this change.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap quoting for FluidDexLite (routing/pricing correctness); behavior is stricter and aligned with the contract, but large trades may disappear from quotes where they previously appeared.
> 
> **Overview**
> **FluidDexLite** swap math now rejects quotes whose output exceeds the pool’s **real adjusted token supply**, matching on-chain `TokenReservesTooLow` instead of relying only on imaginary reserves (which can be much larger than actual holdings).
> 
> In `fluid-dex-lite-math.ts`, **`calculateSwapIn`** and **`calculateSwapOut`** throw `FluidDexLiteMathError('Token reserves too low')` when computed or requested output (in adjusted precision) is above the output side’s `token*TotalSupplyAdjusted`. Both helpers are **exported** for unit tests.
> 
> Adds **`fluid-dex-lite-reserves-cap.test.ts`** (SELL/BUY, both directions, ample supply). Package version **5.0.5 → 5.0.7**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c5c3f744bfa139c5893829e72a12388b15666c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->