### PR TITLE
fix(DEXLIB-194): insert runtime fromAmount on WETH-src unwrap path so msg.value matches calldata amount

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/fluid-dex/fluid-dex-e2e.test.ts
+++ b/src/dex/fluid-dex/fluid-dex-e2e.test.ts
@@ -18,6 +18,7 @@ function testForNetwork(
   tokenBSymbol: string,
   tokenAAmount: string,
   tokenBAmount: string,
+  sides: SwapSide[] = [SwapSide.SELL, SwapSide.BUY],
 ) {
   const provider = new StaticJsonRpcProvider(
     generateConfig(network).privateHttpProvider,
@@ -31,10 +32,13 @@ function testForNetwork(
   const dexHelper = new DummyDexHelper(network);
   const fluidDex = new FluidDex(network, dexKey, dexHelper);
 
-  const sideToContractMethods = new Map([
+  const allSideContractMethods: [SwapSide, ContractMethod[]][] = [
     [SwapSide.SELL, [ContractMethod.swapExactAmountIn]],
     [SwapSide.BUY, [ContractMethod.swapExactAmountOut]],
-  ]);
+  ];
+  const sideToContractMethods = new Map(
+    allSideContractMethods.filter(([side]) => sides.includes(side)),
+  );
 
   describe(`${network}`, () => {
     sideToContractMethods.forEach((contractMethods, side) =>
@@ -116,6 +120,8 @@ describe('FluidDex E2E', () => {
 
     // WETH is priced via the native-ETH pools: the executor unwraps WETH
     // before the swap and wraps the native output after (needUnwrapNative).
+    // SELL only: WETH-src BUY is deliberately unpriced (no rewrap path for
+    // the pool's ETH refund of the unused max input).
     describe('WETH -> wstETH', () => {
       const tokenASymbol: string = 'wstETH';
       const tokenBSymbol: string = 'WETH';
@@ -130,6 +136,7 @@ describe('FluidDex E2E', () => {
         tokenBSymbol,
         tokenAAmount,
         tokenBAmount,
+        [SwapSide.SELL],
       );
     });
 

--- a/src/dex/fluid-dex/fluid-dex-e2e.test.ts
+++ b/src/dex/fluid-dex/fluid-dex-e2e.test.ts
@@ -114,6 +114,25 @@ describe('FluidDex E2E', () => {
       );
     });
 
+    // WETH is priced via the native-ETH pools: the executor unwraps WETH
+    // before the swap and wraps the native output after (needUnwrapNative).
+    describe('WETH -> wstETH', () => {
+      const tokenASymbol: string = 'wstETH';
+      const tokenBSymbol: string = 'WETH';
+
+      const tokenAAmount: string = '100000000000000';
+      const tokenBAmount: string = '3500000000000000000';
+
+      testForNetwork(
+        network,
+        dexKey,
+        tokenASymbol,
+        tokenBSymbol,
+        tokenAAmount,
+        tokenBAmount,
+      );
+    });
+
     describe('USDC -> USDT', () => {
       const tokenASymbol: string = 'USDC';
       const tokenBSymbol: string = 'USDT';

--- a/src/dex/fluid-dex/fluid-dex.ts
+++ b/src/dex/fluid-dex/fluid-dex.ts
@@ -531,22 +531,28 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
 
     const swap0To1 =
       pool.token0.toLowerCase() === this.normalizeTokenAddress(srcToken);
+    const isWethDest = this.dexHelper.config.isWETH(destToken);
+
+    // WETH dest: the pool pays out native ETH; deliver it to the executor so
+    // its wrap-after step can pick it up, and report no recipient support so
+    // the wrapped output is forwarded like any executor-held result.
+    const swapRecipient = isWethDest ? executorAddress : recipient;
 
     if (side === SwapSide.SELL) {
-      args = [swap0To1, BigInt(srcAmount), BigInt(destAmount), recipient];
+      args = [swap0To1, BigInt(srcAmount), BigInt(destAmount), swapRecipient];
     } else {
       args = [
         swap0To1,
         (BigInt(destAmount) * 1000001n) / 1000000n, // 0.0001% increase target out amount when calling Fluid Dex as it is not 100% exact. Guarantees meeting reaching exact out amount condition
         BigInt(srcAmount),
-        recipient,
+        swapRecipient,
       ];
     }
     const swapData = this.fluidDexPoolIface.encodeFunctionData(method, args);
     return {
       needWrapNative: this.needWrapNative,
       needUnwrapNative: true,
-      dexFuncHasRecipient: true,
+      dexFuncHasRecipient: !isWethDest,
       exchangeData: swapData,
       targetExchange: pool!.address,
       returnAmountPos,

--- a/src/dex/fluid-dex/fluid-dex.ts
+++ b/src/dex/fluid-dex/fluid-dex.ts
@@ -131,7 +131,8 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     );
 
     if (!this.dexHelper.config.isSlave) {
-      void this.updateReserves();
+      // Await the first fetch so pricing is usable as soon as init returns.
+      await this.updateReserves();
 
       if (!this.reserveUpdateIntervalTask) {
         this.reserveUpdateIntervalTask = setInterval(
@@ -172,8 +173,19 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     side: SwapSide,
     blockNumber: number,
   ): Promise<string[]> {
+    if (this.isUnsupportedWethBuy(srcToken.address, side)) return [];
+
     const pools = this.getPoolsByTokenPair(srcToken.address, destToken.address);
     return pools.map(pool => pool.id);
+  }
+
+  // Exact-out swaps send the slippage-scaled max input as msg.value and the
+  // pool refunds the unused ETH to the executor — with a WETH-paying user
+  // there is no path returning that raw-ETH refund, so the user would be
+  // silently overcharged. Keep WETH-src BUY unpriced until the executor
+  // supports rewrapping the refund.
+  private isUnsupportedWethBuy(srcToken: Address, side: SwapSide): boolean {
+    return side === SwapSide.BUY && this.dexHelper.config.isWETH(srcToken);
   }
 
   // Fluid pools hold native ETH, never WETH. Map WETH to the native address so
@@ -212,6 +224,8 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     limitPools?: string[],
   ): Promise<null | ExchangePrices<FluidDexData>> {
     try {
+      if (this.isUnsupportedWethBuy(srcToken.address, side)) return null;
+
       const srcTokenAddress = this.normalizeTokenAddress(srcToken.address);
       const destTokenAddress = this.normalizeTokenAddress(destToken.address);
 

--- a/src/dex/fluid-dex/fluid-dex.ts
+++ b/src/dex/fluid-dex/fluid-dex.ts
@@ -9,7 +9,7 @@ import {
   DexExchangeParam,
   Logger,
 } from '../../types';
-import { SwapSide, Network } from '../../constants';
+import { SwapSide, Network, ETHER_ADDRESS } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { IDex } from '../idex';
 import { IDexHelper } from '../../dex-helper';
@@ -176,9 +176,18 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     return pools.map(pool => pool.id);
   }
 
+  // Fluid pools hold native ETH, never WETH. Map WETH to the native address so
+  // WETH-denominated routes price against the native pools; the executor
+  // unwraps/wraps around the swap (see needUnwrapNative in getDexParam).
+  private normalizeTokenAddress(tokenAddress: Address): Address {
+    return this.dexHelper.config.isWETH(tokenAddress)
+      ? ETHER_ADDRESS
+      : tokenAddress.toLowerCase();
+  }
+
   getPoolsByTokenPair(srcToken: Address, destToken: Address): FluidDexPool[] {
-    const srcAddress = srcToken.toLowerCase();
-    const destAddress = destToken.toLowerCase();
+    const srcAddress = this.normalizeTokenAddress(srcToken);
+    const destAddress = this.normalizeTokenAddress(destToken);
 
     // A pair must have 2 different tokens.
     if (srcAddress === destAddress) return [];
@@ -203,8 +212,10 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     limitPools?: string[],
   ): Promise<null | ExchangePrices<FluidDexData>> {
     try {
-      if (srcToken.address.toLowerCase() === destToken.address.toLowerCase())
-        return null;
+      const srcTokenAddress = this.normalizeTokenAddress(srcToken.address);
+      const destTokenAddress = this.normalizeTokenAddress(destToken.address);
+
+      if (srcTokenAddress === destTokenAddress) return null;
 
       // Get the pools to use.
       let pools = this.getPoolsByTokenPair(srcToken.address, destToken.address);
@@ -253,7 +264,7 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
           const prices = amounts.map(amount => {
             if (side === SwapSide.SELL) {
               return this.swapIn(
-                srcToken.address.toLowerCase() === pool.token0.toLowerCase(),
+                srcTokenAddress === pool.token0.toLowerCase(),
                 amount,
                 currentPoolReserves.collateralReserves,
                 currentPoolReserves.debtReserves,
@@ -266,7 +277,7 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
               );
             } else {
               return this.swapOut(
-                srcToken.address.toLowerCase() === pool.token0.toLowerCase(),
+                srcTokenAddress === pool.token0.toLowerCase(),
                 amount,
                 currentPoolReserves.collateralReserves,
                 currentPoolReserves.debtReserves,
@@ -362,7 +373,7 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
     limit: number,
   ): Promise<PoolLiquidity[]> {
     try {
-      const normalizedTokenAddress = tokenAddress.toLowerCase();
+      const normalizedTokenAddress = this.normalizeTokenAddress(tokenAddress);
 
       const relevantPools = this.pools.filter(
         pool =>
@@ -442,10 +453,21 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
                   token1LiquidityUSD,
                 ];
 
+          const connectorTokens = [connectorToken];
+          // Native-ETH pools are also reachable with WETH (see
+          // normalizeTokenAddress), so advertise the wrapped connector too.
+          if (connectorToken.address === ETHER_ADDRESS) {
+            connectorTokens.push({
+              ...connectorToken,
+              address:
+                this.dexHelper.config.data.wrappedNativeTokenAddress.toLowerCase(),
+            });
+          }
+
           poolLiquidity.push({
             exchange: this.dexKey,
             address: pool.address,
-            connectorTokens: [connectorToken],
+            connectorTokens,
             liquidityUSD,
           });
         } catch (error) {
@@ -493,32 +515,23 @@ export class FluidDex extends SimpleExchange implements IDex<FluidDexData> {
         `${this.dexKey}-${this.network}: Pool with id: ${data.poolId} was not found`,
       );
 
+    const swap0To1 =
+      pool.token0.toLowerCase() === this.normalizeTokenAddress(srcToken);
+
     if (side === SwapSide.SELL) {
-      if (pool!.token0.toLowerCase() !== srcToken.toLowerCase()) {
-        args = [false, BigInt(srcAmount), BigInt(destAmount), recipient];
-      } else {
-        args = [true, BigInt(srcAmount), BigInt(destAmount), recipient];
-      }
+      args = [swap0To1, BigInt(srcAmount), BigInt(destAmount), recipient];
     } else {
-      if (pool!.token0.toLowerCase() !== srcToken.toLowerCase()) {
-        args = [
-          false,
-          (BigInt(destAmount) * 1000001n) / 1000000n, // 0.0001% increase target out amount when calling Fluid Dex as it is not 100% exact. Guarantees meeting reaching exact out amount condition
-          BigInt(srcAmount),
-          recipient,
-        ];
-      } else {
-        args = [
-          true,
-          (BigInt(destAmount) * 1000001n) / 1000000n, // 0.0001% increase target out amount when calling Fluid Dex as it is not 100% exact. Guarantees meeting reaching exact out amount condition
-          BigInt(srcAmount),
-          recipient,
-        ];
-      }
+      args = [
+        swap0To1,
+        (BigInt(destAmount) * 1000001n) / 1000000n, // 0.0001% increase target out amount when calling Fluid Dex as it is not 100% exact. Guarantees meeting reaching exact out amount condition
+        BigInt(srcAmount),
+        recipient,
+      ];
     }
     const swapData = this.fluidDexPoolIface.encodeFunctionData(method, args);
     return {
       needWrapNative: this.needWrapNative,
+      needUnwrapNative: true,
       dexFuncHasRecipient: true,
       exchangeData: swapData,
       targetExchange: pool!.address,

--- a/src/executor/Executor01BytecodeBuilder.ts
+++ b/src/executor/Executor01BytecodeBuilder.ts
@@ -107,8 +107,14 @@ export class Executor01BytecodeBuilder extends ExecutorBytecodeBuilder<
     // check WETH src balance (should be 0) after. Some DEXes don't have a 1:1
     // ETH -> custom_ETH rate.
     if (isWETHSrc) {
+      // Also insert the runtime fromAmount into the dex calldata when the dex
+      // supports it: value is always the threaded amount, and split slicing can
+      // drift a wei from the quoted amount — dexes that require
+      // msg.value == amountIn (e.g. FluidDex) revert on the mismatch otherwise.
       dexFlag =
-        Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP;
+        sendEthButSupportsInsertFromAmount && !forcePreventInsertFromAmount
+          ? Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_PLUS_INSERT_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP // 14
+          : Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP; // 5
     } else if (isWETHDest) {
       // DEX returns native ETH; wrap after. Check ETH balance post-swap so the
       // wrap amount can be picked up from it.
@@ -227,8 +233,14 @@ export class Executor01BytecodeBuilder extends ExecutorBytecodeBuilder<
     }
 
     if (isWETHSrc) {
+      // Also insert the runtime fromAmount into the dex calldata when the dex
+      // supports it: value is always the threaded amount, and split slicing can
+      // drift a wei from the quoted amount — dexes that require
+      // msg.value == amountIn (e.g. FluidDex) revert on the mismatch otherwise.
       dexFlag =
-        Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP;
+        sendEthButSupportsInsertFromAmount && !forcePreventInsertFromAmount
+          ? Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_PLUS_INSERT_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP // 14
+          : Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP; // 5
     } else if (isWETHDest) {
       dexFlag = forcePreventInsertFromAmount
         ? Flag.DONT_INSERT_FROM_AMOUNT_CHECK_ETH_BALANCE_AFTER_SWAP

--- a/src/executor/Executor02BytecodeBuilder.ts
+++ b/src/executor/Executor02BytecodeBuilder.ts
@@ -134,8 +134,14 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
     // check WETH src balance (should be 0) after. Some DEXes don't have a 1:1
     // ETH -> custom_ETH rate.
     if (isWETHSrc) {
+      // Also insert the runtime fromAmount into the dex calldata when the dex
+      // supports it: value is always the threaded amount, and split slicing can
+      // drift a wei from the quoted amount — dexes that require
+      // msg.value == amountIn (e.g. FluidDex) revert on the mismatch otherwise.
       dexFlag =
-        Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP;
+        sendEthButSupportsInsertFromAmount && !forcePreventInsertFromAmount
+          ? Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_PLUS_INSERT_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP // 14
+          : Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP; // 5
     } else if (isWETHDest) {
       dexFlag = forcePreventInsertFromAmount
         ? Flag.DONT_INSERT_FROM_AMOUNT_CHECK_ETH_BALANCE_AFTER_SWAP
@@ -290,8 +296,14 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
     // check WETH src balance (should be 0) after. Some DEXes don't have a 1:1
     // ETH -> custom_ETH rate.
     if (isWETHSrcUnwrap) {
+      // Also insert the runtime fromAmount into the dex calldata when the dex
+      // supports it: value is always the threaded amount, and split slicing can
+      // drift a wei from the quoted amount — dexes that require
+      // msg.value == amountIn (e.g. FluidDex) revert on the mismatch otherwise.
       dexFlag =
-        Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP;
+        sendEthButSupportsInsertFromAmount && !forcePreventInsertFromAmount
+          ? Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_PLUS_INSERT_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP // 14
+          : Flag.SEND_ETH_EQUAL_TO_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP; // 5
     } else if (isWETHDestWrap) {
       dexFlag = forcePreventInsertFromAmount
         ? Flag.DONT_INSERT_FROM_AMOUNT_CHECK_ETH_BALANCE_AFTER_SWAP

--- a/src/generic-swap-transaction-builder.ts
+++ b/src/generic-swap-transaction-builder.ts
@@ -226,47 +226,72 @@ export class GenericSwapTransactionBuilder {
               executorAddress,
             );
 
-            let dexParams: DexExchangeParam;
-            if (newDex) {
-              dexParams = await this.fetchRemoteDexParam({
-                dexKey: newDex.key,
-                srcToken,
-                destToken,
-                srcAmount: side === SwapSide.BUY ? se.srcAmount : srcAmount,
-                destAmount,
-                recipient,
-                data: se.data,
-                side,
-                executorAddress,
-                options: getDexParamOptions,
-              });
+            const callGetDexParam = async (
+              recipientArg: Address,
+            ): Promise<DexExchangeParam> => {
+              let params: DexExchangeParam;
+              if (newDex) {
+                params = await this.fetchRemoteDexParam({
+                  dexKey: newDex.key,
+                  srcToken,
+                  destToken,
+                  srcAmount: side === SwapSide.BUY ? se.srcAmount : srcAmount,
+                  destAmount,
+                  recipient: recipientArg,
+                  data: se.data,
+                  side,
+                  executorAddress,
+                  options: getDexParamOptions,
+                });
 
-              // The local `newDexs[*].needWrapNative` is the single source of
-              // truth: it already drove `getDexCallsParams` (and therefore
-              // `wethDeposit`/`wethWithdraw`). Keep the executor builder in
-              // lockstep so the wrap accounting and the bytecode wiring
-              // can't diverge.
-              dexParams.needWrapNative = newDex.needWrapNative;
-            } else {
-              dexParams = await dex!.getDexParam!(
-                srcToken,
-                destToken,
-                side === SwapSide.BUY ? se.srcAmount : srcAmount, // in other case we would not be able to make insert from amount on Ex3
-                destAmount,
-                recipient,
-                se.data,
-                side,
-                executorAddress,
-                getDexParamOptions,
-              );
-            }
+                // The local `newDexs[*].needWrapNative` is the single source of
+                // truth: it already drove `getDexCallsParams` (and therefore
+                // `wethDeposit`/`wethWithdraw`). Keep the executor builder in
+                // lockstep so the wrap accounting and the bytecode wiring
+                // can't diverge.
+                params.needWrapNative = newDex.needWrapNative;
+              } else {
+                params = await dex!.getDexParam!(
+                  srcToken,
+                  destToken,
+                  side === SwapSide.BUY ? se.srcAmount : srcAmount, // in other case we would not be able to make insert from amount on Ex3
+                  destAmount,
+                  recipientArg,
+                  se.data,
+                  side,
+                  executorAddress,
+                  getDexParamOptions,
+                );
+              }
 
-            if (typeof dexParams.needWrapNative === 'function') {
-              dexParams.needWrapNative = dexParams.needWrapNative(
-                priceRoute,
-                swap,
-                se,
-              );
+              if (typeof params.needWrapNative === 'function') {
+                params.needWrapNative = params.needWrapNative(
+                  priceRoute,
+                  swap,
+                  se,
+                );
+              }
+
+              return params;
+            };
+
+            let dexParams = await callGetDexParam(recipient);
+
+            // A needUnwrapNative dex on a WETH-dest hop outputs raw ETH, and
+            // the executor's wrap-after machinery expects that ETH ON the
+            // executor — but whether the dex needs the unwrap treatment is
+            // only known from the returned param, after the recipient was
+            // already chosen. If it went elsewhere, re-encode with the
+            // executor as recipient and let the standard !dexFuncHasRecipient
+            // epilogue forward the wrapped output.
+            if (
+              dexParams.needUnwrapNative &&
+              dexParams.dexFuncHasRecipient &&
+              this.dexAdapterService.dexHelper.config.isWETH(swap.destToken) &&
+              recipient.toLowerCase() !== executorAddress.toLowerCase()
+            ) {
+              dexParams = await callGetDexParam(executorAddress);
+              dexParams.dexFuncHasRecipient = false;
             }
 
             return {

--- a/src/generic-swap-transaction-builder.ts
+++ b/src/generic-swap-transaction-builder.ts
@@ -226,72 +226,47 @@ export class GenericSwapTransactionBuilder {
               executorAddress,
             );
 
-            const callGetDexParam = async (
-              recipientArg: Address,
-            ): Promise<DexExchangeParam> => {
-              let params: DexExchangeParam;
-              if (newDex) {
-                params = await this.fetchRemoteDexParam({
-                  dexKey: newDex.key,
-                  srcToken,
-                  destToken,
-                  srcAmount: side === SwapSide.BUY ? se.srcAmount : srcAmount,
-                  destAmount,
-                  recipient: recipientArg,
-                  data: se.data,
-                  side,
-                  executorAddress,
-                  options: getDexParamOptions,
-                });
+            let dexParams: DexExchangeParam;
+            if (newDex) {
+              dexParams = await this.fetchRemoteDexParam({
+                dexKey: newDex.key,
+                srcToken,
+                destToken,
+                srcAmount: side === SwapSide.BUY ? se.srcAmount : srcAmount,
+                destAmount,
+                recipient,
+                data: se.data,
+                side,
+                executorAddress,
+                options: getDexParamOptions,
+              });
 
-                // The local `newDexs[*].needWrapNative` is the single source of
-                // truth: it already drove `getDexCallsParams` (and therefore
-                // `wethDeposit`/`wethWithdraw`). Keep the executor builder in
-                // lockstep so the wrap accounting and the bytecode wiring
-                // can't diverge.
-                params.needWrapNative = newDex.needWrapNative;
-              } else {
-                params = await dex!.getDexParam!(
-                  srcToken,
-                  destToken,
-                  side === SwapSide.BUY ? se.srcAmount : srcAmount, // in other case we would not be able to make insert from amount on Ex3
-                  destAmount,
-                  recipientArg,
-                  se.data,
-                  side,
-                  executorAddress,
-                  getDexParamOptions,
-                );
-              }
+              // The local `newDexs[*].needWrapNative` is the single source of
+              // truth: it already drove `getDexCallsParams` (and therefore
+              // `wethDeposit`/`wethWithdraw`). Keep the executor builder in
+              // lockstep so the wrap accounting and the bytecode wiring
+              // can't diverge.
+              dexParams.needWrapNative = newDex.needWrapNative;
+            } else {
+              dexParams = await dex!.getDexParam!(
+                srcToken,
+                destToken,
+                side === SwapSide.BUY ? se.srcAmount : srcAmount, // in other case we would not be able to make insert from amount on Ex3
+                destAmount,
+                recipient,
+                se.data,
+                side,
+                executorAddress,
+                getDexParamOptions,
+              );
+            }
 
-              if (typeof params.needWrapNative === 'function') {
-                params.needWrapNative = params.needWrapNative(
-                  priceRoute,
-                  swap,
-                  se,
-                );
-              }
-
-              return params;
-            };
-
-            let dexParams = await callGetDexParam(recipient);
-
-            // A needUnwrapNative dex on a WETH-dest hop outputs raw ETH, and
-            // the executor's wrap-after machinery expects that ETH ON the
-            // executor — but whether the dex needs the unwrap treatment is
-            // only known from the returned param, after the recipient was
-            // already chosen. If it went elsewhere, re-encode with the
-            // executor as recipient and let the standard !dexFuncHasRecipient
-            // epilogue forward the wrapped output.
-            if (
-              dexParams.needUnwrapNative &&
-              dexParams.dexFuncHasRecipient &&
-              this.dexAdapterService.dexHelper.config.isWETH(swap.destToken) &&
-              recipient.toLowerCase() !== executorAddress.toLowerCase()
-            ) {
-              dexParams = await callGetDexParam(executorAddress);
-              dexParams.dexFuncHasRecipient = false;
+            if (typeof dexParams.needWrapNative === 'function') {
+              dexParams.needWrapNative = dexParams.needWrapNative(
+                priceRoute,
+                swap,
+                se,
+              );
             }
 
             return {


### PR DESCRIPTION
## Summary

Extracted from #1202 so it can merge independently, plus FluidDex WETH support that activates the fixed path.

### Fix: WETH-src unwrap wei-drift (flag 14)

The `isWETHSrc` / unwrap flag branch in both Executor01 and Executor02 bytecode builders hardcoded `SEND_ETH_EQUAL_TO_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP` (flag 5), which sends the runtime-threaded amount as `msg.value` but leaves the statically-quoted amount in the dex calldata. With split slicing the two can drift a wei apart, and dexes that require `msg.value == amountIn` (e.g. FluidDex) revert on the mismatch.

When the dex sets `sendEthButSupportsInsertFromAmount` (and insertion isn't force-prevented), both builders now use the `SEND_ETH_EQUAL_TO_FROM_AMOUNT_PLUS_INSERT_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP` variant (flag 14), so the runtime amount is inserted into the calldata as well.

### FluidDex: WETH pricing + needUnwrapNative

Fluid pools hold native ETH, never WETH. WETH-denominated queries are now normalized to the native ETH address so they match the native pools (pool lookup, pricing direction, top pools; ETH-side connectors also advertise WETH). `getDexParam` sets `needUnwrapNative: true` so the executor unwraps WETH before the swap and wraps the native output after. Combined with `sendEthButSupportsInsertFromAmount` this makes FluidDex the first TS dex to exercise the flag-14 path above.

On WETH-dest hops the pool pays out native ETH, so `getDexParam` encodes the executor as the swap recipient and reports `dexFuncHasRecipient: false` — the executor's wrap-after step picks the ETH up and the standard epilogue forwards the wrapped output (same shape as Lido/dETH/EtherFi).

On chains where the wrapped native isn't WETH (e.g. Plasma/WXPL), WETH is a plain ERC20 and is not remapped — existing WETH pools keep matching exactly.

### Also fixed

`FluidDex.initializePricing` fired the first reserves fetch without awaiting it, so pricing returned nothing until the liquidity-proxy state landed (flaky e2e / cold-start window). The first fetch is now awaited.

## Known limitation: WETH-src exact-out (BUY)

Exact-out swaps send the slippage-scaled max input as `msg.value` and Fluid refunds the unused ETH to the executor. With a WETH-paying user there is no path returning that raw-ETH refund, so the user would be silently overcharged by the full slippage margin (verified on a Tenderly sim: overcharge = exactly maxIn/100 at 100 bps). FluidDex therefore returns no pools/prices for WETH-src BUY until the executor supports rewrapping the refund. Executor03 was intentionally left untouched (consistent with #1202's scope).

## Tests

Live e2e on mainnet (Tenderly):

- `WETH -> wstETH` SELL both directions **pass**: WETH-src exercises unwrap + flag 14 on Executor01; WETH-dest exercises executor-recipient delivery + wrap-after + forward.
- Native `ETH -> wstETH` SELL controls still pass.
- Pre-existing (unrelated, also red on master): Fluid BUY e2e fails the 10-wei exact-out assertion because Fluid intentionally overshoots the target by 0.0001% (`amountOut * 1000001 / 1000000` in `getDexParam`); affects native ETH controls identically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap execution bytecode flags and FluidDex pricing/execution for WETH↔native ETH; incorrect flags or recipient handling could revert swaps or mis-route funds, though scope is limited to FluidDex and existing WETH unwrap paths.
> 
> **Overview**
> **Executor01/02:** On the WETH-source unwrap path, when a DEX sets `sendEthButSupportsInsertFromAmount`, builders now use flag **14** (send ETH + insert runtime `fromAmount` into calldata) instead of always flag **5**, so `msg.value` and quoted `amountIn` stay aligned when split routing drifts by a wei.
> 
> **FluidDex:** WETH is normalized to native ETH for pool lookup, pricing, and liquidity connectors; `getDexParam` enables `needUnwrapNative`, `sendEthButSupportsInsertFromAmount`, executor-as-recipient on WETH-dest, and **WETH-src BUY** is explicitly unpriced (no ETH refund rewrap). First reserve fetch in `initializePricing` is **awaited** to avoid empty quotes on cold start.
> 
> **Tests:** Mainnet e2e adds **WETH → wstETH** SELL-only; helper accepts optional `sides` filter. Version bump **5.0.7 → 5.0.8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad99cc8534cb22241e6aeb989d1032279f0c9e57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->