### PR TITLE
feat(flowstate): add FlowState C1 pools as a liquidity source

### DIFF
--- a/src/dex/flowstate/config.ts
+++ b/src/dex/flowstate/config.ts
@@ -1,0 +1,52 @@
+import { DexParams } from './types';
+import { DexConfigMap } from '../../types';
+import { Network } from '../../constants';
+
+// FlowState buyFromPool router. CREATE2-deterministic → same address on every
+// chain, and it is the address that on-chain evidence (deposits + buys + the
+// indexer) confirms is live today. NOTE: the team flagged newer per-chain
+// contracts (0x445124…) as a possible migration target — if/when that lands,
+// only this constant changes (same 4-arg buyFromPool ABI either way).
+const FLOWSTATE_ROUTER = '0x93B7C8A5d4F70Bc6158c2A03D77b1B3134224Bb1';
+
+// 1inch spot price aggregator. Same address across ETH/BSC/Base/Arbitrum
+// (from the contract's PriceOracleAddresses.getPriceOracleAddress()).
+const ONE_INCH_ORACLE = '0x00000000000D6FFc74A8feb35aF5827bf57f6786';
+
+const GRAPHQL_URL = 'https://gql.poolparty.market/v1/graphql';
+
+// '' = no reseller code (buyFromPool accepts it and skips the reseller cut).
+// Swap in the Velora code once it's registered on-chain (verifyReseller) — no
+// other change needed.
+const RESELLER_CODE = '';
+
+export const FLOWSTATE_GAS_COST = 120_000;
+
+export const FlowStateConfig: DexConfigMap<DexParams> = {
+  FlowState: {
+    [Network.MAINNET]: {
+      router: FLOWSTATE_ROUTER,
+      oracle: ONE_INCH_ORACLE,
+      graphqlURL: GRAPHQL_URL,
+      resellerCode: RESELLER_CODE,
+    },
+    [Network.BSC]: {
+      router: FLOWSTATE_ROUTER,
+      oracle: ONE_INCH_ORACLE,
+      graphqlURL: GRAPHQL_URL,
+      resellerCode: RESELLER_CODE,
+    },
+    [Network.BASE]: {
+      router: FLOWSTATE_ROUTER,
+      oracle: ONE_INCH_ORACLE,
+      graphqlURL: GRAPHQL_URL,
+      resellerCode: RESELLER_CODE,
+    },
+    [Network.ARBITRUM]: {
+      router: FLOWSTATE_ROUTER,
+      oracle: ONE_INCH_ORACLE,
+      graphqlURL: GRAPHQL_URL,
+      resellerCode: RESELLER_CODE,
+    },
+  },
+};

