### PR TITLE
fix(DEXLIB-195): cap quotes for `WooFiV2`  by maxGamma and maxNotionalSwap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/woo-fi-v2/config.ts
+++ b/src/dex/woo-fi-v2/config.ts
@@ -70,7 +70,7 @@ export const WooFiV2Config: DexConfigMap<DexParams> = {
       wooPPV2Address: '0x5520385bFcf07Ec87C4c53A7d8d65595Dff69FA4',
       wooOracleV2Address: WOO_ORACLE_V2_ADDRESS,
       integrationHelperAddress: '0xC4E9B633685461E7B7A807D12a246C81f96F31B8',
-      // USDbC
+      // USDC (native)
       quoteToken: {
         address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
         decimals: 6,

--- a/src/dex/woo-fi-v2/woo-fi-v2-e2e.test.ts
+++ b/src/dex/woo-fi-v2/woo-fi-v2-e2e.test.ts
@@ -190,11 +190,15 @@ describe('WooFiV2 E2E', () => {
     const network = Network.BASE;
 
     const baseATokenSymbol = 'WETH';
-    const baseBTokenSymbol = 'USDbC';
+    // USDbC was delisted from the Base WooPP (reserve 0); cbBTC and WETH are
+    // the live base tokens (integration helper allBaseTokens).
+    const baseBTokenSymbol = 'cbBTC';
     const quoteTokenSymbol = 'USDC';
 
     const tokenBaseAAmount = '1000000000000000000';
-    const tokenBaseBAmount = '100000000';
+    // 0.01 cbBTC (8 decimals) — keeps the notional under the pool's maxGamma
+    // swap-size cap (~$10k at coeff 1e10).
+    const tokenBaseBAmount = '1000000';
 
     testForNetwork(
       network,

--- a/src/dex/woo-fi-v2/woo-fi-v2-gamma-cap.test.ts
+++ b/src/dex/woo-fi-v2/woo-fi-v2-gamma-cap.test.ts
@@ -1,0 +1,136 @@
+/**
+ * WooFiV2 pricing must not quote swaps above the pool's per-token swap-size
+ * caps: WooPPV2._calcQuoteAmountSellBase / _calcBaseAmountSellQuote revert
+ * with "WooPPV2: !gamma" (gamma = k * price * amount > maxGamma) and
+ * "WooPPV2: !maxNotionalValue" (notional > maxNotionalSwap) — both read from
+ * tokenInfos(baseToken), which the TS pricing already fetches but ignored.
+ *
+ * Regression for prod fallback routes (Base cbBTC->USDC, ~$21.5k) quoted fine
+ * by TS pricing but reverting on-chain with the !gamma custom error: the
+ * pool's maxGamma (1e14) capped swaps at ~$10k notional.
+ */
+import { WooFiV2Math } from './woo-fi-v2-math';
+import { PoolState } from './types';
+
+const USDC = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const CBBTC = '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf';
+
+const dummyLogger = {
+  error: () => {},
+  warn: () => {},
+  info: () => {},
+  debug: () => {},
+  trace: () => {},
+  log: () => {},
+} as any;
+
+// Real Base WooPP state at block 48681324 (route f9927d91).
+const CBBTC_PRICE = 6477825010912n; // $64,778.25, 8 price decimals
+const CBBTC_STATE = {
+  price: CBBTC_PRICE,
+  spread: 397000000000000n,
+  coeff: 10000000000n, // 1e10
+  woFeasible: true,
+};
+
+const makeState = (over: {
+  maxGamma: bigint;
+  maxNotionalSwap: bigint;
+}): PoolState => ({
+  tokenInfos: {
+    [CBBTC]: {
+      reserve: 72863500n,
+      feeRate: 5n,
+      maxGamma: over.maxGamma,
+      maxNotionalSwap: over.maxNotionalSwap,
+      capBal: 2n ** 190n,
+    },
+    [USDC]: {
+      reserve: 1000000000000n, // $1m
+      feeRate: 5n,
+      maxGamma: over.maxGamma,
+      maxNotionalSwap: over.maxNotionalSwap,
+      capBal: 2n ** 190n,
+    },
+  },
+  tokenStates: { [CBBTC]: { ...CBBTC_STATE } },
+  decimals: {
+    [CBBTC]: { priceDec: 10n ** 8n, quoteDec: 10n ** 6n, baseDec: 10n ** 8n },
+  },
+  oracleTimestamp: 0n,
+  isPaused: false,
+});
+
+// The failing prod amount: 0.332 cbBTC (~$21.5k) with the pool's real caps.
+const PROD_AMOUNT = 33205199n;
+const REAL_MAX_GAMMA = 100000000000000n; // 1e14
+const REAL_MAX_NOTIONAL = 200000000000n; // $200k, 6dp
+
+describe('WooFiV2 swap-size caps (!gamma / !maxNotionalValue mirror)', () => {
+  const makeMath = (over: { maxGamma: bigint; maxNotionalSwap: bigint }) => {
+    const math = new WooFiV2Math(dummyLogger, USDC);
+    math.state = makeState(over);
+    return math;
+  };
+
+  describe('sellBase (cbBTC -> USDC)', () => {
+    it('returns 0 when gamma exceeds maxGamma (the prod route)', () => {
+      const math = makeMath({
+        maxGamma: REAL_MAX_GAMMA,
+        maxNotionalSwap: REAL_MAX_NOTIONAL,
+      });
+      // gamma = amount * price * coeff / priceDec / baseDec ≈ 2.15e14 > 1e14
+      const out = math.query(CBBTC, USDC, [PROD_AMOUNT]);
+      expect(out).toEqual([0n]);
+    });
+
+    it('returns 0 when the notional exceeds maxNotionalSwap', () => {
+      const math = makeMath({
+        maxGamma: 2n ** 100n, // gamma cap out of the way
+        maxNotionalSwap: 10000000000n, // $10k < $21.5k notional
+      });
+      const out = math.query(CBBTC, USDC, [PROD_AMOUNT]);
+      expect(out).toEqual([0n]);
+    });
+
+    it('quotes normally under both caps', () => {
+      const math = makeMath({
+        maxGamma: REAL_MAX_GAMMA,
+        maxNotionalSwap: REAL_MAX_NOTIONAL,
+      });
+      // 0.01 cbBTC (~$648): gamma ≈ 6.5e12, well under 1e14
+      const out = math.query(CBBTC, USDC, [1000000n]);
+      expect(out![0]).toBeGreaterThan(0n);
+    });
+  });
+
+  describe('sellQuote (USDC -> cbBTC)', () => {
+    it('returns 0 when gamma exceeds maxGamma', () => {
+      const math = makeMath({
+        // gamma = quoteAmount * coeff / quoteDec = $21.5k * 1e10 / 1e6 = 2.15e11
+        maxGamma: 100000000000n, // 1e11 < 2.15e11
+        maxNotionalSwap: REAL_MAX_NOTIONAL,
+      });
+      const out = math.query(USDC, CBBTC, [21500000000n]);
+      expect(out).toEqual([0n]);
+    });
+
+    it('returns 0 when the quote amount exceeds maxNotionalSwap', () => {
+      const math = makeMath({
+        maxGamma: 2n ** 100n,
+        maxNotionalSwap: 10000000000n, // $10k
+      });
+      const out = math.query(USDC, CBBTC, [21500000000n]);
+      expect(out).toEqual([0n]);
+    });
+
+    it('quotes normally under both caps', () => {
+      const math = makeMath({
+        maxGamma: REAL_MAX_GAMMA,
+        maxNotionalSwap: REAL_MAX_NOTIONAL,
+      });
+      const out = math.query(USDC, CBBTC, [648000000n]); // $648
+      expect(out![0]).toBeGreaterThan(0n);
+    });
+  });
+});

--- a/src/dex/woo-fi-v2/woo-fi-v2-math.ts
+++ b/src/dex/woo-fi-v2/woo-fi-v2-math.ts
@@ -194,14 +194,23 @@ export class WooFiV2Math {
     state: TokenState,
   ): bigint[] {
     let { priceDec, quoteDec, baseDec } = this.state.decimals[baseToken];
+    const { maxGamma, maxNotionalSwap } = this.state.tokenInfos[baseToken];
 
     return baseAmounts.map(baseAmount => {
       if (baseAmount === 0n) return 0n;
 
-      const coef: bigint =
-        BI_POWS[18] -
-        (state.coeff * baseAmount * state.price) / baseDec / priceDec -
-        state.spread;
+      // Mirror WooPPV2._calcQuoteAmountSellBase's swap-size caps: the contract
+      // reverts with "WooPPV2: !maxNotionalValue" / "WooPPV2: !gamma" above
+      // them, so bigger amounts must not be quoted.
+      const notionalSwap =
+        (baseAmount * state.price * quoteDec) / baseDec / priceDec;
+      if (notionalSwap > maxNotionalSwap) return 0n;
+
+      const gamma =
+        (baseAmount * state.price * state.coeff) / priceDec / baseDec;
+      if (gamma > maxGamma) return 0n;
+
+      const coef: bigint = BI_POWS[18] - gamma - state.spread;
 
       return (
         (((baseAmount * quoteDec * state.price) / priceDec) * coef) /
@@ -217,12 +226,18 @@ export class WooFiV2Math {
     state: TokenState,
   ): bigint[] {
     let { priceDec, quoteDec, baseDec } = this.state.decimals[baseToken];
+    const { maxGamma, maxNotionalSwap } = this.state.tokenInfos[baseToken];
 
     return quoteAmounts.map(quoteAmount => {
       if (quoteAmount === 0n) return 0n;
 
-      const coef: bigint =
-        BI_POWS[18] - (quoteAmount * state.coeff) / quoteDec - state.spread;
+      // Mirror WooPPV2._calcBaseAmountSellQuote's swap-size caps (see above).
+      if (quoteAmount > maxNotionalSwap) return 0n;
+
+      const gamma = (quoteAmount * state.coeff) / quoteDec;
+      if (gamma > maxGamma) return 0n;
+
+      const coef: bigint = BI_POWS[18] - gamma - state.spread;
 
       return (
         (((quoteAmount * baseDec * priceDec) / state.price) * coef) /


### PR DESCRIPTION
## Problem

WooFiV2 TS pricing quotes swap sizes the pool contract refuses to fill. `WooPPV2._calcQuoteAmountSellBase` / `_calcBaseAmountSellQuote` enforce two per-token caps read from `tokenInfos(baseToken)`:

- `gamma = k * price * amount` must be `<= maxGamma` — otherwise `WooPPV2: !gamma`
- swap notional must be `<= maxNotionalSwap` — otherwise `WooPPV2: !maxNotionalValue`

The TS math already fetches both fields via `tokenInfoDecoder` but never checked them, so oversized quotes were priced normally and reverted on-chain.

## Real-world case

Base cbBTC->USDC, ~$21.5k (0.332 cbBTC at $64,778): the pool's `maxGamma = 1e14` with `coeff = 1e10` caps swaps at roughly $10k notional — `gamma ≈ 2.15e14` and the swap reverts with the `!gamma` custom error (`0x088d21a9` on the Base WooPPV2 build). Surfaced by the revertable-fallback replay campaign, where WooFiV2 fallback quotes above the cap could never fill (Tenderly ref: `fba89e9e-ba99-4b23-99fa-45a7eece1847`).

## Fix

Mirror the contract checks in `_calcQuoteAmountSellBase` (notional + gamma, sellBase form) and `_calcBaseAmountSellQuote` (quote amount + gamma, sellQuote form), returning `0n` for amounts over either cap — consistent with the existing `capBal`/reserve handling. Also aligns the gamma division order with the contract (`/ priceDec / baseDec`).

## Tests

`woo-fi-v2-gamma-cap.test.ts` — 6 unit tests with the real Base pool state at block 48681324: over-gamma and over-notional return 0 in both directions; amounts under the caps quote normally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live swap quoting for WooFiV2 routes—large trades may stop getting Woo quotes—but aligns behavior with on-chain fills and reduces unfilled fallback routes.
> 
> **Overview**
> WooFiV2 **TypeScript pricing** now enforces the same per-token **swap-size limits** as on-chain `WooPPV2`: **`maxNotionalSwap`** and **`maxGamma`**. Oversized amounts return **`0n`** instead of a quote that would revert with `!gamma` or `!maxNotionalValue` (e.g. Base **cbBTC→USDC** ~$21.5k vs ~$10k effective cap). Gamma is computed with the contract’s division order and folded into the pricing coefficient.
> 
> Adds **`woo-fi-v2-gamma-cap.test.ts`** (real Base pool state) and bumps the package to **5.0.9**. **Base e2e** switches **WETH/USDbC** to **WETH/cbBTC** with a smaller cbBTC size under the cap; Base config comment is corrected to **native USDC**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d512ac86a688335dd1b9fa815776f9992b70be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


## Also in this PR

- **Base e2e pair fix**: the suite paired WETH with USDbC, but USDbC was delisted from the Base WooPP (`tokenInfos` reserve 0; the integration helper's `allBaseTokens()` returns only WETH and cbBTC) — the `WETH -> USDbC` leg failed with "Fail to get price" on master too. Switched the pair to WETH/cbBTC (0.01 cbBTC, under the gamma cap) — all 3 Base e2e legs pass. Also corrected the stale `// USDbC` comment on the Base quoteToken config (the address is native USDC).

## Validation

- New unit tests: 6/6.
- `woo-fi-v2-integration.test.ts`: 27 passed; 8 pre-existing failures (BSC + Sonic env/RPC) — identical on clean master.
- `woo-fi-v2-e2e.test.ts`: all failures A/B'd against master — BSC (3) and Sonic (3) pre-exist; the Base one is fixed here. Base suite green (3/3) with the caps in place, confirming normal-size quotes are unaffected.