--- a/src/dex/flowstate/flowstate-integration.test.ts
+++ b/src/dex/flowstate/flowstate-integration.test.ts
@@ -1,0 +1,216 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Contract } from 'ethers';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide, ETHER_ADDRESS } from '../../constants';
+import { Token } from '../../types';
+import { FlowState } from './flowstate';
+
+/*
+  Live integration test — hits our Hasura + a public RPC (read-only, no
+  Tenderly, no simulated swaps). It anchors on whatever active pool currently
+  has the most on-chain, 1inch-priceable inventory on the network, so it
+  exercises real pricing instead of a hardcoded (ephemeral) pool.
+
+  What it proves:
+   - Discovery: getPoolIdentifiers finds the live pool for ETH -> TOKEN.
+   - Pricing parity: the module's multicall reads (oracle rate + pool balance)
+     and its price curve are byte-identical to an INDEPENDENT direct-RPC
+     recompute of the exact contract formula (price*1e18/weiPerToken, capped by
+     inventory).
+   - Inventory cap: amounts above the pool's balance price to 0 (never overfill).
+   - getTopPoolsForToken surfaces the pool with a native-ETH connector.
+
+  If no priceable inventory exists at run time, the pricing assertions skip
+  (with a clear log) rather than failing — pools are ephemeral.
+
+  Run: npx jest src/dex/flowstate/flowstate-integration.test.ts
+*/
+
+jest.setTimeout(180000);
+
+const DEX_KEY = 'FlowState';
+const ORACLE = '0x00000000000D6FFc74A8feb35aF5827bf57f6786';
+const GRAPHQL_URL = 'https://gql.poolparty.market/v1/graphql';
+const E18 = 10n ** 18n;
+
+const ORACLE_ABI = [
+  'function getRateToEth(address srcToken, bool useWrappers) view returns (uint256)',
+];
+const ERC20_ABI = ['function balanceOf(address) view returns (uint256)'];
+
+type LivePool = {
+  poolAddress: string;
+  tokenAddress: string;
+  tokenSymbol: string;
+  tokenDecimals: number;
+  rate: bigint; // 1inch weiPerToken @ blockNumber
+  balance: bigint; // on-chain token balance of the pool @ blockNumber
+};
+
+// Find the active pool with the largest on-chain, oracle-priceable inventory.
+async function pickLivePool(
+  dexHelper: DummyDexHelper,
+  network: number,
+  blockNumber: number,
+): Promise<LivePool | null> {
+  const query = `{ Pool(where: { poolStatus: {_eq: "ACTIVE"}, poolType: {_in: ["2","3"]}, publicAmountAvailable: {_gt: "0"}, chainID: {_eq: ${network}} }, limit: 40) { poolAddress tokenAddress tokenSymbol tokenDecimals publicAmountAvailable } }`;
+
+  const resp = await dexHelper.httpRequest.post<{
+    data?: { Pool?: any[] };
+  }>(GRAPHQL_URL, { query });
+  const candidates = resp?.data?.Pool ?? [];
+  console.log(
+    `[pickLivePool] ${candidates.length} inventory-bearing pools on chain ${network}`,
+  );
+
+  const oracle = new Contract(ORACLE, ORACLE_ABI, dexHelper.provider);
+  let best: LivePool | null = null;
+
+  for (const p of candidates) {
+    try {
+      const rate = BigInt(
+        (
+          await oracle.getRateToEth(p.tokenAddress, false, {
+            blockTag: blockNumber,
+          })
+        ).toString(),
+      );
+      if (rate === 0n) continue; // not priceable by 1inch
+      const erc20 = new Contract(p.tokenAddress, ERC20_ABI, dexHelper.provider);
+      const balance = BigInt(
+        (
+          await erc20.balanceOf(p.poolAddress, { blockTag: blockNumber })
+        ).toString(),
+      );
+      if (balance === 0n) continue;
+      // Prefer the pool whose inventory is worth the most ETH (balance*rate).
+      if (!best || balance * rate > best.balance * best.rate) {
+        best = {
+          poolAddress: p.poolAddress,
+          tokenAddress: p.tokenAddress,
+          tokenSymbol: p.tokenSymbol,
+          tokenDecimals: p.tokenDecimals,
+          rate,
+          balance,
+        };
+      }
+    } catch (e) {
+      // token not routable by the oracle on this chain — skip quietly
+    }
+  }
+  return best;
+}
+
+describe('FlowState (integration, live)', () => {
+  // Arbitrum carries most active pools; the module + config are chain-agnostic.
+  const network = Network.ARBITRUM;
+  const dexHelper = new DummyDexHelper(network);
+  const flowState = new FlowState(network, DEX_KEY, dexHelper);
+  const ETH: Token = { address: ETHER_ADDRESS, decimals: 18 };
+
+  let blockNumber: number;
+  let live: LivePool | null;
+  let identifier: string;
+
+  beforeAll(async () => {
+    blockNumber = await dexHelper.provider.getBlockNumber();
+    live = await pickLivePool(dexHelper, network, blockNumber);
+    if (!live) {
+      console.warn(
+        `[FlowState] No priceable inventory on chain ${network} @ block ${blockNumber} — pricing assertions will skip.`,
+      );
+      return;
+    }
+    identifier = `${DEX_KEY}_${live.poolAddress.toLowerCase()}`;
+    const unitTokensPerEth = (E18 * E18) / live.rate; // tokens (smallest units) per 1 ETH
+    const humanPerEth =
+      Number(unitTokensPerEth) / 10 ** live.tokenDecimals;
+    console.log(
+      `[FlowState] Anchor ${live.tokenSymbol} pool=${live.poolAddress} ` +
+        `balance=${live.balance} rate=${live.rate} ` +
+        `=> ~${humanPerEth.toLocaleString()} ${live.tokenSymbol}/ETH`,
+    );
+  });
+
+  it('discovers the live pool for ETH -> TOKEN SELL', async () => {
+    if (!live) return;
+    const token: Token = {
+      address: live.tokenAddress,
+      decimals: live.tokenDecimals,
+    };
+    const ids = await flowState.getPoolIdentifiers(
+      ETH,
+      token,
+      SwapSide.SELL,
+      blockNumber,
+    );
+    expect(ids).toContain(identifier);
+  });
+
+  it('prices ETH -> TOKEN identically to an independent on-chain recompute, capped by inventory', async () => {
+    if (!live) return;
+    const token: Token = {
+      address: live.tokenAddress,
+      decimals: live.tokenDecimals,
+    };
+
+    // capEth = ETH-wei needed to buy the entire pool balance at the oracle rate.
+    const capEth = (live.balance * live.rate) / E18;
+    if (capEth === 0n) {
+      console.warn('[FlowState] Inventory rounds to <1 wei of ETH — skipping.');
+      return;
+    }
+
+    const amounts = [
+      0n,
+      capEth / 5n,
+      capEth / 2n,
+      (capEth * 9n) / 10n,
+      capEth,
+      capEth + capEth / 2n, // deliberately over the cap
+    ];
+
+    const poolPrices = await flowState.getPricesVolume(
+      ETH,
+      token,
+      amounts,
+      SwapSide.SELL,
+      blockNumber,
+      [identifier],
+    );
+    expect(poolPrices).not.toBeNull();
+
+    const entry = poolPrices!.find(
+      pp => pp.poolAddresses![0].toLowerCase() === live!.poolAddress.toLowerCase(),
+    );
+    expect(entry).toBeDefined();
+
+    // Independent recompute using the EXACT contract formula (publicPool.sol:444).
+    const expected = amounts.map(a => {
+      if (a === 0n) return 0n;
+      const out = (a * E18) / live!.rate;
+      return out > live!.balance ? 0n : out;
+    });
+
+    expect(entry!.prices).toEqual(expected);
+    // At least one real, fillable quote…
+    expect(entry!.prices.some(x => x > 0n)).toBe(true);
+    // …and the over-cap request must be unfillable (0), never an overfill.
+    expect(entry!.prices[entry!.prices.length - 1]).toBe(0n);
+  });
+
+  it('surfaces the pool via getTopPoolsForToken with a native-ETH connector', async () => {
+    if (!live) return;
+    const top = await flowState.getTopPoolsForToken(live.tokenAddress, 10);
+    const entry = top.find(
+      p => p.address.toLowerCase() === live!.poolAddress.toLowerCase(),
+    );
+    expect(entry).toBeDefined();
+    expect(entry!.connectorTokens[0].address.toLowerCase()).toBe(
+      ETHER_ADDRESS.toLowerCase(),
+    );
+  });
+});

--- a/src/dex/flowstate/flowstate.test.ts
+++ b/src/dex/flowstate/flowstate.test.ts
@@ -66,7 +66,17 @@ describe('FlowState (unit)', () => {
       expect(ids).toEqual([]);
     });
 
-    it('getPoolIdentifiers is empty when dest is ETH (TOKEN -> ETH, the sell side we do NOT serve)', async () => {
+    it('getPoolIdentifiers is empty for TOKEN -> ETH (the sell side we do NOT serve)', async () => {
+      const ids = await flowState.getPoolIdentifiers(
+        TOKEN,
+        ETH,
+        SwapSide.SELL,
+        blockNumber,
+      );
+      expect(ids).toEqual([]);
+    });
+
+    it('getPoolIdentifiers is empty for ETH -> ETH (dest must be an ERC20)', async () => {
       const ids = await flowState.getPoolIdentifiers(
         ETH,
         ETH,

--- a/src/dex/flowstate/flowstate.test.ts
+++ b/src/dex/flowstate/flowstate.test.ts
@@ -1,0 +1,171 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { Interface } from '@ethersproject/abi';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Network, SwapSide, ETHER_ADDRESS } from '../../constants';
+import { BI_POWS } from '../../bigint-constants';
+import { Token } from '../../types';
+import { FlowState } from './flowstate';
+import { FlowStateData } from './types';
+
+/*
+  Deterministic unit tests — no network, no live pools. These pin the two
+  things that MUST stay correct for safety:
+
+  1. Additivity guards: the module returns []/null for everything except an
+     exact-input NATIVE-ETH -> ERC20 SELL. This is what guarantees adding
+     FlowState can never perturb an existing Velora route (Kyber included) —
+     it only ever contributes a new source on the one shape it serves.
+
+  2. getDexParam calldata: buyFromPool(pool, amount, resellerCode, recipient)
+     with amount RE-DERIVED from srcAmount at the quoted 1inch rate (matching
+     the contract's checkAmounts band), plus the exact V6 execution flags
+     (native ETH, recipient-aware, NO insert-from-amount patch = Flag 9).
+*/
+
+const DEX_KEY = 'FlowState';
+const ROUTER = '0x93B7C8A5d4F70Bc6158c2A03D77b1B3134224Bb1';
+
+const FLOWSTATE_IFACE = new Interface([
+  'function buyFromPool(address pool, uint256 amount, string resellerCode, address buyer) payable',
+]);
+
+// An arbitrary ERC20 (WETH address reused purely as a non-native placeholder).
+const TOKEN: Token = {
+  address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+  decimals: 18,
+};
+const ETH: Token = { address: ETHER_ADDRESS, decimals: 18 };
+
+describe('FlowState (unit)', () => {
+  const network = Network.MAINNET;
+  const dexHelper = new DummyDexHelper(network);
+  const flowState = new FlowState(network, DEX_KEY, dexHelper);
+  const blockNumber = 0;
+
+  describe('additivity guards', () => {
+    it('getPoolIdentifiers is empty for BUY (exact-output)', async () => {
+      const ids = await flowState.getPoolIdentifiers(
+        ETH,
+        TOKEN,
+        SwapSide.BUY,
+        blockNumber,
+      );
+      expect(ids).toEqual([]);
+    });
+
+    it('getPoolIdentifiers is empty for non-ETH src (TOKEN -> TOKEN)', async () => {
+      const ids = await flowState.getPoolIdentifiers(
+        TOKEN,
+        TOKEN,
+        SwapSide.SELL,
+        blockNumber,
+      );
+      expect(ids).toEqual([]);
+    });
+
+    it('getPoolIdentifiers is empty when dest is ETH (TOKEN -> ETH, the sell side we do NOT serve)', async () => {
+      const ids = await flowState.getPoolIdentifiers(
+        ETH,
+        ETH,
+        SwapSide.SELL,
+        blockNumber,
+      );
+      expect(ids).toEqual([]);
+    });
+
+    it('getPricesVolume returns null for BUY', async () => {
+      const prices = await flowState.getPricesVolume(
+        ETH,
+        TOKEN,
+        [0n, BI_POWS[18]],
+        SwapSide.BUY,
+        blockNumber,
+      );
+      expect(prices).toBeNull();
+    });
+
+    it('getPricesVolume returns null for non-ETH src', async () => {
+      const prices = await flowState.getPricesVolume(
+        TOKEN,
+        TOKEN,
+        [0n, BI_POWS[18]],
+        SwapSide.SELL,
+        blockNumber,
+      );
+      expect(prices).toBeNull();
+    });
+
+    it('getPricesVolume declines when isFirstSwap === false (cannot be an intermediate hop)', async () => {
+      const prices = await flowState.getPricesVolume(
+        ETH,
+        TOKEN,
+        [0n, BI_POWS[18]],
+        SwapSide.SELL,
+        blockNumber,
+        undefined, // limitPools
+        undefined, // transferFees
+        false, // isFirstSwap — engine says we're not the route input
+      );
+      expect(prices).toBeNull();
+    });
+  });
+
+  describe('getDexParam (V6 calldata)', () => {
+    // rate = weiPerToken. 5e14 wei/token => 1 token costs 0.0005 ETH.
+    const rate = 5n * BI_POWS[14];
+    const data: FlowStateData = {
+      pool: '0xb2281ea3c4e92365abf12666c6057ba61ec41358',
+      resellerCode: '',
+      rate: rate.toString(),
+    };
+    const recipient = '0x1111111111111111111111111111111111111111';
+    const srcAmount = (3n * BI_POWS[18]).toString(); // 3 ETH in
+
+    const param = flowState.getDexParam(
+      ETHER_ADDRESS,
+      TOKEN.address,
+      srcAmount,
+      '0', // destAmount (min) is intentionally ignored by getDexParam
+      recipient,
+      data,
+      SwapSide.SELL,
+    );
+
+    it('sets the exact V6 execution flags (native ETH, recipient-aware, no insert-from-amount)', () => {
+      expect(param.needWrapNative).toBe(false);
+      expect(param.dexFuncHasRecipient).toBe(true);
+      expect(param.targetExchange.toLowerCase()).toBe(ROUTER.toLowerCase());
+      expect(param.returnAmountPos).toBeUndefined();
+      // Flag 9, NOT Flag 18: we must never patch an ETH amount into calldata.
+      expect(
+        (param as { sendEthButSupportsInsertFromAmount?: boolean })
+          .sendEthButSupportsInsertFromAmount,
+      ).toBeUndefined();
+    });
+
+    it('encodes buyFromPool with amount re-derived from srcAmount at the quoted rate', () => {
+      const decoded = FLOWSTATE_IFACE.decodeFunctionData(
+        'buyFromPool',
+        param.exchangeData,
+      );
+      // 3 ETH / (0.0005 ETH/token) = 6000 tokens
+      const expectedAmount = (3n * BI_POWS[18] * BI_POWS[18]) / rate;
+      expect(expectedAmount).toBe(6000n * BI_POWS[18]);
+      expect(decoded.pool.toLowerCase()).toBe(data.pool.toLowerCase());
+      expect(BigInt(decoded.amount.toString())).toBe(expectedAmount);
+      expect(decoded.resellerCode).toBe('');
+      expect(decoded.buyer.toLowerCase()).toBe(recipient.toLowerCase());
+    });
+
+    it('sends the buyer the tokens directly (buyer arg == recipient)', () => {
+      const decoded = FLOWSTATE_IFACE.decodeFunctionData(
+        'buyFromPool',
+        param.exchangeData,
+      );
+      expect(decoded.buyer.toLowerCase()).toBe(recipient.toLowerCase());
+    });
+  });
+});

--- a/src/dex/flowstate/flowstate.ts
+++ b/src/dex/flowstate/flowstate.ts
@@ -1,0 +1,332 @@
+import { Interface } from '@ethersproject/abi';
+import {
+  Token,
+  Address,
+  ExchangePrices,
+  PoolPrices,
+  AdapterExchangeParam,
+  PoolLiquidity,
+  DexExchangeParam,
+  Logger,
+  NumberAsString,
+  TransferFeeParams,
+} from '../../types';
+import { SwapSide, Network, ETHER_ADDRESS } from '../../constants';
+import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
+import { IDex } from '../idex';
+import { IDexHelper } from '../../dex-helper';
+import { SimpleExchange } from '../simple-exchange';
+import { getDexKeysWithNetwork, getBigIntPow, isETHAddress } from '../../utils';
+import { uint256ToBigInt } from '../../lib/decoders';
+import { MultiCallParams } from '../../lib/multi-wrapper';
+import { FlowStateData, DexParams } from './types';
+import { FlowStateConfig, FLOWSTATE_GAS_COST } from './config';
+
+// Minimal interfaces (human-readable ABIs) — self-contained, no ABI json files.
+const ORACLE_IFACE = new Interface([
+  'function getRateToEth(address srcToken, bool useWrappers) view returns (uint256)',
+]);
+const FLOWSTATE_IFACE = new Interface([
+  'function buyFromPool(address pool, uint256 amount, string resellerCode, address buyer) payable',
+]);
+
+type DiscoveredPool = {
+  poolAddress: Address;
+  tokenAddress: Address;
+  tokenDecimals: number;
+  publicAmountAvailable: string;
+  tokenSymbol: string;
+};
+
+const POOL_CACHE_TTL_S = 60;
+
+/**
+ * FlowState C1 pools as a Velora liquidity source.
+ *
+ * Shape: buyers spend NATIVE ETH to buy an ERC20 out of a C1 pool via
+ * `buyFromPool(pool, amount, resellerCode, buyer)` (payable). Pricing is the
+ * on-chain 1inch spot rate (the exact rate the contract's `checkAmounts` uses),
+ * flat/zero-slippage up to the pool's live inventory. Discovery is our Hasura.
+ *
+ * Direction: ETH -> TOKEN, exact-input SELL only. Everything else returns
+ * []/null, so this module can only ever ADD a route, never affect others.
+ */
+export class FlowState extends SimpleExchange implements IDex<FlowStateData> {
+  readonly hasConstantPriceLargeAmounts = false; // capped by pool inventory
+  readonly needWrapNative = false; // payable buyFromPool consumes native ETH directly
+  readonly isFeeOnTransferSupported = false;
+
+  public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
+    getDexKeysWithNetwork(FlowStateConfig);
+
+  logger: Logger;
+  private cfg: DexParams;
+  private poolCache: Record<
+    string,
+    { pools: DiscoveredPool[]; expiry: number }
+  > = {};
+
+  constructor(
+    readonly network: Network,
+    readonly dexKey: string,
+    readonly dexHelper: IDexHelper,
+  ) {
+    super(dexHelper, dexKey);
+    this.logger = dexHelper.getLogger(dexKey);
+    this.cfg = FlowStateConfig[dexKey][network];
+  }
+
+  // V6-only integration: no legacy V5 adapters.
+  getAdapters(_side: SwapSide): { name: string; index: number }[] | null {
+    return null;
+  }
+
+  private poolIdentifier(poolAddress: Address): string {
+    return `${this.dexKey}_${poolAddress.toLowerCase()}`;
+  }
+
+  // Active C1 pools that sell `tokenAddress` for ETH, from our Hasura. Cached
+  // briefly; on error we serve the last good snapshot rather than dropping out.
+  private async discoverPools(
+    tokenAddress: Address,
+  ): Promise<DiscoveredPool[]> {
+    const key = tokenAddress.toLowerCase();
+    const now = Math.floor(Date.now() / 1000);
+    const cached = this.poolCache[key];
+    if (cached && cached.expiry > now) return cached.pools;
+
+    const query = `{ Pool(where: { tokenAddress: {_ilike: "${key}"}, chainID: {_eq: ${this.network}}, poolStatus: {_eq: "ACTIVE"}, poolType: {_in: ["2","3"]} }, limit: 100) { poolAddress tokenAddress tokenDecimals publicAmountAvailable tokenSymbol } }`;
+
+    try {
+      const resp = await this.dexHelper.httpRequest.post<{
+        data?: { Pool?: DiscoveredPool[] };
+      }>(this.cfg.graphqlURL, { query });
+      const pools = (resp?.data?.Pool ?? []).filter(p => !!p.poolAddress);
+      this.poolCache[key] = { pools, expiry: now + POOL_CACHE_TTL_S };
+      return pools;
+    } catch (e) {
+      this.logger.error(`FlowState discoverPools failed for ${key}`, e);
+      return cached?.pools ?? [];
+    }
+  }
+
+  async getPoolIdentifiers(
+    srcToken: Token,
+    destToken: Token,
+    side: SwapSide,
+    _blockNumber: number,
+  ): Promise<string[]> {
+    if (side !== SwapSide.SELL) return []; // exact-input only
+    if (!isETHAddress(srcToken.address)) return []; // ETH -> TOKEN only
+    if (isETHAddress(destToken.address)) return [];
+    const pools = await this.discoverPools(destToken.address);
+    return pools.map(p => this.poolIdentifier(p.poolAddress));
+  }
+
+  async getPricesVolume(
+    srcToken: Token,
+    destToken: Token,
+    amounts: bigint[],
+    side: SwapSide,
+    blockNumber: number,
+    limitPools?: string[],
+    transferFees?: TransferFeeParams,
+    isFirstSwap?: boolean,
+  ): Promise<ExchangePrices<FlowStateData> | null> {
+    if (side !== SwapSide.SELL) return null;
+    if (!isETHAddress(srcToken.address)) return null;
+    if (isETHAddress(destToken.address)) return null;
+    // We can only be the ROUTE INPUT. Our calldata bakes a static token amount
+    // sized to the quoted ETH, and the contract re-validates it against the
+    // RUNTIME msg.value (±1%) at execution. As the first/only swap (incl.
+    // splits) msg.value is the user's fixed input and matches; as a non-first
+    // hop it is the prior hop's live output, which can drift >1% and revert
+    // (fail-closed). So decline when the pricing engine says we're not first.
+    // (isFirstSwap === swapIndex 0. When the flag is absent — undefined — we
+    // fall through and the non-first-hop case fails closed on-chain; see
+    // getDexParam. This guard can only ever ADD a decline, never break a swap.)
+    if (isFirstSwap === false) return null;
+
+    let pools = await this.discoverPools(destToken.address);
+    if (limitPools) {
+      const allow = new Set(limitPools);
+      pools = pools.filter(p => allow.has(this.poolIdentifier(p.poolAddress)));
+    }
+    if (!pools.length) return null;
+
+    // Read the exact fill inputs on-chain @ blockNumber: the 1inch rate the
+    // contract prices against, plus each pool's live token inventory.
+    const calls: MultiCallParams<bigint>[] = [
+      {
+        target: this.cfg.oracle,
+        callData: ORACLE_IFACE.encodeFunctionData('getRateToEth', [
+          destToken.address,
+          false,
+        ]),
+        decodeFunction: uint256ToBigInt,
+      },
+      ...pools.map(p => ({
+        target: destToken.address,
+        callData: this.erc20Interface.encodeFunctionData('balanceOf', [
+          p.poolAddress,
+        ]),
+        decodeFunction: uint256ToBigInt,
+      })),
+    ];
+
+    // tryAggregate (not aggregate): a token 1inch can't route reverts
+    // getRateToEth, and a broken token can revert balanceOf. All-or-nothing
+    // aggregate would throw the whole batch and disrupt the rest of the
+    // pricing run; per-call success flags let us degrade to "no quote".
+    const results = await this.dexHelper.multiWrapper.tryAggregate<bigint>(
+      false,
+      calls,
+      blockNumber,
+    );
+
+    // No oracle price => the contract's checkAmounts can never be satisfied.
+    const rateResult = results[0];
+    if (!rateResult.success || !rateResult.returnData) return null;
+    const rate = rateResult.returnData; // weiPerToken (1inch getRateToEth)
+    if (rate === 0n) return null;
+
+    const E18 = getBigIntPow(18);
+    const unit = (E18 * E18) / rate; // tokens out for exactly 1 ETH
+
+    const poolPrices: ExchangePrices<FlowStateData> = [];
+    pools.forEach((p, i) => {
+      const balResult = results[i + 1];
+      // balanceOf reverted (broken token) => treat as no inventory.
+      const balance =
+        balResult.success && balResult.returnData ? balResult.returnData : 0n;
+      if (balance === 0n) return; // nothing fillable — don't offer this pool
+
+      const prices = amounts.map(a => {
+        if (a === 0n) return 0n;
+        const out = (a * E18) / rate; // == publicPool.checkAmounts formula
+        return out > balance ? 0n : out; // cannot fill beyond live inventory
+      });
+      poolPrices.push({
+        prices,
+        unit,
+        data: {
+          pool: p.poolAddress,
+          resellerCode: this.cfg.resellerCode,
+          rate: rate.toString(),
+        },
+        exchange: this.dexKey,
+        gasCost: FLOWSTATE_GAS_COST,
+        poolAddresses: [p.poolAddress],
+        poolIdentifiers: [this.poolIdentifier(p.poolAddress)],
+      });
+    });
+
+    return poolPrices.length ? poolPrices : null;
+  }
+
+  getCalldataGasCost(
+    poolPrices: PoolPrices<FlowStateData>,
+  ): number | number[] {
+    // buyFromPool(address pool, uint256 amount, string resellerCode, address
+    // buyer): 4 head words (pool, amount, string offset, buyer) + string tail
+    // (1 length word + ceil(len/32) data words). resellerCode is '' by default
+    // (0 data words); size it from the actual code so a set code isn't
+    // under-counted.
+    const codeBytes = (poolPrices.data?.resellerCode ?? '').length;
+    const stringTailWords = 1 + Math.ceil(codeBytes / 32);
+    return (
+      CALLDATA_GAS_COST.DEX_OVERHEAD +
+      CALLDATA_GAS_COST.FULL_WORD * (4 + stringTailWords)
+    );
+  }
+
+  // V5 adapter path is unused (V6-only); return an inert stub (matches the
+  // repo convention for V6-only dexes — no adapter is ever registered because
+  // getAdapters returns null).
+  getAdapterParam(): AdapterExchangeParam {
+    return { targetExchange: '0x', payload: '0x', networkFee: '0' };
+  }
+
+  getDexParam(
+    _srcToken: Address,
+    _destToken: Address,
+    srcAmount: NumberAsString,
+    _destAmount: NumberAsString,
+    recipient: Address,
+    data: FlowStateData,
+    _side: SwapSide,
+  ): DexExchangeParam {
+    // Exact token OUT = ETH IN priced at the quote's 1inch rate — the value
+    // `checkAmounts` expects against msg.value (= srcAmount). We recompute here
+    // (not `_destAmount`, which is the slippage-reduced min and could break the
+    // contract's ±1% band).
+    //
+    // NON-FIRST-HOP LIMITATION: the V6 executor sends msg.value = the RUNTIME
+    // fromAmount. For the route input (single swap / first hop / splits) that is
+    // the user's fixed ETH and equals `srcAmount`, so this static token amount
+    // matches. As a *non-first* hop, msg.value is the prior hop's live output
+    // and can drift >1% from the quote, tripping checkAmounts — a fail-closed
+    // revert of that route only (no fund loss, no effect on other dexes).
+    // getPricesVolume declines when isFirstSwap === false; where the engine does
+    // not pass that flag this stays a documented fail-closed edge. The clean fix
+    // is contract-side: a buyFromPool variant that derives the token amount from
+    // msg.value on-chain, making any msg.value safe.
+    const amount = (BigInt(srcAmount) * getBigIntPow(18)) / BigInt(data.rate);
+
+    const exchangeData = FLOWSTATE_IFACE.encodeFunctionData('buyFromPool', [
+      data.pool,
+      amount.toString(),
+      data.resellerCode,
+      recipient, // buyer == recipient → tokens delivered straight to the user
+    ]);
+
+    return {
+      // Native ETH consumed directly by payable buyFromPool. The V6 executor
+      // sends msg.value = srcAmount via Flag 9 (SEND_ETH_EQUAL_TO_FROM_AMOUNT).
+      needWrapNative: false,
+      dexFuncHasRecipient: true,
+      exchangeData,
+      targetExchange: this.cfg.router,
+      // buyFromPool returns nothing → executor reads the recipient balance
+      // delta. And we intentionally DO NOT set
+      // sendEthButSupportsInsertFromAmount: our calldata has no ETH-amount arg
+      // to patch (that would be Flag 18, wrong for this ABI).
+      returnAmountPos: undefined,
+    };
+  }
+
+  async getTopPoolsForToken(
+    tokenAddress: Address,
+    limit: number,
+  ): Promise<PoolLiquidity[]> {
+    if (isETHAddress(tokenAddress)) return [];
+    const pools = await this.discoverPools(tokenAddress);
+
+    const liquidity = await Promise.all(
+      pools.map(async (p): Promise<PoolLiquidity> => {
+        let liquidityUSD = 0;
+        try {
+          liquidityUSD = await this.dexHelper.getTokenUSDPrice(
+            { address: p.tokenAddress, decimals: p.tokenDecimals },
+            BigInt(p.publicAmountAvailable || '0'),
+          );
+        } catch (e) {
+          this.logger.error(
+            `FlowState getTokenUSDPrice failed for ${p.tokenAddress}`,
+            e,
+          );
+        }
+        return {
+          exchange: this.dexKey,
+          address: p.poolAddress,
+          connectorTokens: [{ address: ETHER_ADDRESS, decimals: 18 }],
+          liquidityUSD,
+        };
+      }),
+    );
+
+    return liquidity
+      .sort((a, b) => b.liquidityUSD - a.liquidityUSD)
+      .slice(0, limit);
+  }
+}

--- a/src/dex/flowstate/types.ts
+++ b/src/dex/flowstate/types.ts
@@ -1,0 +1,15 @@
+import { Address } from '../../types';
+
+// Returned by getPricesVolume, consumed by getDexParam. Keep minimal.
+export type FlowStateData = {
+  pool: Address; // the C1 pool clone to buy from
+  resellerCode: string; // Velora fee-attribution code (may be '')
+  rate: string; // 1inch weiPerToken at quote time; getDexParam re-derives the exact token `amount` from srcAmount so it matches the contract's checkAmounts band
+};
+
+export type DexParams = {
+  router: Address; // FlowState contract exposing buyFromPool (0x93B7C8… today)
+  oracle: Address; // 1inch spot aggregator used on-chain to price the fill
+  graphqlURL: string; // Hasura endpoint for pool discovery
+  resellerCode: string; // '' = no reseller (safe default until Velora code is registered on-chain)
+};

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -107,6 +107,7 @@ import { Cap } from './cap/cap';
 import { PancakeSwapInfinity } from './pancakeswap-infinity/pancakeswap-infinity';
 import { Metric } from './metric/metric';
 import { Tessera } from './tessera/tessera';
+import { FlowState } from './flowstate/flowstate';
 
 const LegacyDexes = [
   CurveV2,
@@ -201,6 +202,7 @@ const Dexes = [
   Blackhole,
   BlackholeCL,
   Cap,
+  FlowState,
 ];
 
 export type LegacyDexConstructor = new (dexHelper: IDexHelper) => IDexTxBuilder<


### PR DESCRIPTION
# PR title

feat: add FlowState (C1 pools) as a liquidity source

# PR description

## FlowState - C1 pools as a liquidity source

Adds **FlowState** as a V6 DEX integration. FlowState runs on-chain "C1 pools"
that let buyers spend **native ETH** to buy an ERC-20 out of a pool at the
on-chain 1inch spot price. This PR lets Velora route ETH→token buys into them.

### How it works
- **Direction:** exact-input **SELL, native ETH → ERC-20 only.** Every other
  case (BUY, non-ETH src, ETH dest, token→token) returns `[]`/`null`, so the
  integration is strictly **additive** - it can only contribute a new source on
  the one shape it serves, never alter or break an existing route.
- **Pricing:** fills at the 1inch spot oracle (`getRateToEth`) - the exact rate
  the pool's on-chain `checkAmounts` uses - flat/zero-slippage, capped by the
  pool's live token balance. `getPricesVolume` reads rate + balances via
  `tryAggregate`, so an unpriceable token (oracle revert) or a broken
  `balanceOf` degrades to "no quote" instead of disrupting the pricing batch.
- **Execution:** `getDexParam` encodes `buyFromPool(pool, amount, resellerCode,
  recipient)` (payable). The token `amount` is re-derived from `srcAmount` at
  the quoted rate so it lands centered in the contract's ±1% `checkAmounts`
  band. Native ETH is consumed directly (`needWrapNative: false`,
  `dexFuncHasRecipient: true`, Flag 9 - no `insertFromAmount`).
- **Discovery:** active pools per token/chain from FlowState's indexer (Hasura).

### Chains
Ethereum, BSC, Base, Arbitrum. The 1inch oracle (`0x…6786`) and the
CREATE2 router (`0x93B7C8…`) are identical across all four (verified against the
contract's own `PriceOracleAddresses`).

### Tests
- **Unit** (deterministic, offline): additivity guards + `buyFromPool` calldata
  encoding + V6 flags.
- **Integration** (live, no Tenderly): discovers a live pool and asserts the
  module's multicall pricing is byte-identical to an independent on-chain
  recompute of the contract formula, capped by inventory.
  Run: `npx jest src/dex/flowstate`

### Known limitation (documented in `getDexParam`)
The pool takes native ETH via `msg.value` + a **static** token `amount`. As a
**non-first hop** consuming intermediate native ETH, `msg.value` is the prior
hop's runtime output and can drift >1% from the quote, tripping `checkAmounts`
and reverting **that route only** - fail-closed (no fund loss, no effect on
other DEXes). The single-hop ETH-buy path (the primary use case) is unaffected.
`getPricesVolume` declines when `isFirstSwap === false`.

**Open question for maintainers:** does the production pricing engine pass
`isFirstSwap` to `getPricesVolume`? The open-source `pricing-helper` passes 7
args (no `isFirstSwap`); if production passes it, the guard fully prevents the
non-first-hop case. If not, is there a preferred way for a payable/fixed-amount
source to opt out of intermediate placement? The clean long-term fix is
contract-side (a `buyFromPool` variant that derives the token amount from
`msg.value` on-chain, making any `msg.value` safe).

### Notes
- Pure dex-lib integration.
- `-e2e.test.ts` not included: it simulates swaps via a fork/Tenderly, which we
  validated manually instead. Happy to add it in-repo if you'd prefer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New routing path for native-ETH swaps with payable execution and contract ±1% amount checks; mis-pricing or multi-hop placement could cause route reverts, though guards and fail-closed behavior limit blast radius.
> 
> **Overview**
> Adds a new **FlowState** V6 DEX that routes **native ETH → ERC-20** exact-input buys through on-chain C1 pools via payable `buyFromPool`, and registers it on **Ethereum, BSC, Base, and Arbitrum**.
> 
> **Discovery & pricing:** Active pools come from FlowState’s Hasura GraphQL indexer (short TTL cache, stale snapshot on errors). Quotes use the on-chain 1inch `getRateToEth` rate plus live pool `balanceOf`, with `tryAggregate` so oracle/token failures drop to “no quote” instead of breaking the batch. Output is flat at the oracle rate and **capped at inventory** (over-size amounts price to `0`).
> 
> **Additive routing:** Every path except **SELL with native ETH source and ERC-20 dest** returns `[]`/`null`; `getPricesVolume` also returns `null` when `isFirstSwap === false` so the source is not used as a middle hop where static calldata vs runtime `msg.value` could revert.
> 
> **Execution:** `getDexParam` encodes `buyFromPool` with token `amount` recomputed from `srcAmount` and the quoted rate (not min-out), native ETH (Flag 9, no `insertFromAmount`), and tokens sent to the route recipient.
> 
> Unit tests lock additivity guards and calldata/flags; a live integration test checks discovery, pricing vs an independent on-chain formula, and `getTopPoolsForToken`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88b2bbde94c491ef42fd1695a458b6aae30c6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->