### PR TITLE
feat: verify token storage slots with additional simulations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.8",
+  "version": "5.0.9",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.9",
+  "version": "5.0.10",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/tenderly-simulation.ts
+++ b/src/tenderly-simulation.ts
@@ -633,13 +633,15 @@ export class TenderlySimulator {
    * Simulates the given read call with the state override applied and checks
    * that the override actually controls the returned value: the call must
    * succeed and return a non-zero value different from the baseline.
-   * An exact match with `writtenValue` is not required — tokens with derived
-   * balances (e.g. stETH shares, aToken scaled balances) return a scaled value
+   * With `allowScaled` an exact match with `writtenValue` is not required —
+   * tokens with derived balances (e.g. stETH shares, aToken scaled balances)
+   * return a scaled value. Without it, only an exact match passes
    */
   private async simulateAndCheckOutput(
     request: SimulateTransactionRequest,
     writtenValue: bigint,
     baselineValue: bigint,
+    allowScaled: boolean,
   ): Promise<boolean> {
     try {
       const { transaction, simulation } = await this.simulateTransaction(
@@ -660,6 +662,10 @@ export class TenderlySimulator {
       }
 
       if (decoded !== writtenValue) {
+        if (!allowScaled) {
+          return false;
+        }
+
         console.warn(
           `Slot override verification for token ${request.to}: written value ${writtenValue} but call returned ${decoded} (derived/scaled value), accepting slot`,
         );
@@ -714,6 +720,7 @@ export class TenderlySimulator {
       },
       amount,
       baselineValue,
+      true, // balances can be derived from the stored value (stETH, aTokens)
     );
   }
 
@@ -762,6 +769,7 @@ export class TenderlySimulator {
       },
       amount,
       baselineValue,
+      false, // allowances are stored raw, require an exact match
     );
   }
 

--- a/src/tenderly-simulation.ts
+++ b/src/tenderly-simulation.ts
@@ -29,6 +29,9 @@ interface TokenStorageSlots {
   balanceSlot: string;
   allowanceSlot: string;
   isVyper?: boolean;
+  // Solady ERC20 layout: `balanceSlot`/`allowanceSlot` hold the Solady slot
+  // seeds instead of mapping slots
+  isSolady?: boolean;
   stateProxy?: string;
   additionalOverrides?: StateOverride;
 }
@@ -36,6 +39,7 @@ interface TokenStorageSlots {
 interface FoundSlot {
   slot: string;
   isVyper?: boolean;
+  isSolady?: boolean;
   stateProxy?: string;
 }
 
@@ -257,6 +261,11 @@ export class TenderlySimulator {
   // distinctive value written into a candidate slot during verification,
   // unlikely to collide with any pre-existing balance/allowance
   static readonly SLOT_VERIFICATION_AMOUNT = 123456789012345678901234567n;
+  // Solady ERC20 doesn't use Solidity mappings — balances/allowances live at
+  // slots derived from these fixed library constants
+  // https://github.com/Vectorized/solady/blob/main/src/tokens/ERC20.sol
+  static readonly SOLADY_BALANCE_SLOT_SEED = '0x87a211a2';
+  static readonly SOLADY_ALLOWANCE_SLOT_SEED = '0x7f5e9f20';
 
   // singleton
   private static instance: TenderlySimulator;
@@ -415,15 +424,20 @@ export class TenderlySimulator {
 
   /**
    *
-   * @param balanceOfSlot storage slot of `balanceOf` mapping
+   * @param balanceOfSlot storage slot of `balanceOf` mapping (Solady slot seed if `isSolady`)
    * @param owner account's address
    * @param isVyper `true` if contract is written in Vyper
+   * @param isSolady `true` if contract uses Solady ERC20 storage layout
    */
   calculateAddressBalanceSlot(
     balanceOfSlot: string,
     owner: string,
     isVyper = false,
+    isSolady = false,
   ) {
+    if (isSolady) {
+      return this.calculateSoladyAddressBalanceSlot(balanceOfSlot, owner);
+    }
     return isVyper
       ? this.calculateVyperAddressBalanceSlot(balanceOfSlot, owner)
       : this.calculateSolidityAddressBalanceSlot(balanceOfSlot, owner);
@@ -452,18 +466,42 @@ export class TenderlySimulator {
   }
 
   /**
+   * Solady ERC20 stores balances at `keccak256(owner ++ seed)` where the seed
+   * is the 12-byte-padded `_BALANCE_SLOT_SEED` library constant
+   * @param balanceSlotSeed Solady balance slot seed
+   * @param owner account's address
+   */
+  calculateSoladyAddressBalanceSlot(balanceSlotSeed: string, owner: string) {
+    return ethers.utils.keccak256(
+      ethers.utils.concat([
+        ethers.utils.hexZeroPad(owner, 20),
+        ethers.utils.hexZeroPad(balanceSlotSeed, 12),
+      ]),
+    );
+  }
+
+  /**
    *
-   * @param allowanceSlot storage slot of `allowance` mapping
+   * @param allowanceSlot storage slot of `allowance` mapping (Solady slot seed if `isSolady`)
    * @param owner account's address
    * @param spender spender's address
    * @param isVyper `true` if contract is written in Vyper
+   * @param isSolady `true` if contract uses Solady ERC20 storage layout
    */
   calculateAddressAllowanceSlot(
     allowanceSlot: string,
     owner: string,
     spender: string,
     isVyper = false,
+    isSolady = false,
   ) {
+    if (isSolady) {
+      return this.calculateSoladyAddressAllowanceSlot(
+        allowanceSlot,
+        owner,
+        spender,
+      );
+    }
     return isVyper
       ? this.calculateVyperAddressAllowanceSlot(allowanceSlot, owner, spender)
       : this.calculateSolidityAddressAllowanceSlot(
@@ -516,6 +554,27 @@ export class TenderlySimulator {
 
     return ethers.utils.keccak256(
       ethers.utils.concat([slotHash, ethers.utils.hexZeroPad(spender, 32)]),
+    );
+  }
+
+  /**
+   * Solady ERC20 stores allowances at `keccak256(owner ++ seed ++ spender)`
+   * where the seed is the 12-byte-padded `_ALLOWANCE_SLOT_SEED` library constant
+   * @param allowanceSlotSeed Solady allowance slot seed
+   * @param owner account's address
+   * @param spender spender's address
+   */
+  calculateSoladyAddressAllowanceSlot(
+    allowanceSlotSeed: string,
+    owner: string,
+    spender: string,
+  ) {
+    return ethers.utils.keccak256(
+      ethers.utils.concat([
+        ethers.utils.hexZeroPad(owner, 20),
+        ethers.utils.hexZeroPad(allowanceSlotSeed, 12),
+        ethers.utils.hexZeroPad(spender, 20),
+      ]),
     );
   }
 
@@ -633,6 +692,7 @@ export class TenderlySimulator {
       foundSlot.slot,
       owner,
       foundSlot.isVyper,
+      foundSlot.isSolady,
     );
 
     const address = foundSlot.stateProxy ?? token;
@@ -680,6 +740,7 @@ export class TenderlySimulator {
       owner,
       spender,
       foundSlot.isVyper,
+      foundSlot.isSolady,
     );
 
     const address = foundSlot.stateProxy ?? token;
@@ -752,6 +813,44 @@ export class TenderlySimulator {
         parentCallType: call.parentCall ? call.parentCall.call_type : null,
       }))
       .filter(({ slot }) => !!slot);
+
+    // try Solady layout: balance slot is derived from a fixed seed, not a mapping
+    const soladyBalanceOfSlot = this.calculateSoladyAddressBalanceSlot(
+      TenderlySimulator.SOLADY_BALANCE_SLOT_SEED,
+      account,
+    );
+    const foundSoladySlot = readSlots.find(
+      ({ slot }) => slot === soladyBalanceOfSlot,
+    );
+    if (foundSoladySlot) {
+      const candidate: FoundSlot =
+        foundSoladySlot.address !== token.toLowerCase() &&
+        foundSoladySlot.parentCallType !== 'DELEGATECALL'
+          ? {
+              slot: TenderlySimulator.SOLADY_BALANCE_SLOT_SEED,
+              isSolady: true,
+              stateProxy: foundSoladySlot.address,
+            }
+          : {
+              slot: TenderlySimulator.SOLADY_BALANCE_SLOT_SEED,
+              isSolady: true,
+            };
+
+      if (
+        await this.verifyTokenBalanceSlot(
+          chainId,
+          token,
+          candidate,
+          baselineValue,
+        )
+      ) {
+        return candidate;
+      }
+
+      console.warn(
+        `Candidate 'balanceOf' slot seed (solady) for token ${token} on chain ${chainId} failed verification, continuing search`,
+      );
+    }
 
     const startingPoints = [
       // regular contract
@@ -891,6 +990,45 @@ export class TenderlySimulator {
         parentCallType: call.parentCall ? call.parentCall.call_type : null,
       }))
       .filter(({ slot }) => !!slot);
+
+    // try Solady layout: allowance slot is derived from a fixed seed, not a mapping
+    const soladyAllowanceSlot = this.calculateSoladyAddressAllowanceSlot(
+      TenderlySimulator.SOLADY_ALLOWANCE_SLOT_SEED,
+      account,
+      spender,
+    );
+    const foundSoladySlot = readSlots.find(
+      ({ slot }) => slot === soladyAllowanceSlot,
+    );
+    if (foundSoladySlot) {
+      const candidate: FoundSlot =
+        foundSoladySlot.address !== token.toLowerCase() &&
+        foundSoladySlot.parentCallType !== 'DELEGATECALL'
+          ? {
+              slot: TenderlySimulator.SOLADY_ALLOWANCE_SLOT_SEED,
+              isSolady: true,
+              stateProxy: foundSoladySlot.address,
+            }
+          : {
+              slot: TenderlySimulator.SOLADY_ALLOWANCE_SLOT_SEED,
+              isSolady: true,
+            };
+
+      if (
+        await this.verifyTokenAllowanceSlot(
+          chainId,
+          token,
+          candidate,
+          baselineValue,
+        )
+      ) {
+        return candidate;
+      }
+
+      console.warn(
+        `Candidate 'allowance' slot seed (solady) for token ${token} on chain ${chainId} failed verification, continuing search`,
+      );
+    }
 
     const startingPoints = [
       // regular contract
@@ -1032,6 +1170,7 @@ export class TenderlySimulator {
       balanceSlot: balanceSlot.slot,
       allowanceSlot: allowanceSlot.slot,
       isVyper: balanceSlot.isVyper,
+      isSolady: balanceSlot.isSolady,
       stateProxy: balanceSlot.stateProxy,
     };
 
@@ -1079,6 +1218,7 @@ export class TenderlySimulator {
       tokenSlots.balanceSlot,
       account,
       tokenSlots.isVyper,
+      tokenSlots.isSolady,
     );
     // add the balance override
     const address = tokenSlots.stateProxy ? tokenSlots.stateProxy : token;
@@ -1117,6 +1257,7 @@ export class TenderlySimulator {
       account,
       spender,
       tokenSlots.isVyper,
+      tokenSlots.isSolady,
     );
     // add the allowance override
     const address = tokenSlots.stateProxy ? tokenSlots.stateProxy : token;

--- a/src/tenderly-simulation.ts
+++ b/src/tenderly-simulation.ts
@@ -32,6 +32,9 @@ interface TokenStorageSlots {
   // Solady ERC20 layout: `balanceSlot`/`allowanceSlot` hold the Solady slot
   // seeds instead of mapping slots
   isSolady?: boolean;
+  // partitioned layout (e.g. ViciERC20): mappings are keyed by a partition
+  // (item/token id) in addition to the account, see calculatePartitioned* methods
+  partition?: string;
   stateProxy?: string;
   additionalOverrides?: StateOverride;
 }
@@ -40,6 +43,7 @@ interface FoundSlot {
   slot: string;
   isVyper?: boolean;
   isSolady?: boolean;
+  partition?: string;
   stateProxy?: string;
 }
 
@@ -428,13 +432,22 @@ export class TenderlySimulator {
    * @param owner account's address
    * @param isVyper `true` if contract is written in Vyper
    * @param isSolady `true` if contract uses Solady ERC20 storage layout
+   * @param partition partition key if contract uses partitioned storage layout
    */
   calculateAddressBalanceSlot(
     balanceOfSlot: string,
     owner: string,
     isVyper = false,
     isSolady = false,
+    partition?: string,
   ) {
+    if (partition) {
+      return this.calculatePartitionedAddressBalanceSlot(
+        balanceOfSlot,
+        owner,
+        partition,
+      );
+    }
     if (isSolady) {
       return this.calculateSoladyAddressBalanceSlot(balanceOfSlot, owner);
     }
@@ -481,12 +494,36 @@ export class TenderlySimulator {
   }
 
   /**
+   * Partitioned layout (e.g. ViciERC20's `balances[partition][owner]`):
+   * balance is stored at `keccak256(owner ++ keccak256(partition ++ slot))`
+   * @param balanceOfSlot storage slot of the partitioned balances mapping
+   * @param owner account's address
+   * @param partition partition key (item/token id) as a 32-byte value
+   */
+  calculatePartitionedAddressBalanceSlot(
+    balanceOfSlot: string,
+    owner: string,
+    partition: string,
+  ) {
+    return this.calculateSolidityAddressBalanceSlot(
+      ethers.utils.keccak256(
+        ethers.utils.concat([
+          ethers.utils.hexZeroPad(partition, 32),
+          balanceOfSlot,
+        ]),
+      ),
+      owner,
+    );
+  }
+
+  /**
    *
    * @param allowanceSlot storage slot of `allowance` mapping (Solady slot seed if `isSolady`)
    * @param owner account's address
    * @param spender spender's address
    * @param isVyper `true` if contract is written in Vyper
    * @param isSolady `true` if contract uses Solady ERC20 storage layout
+   * @param partition partition key if contract uses partitioned storage layout
    */
   calculateAddressAllowanceSlot(
     allowanceSlot: string,
@@ -494,7 +531,16 @@ export class TenderlySimulator {
     spender: string,
     isVyper = false,
     isSolady = false,
+    partition?: string,
   ) {
+    if (partition) {
+      return this.calculatePartitionedAddressAllowanceSlot(
+        allowanceSlot,
+        owner,
+        spender,
+        partition,
+      );
+    }
     if (isSolady) {
       return this.calculateSoladyAddressAllowanceSlot(
         allowanceSlot,
@@ -574,6 +620,35 @@ export class TenderlySimulator {
         ethers.utils.hexZeroPad(owner, 20),
         ethers.utils.hexZeroPad(allowanceSlotSeed, 12),
         ethers.utils.hexZeroPad(spender, 20),
+      ]),
+    );
+  }
+
+  /**
+   * Partitioned layout (e.g. ViciERC20's `allowances[owner][partition][spender]`):
+   * allowance is stored at
+   * `keccak256(spender ++ keccak256(partition ++ keccak256(owner ++ slot)))`
+   * @param allowanceSlot storage slot of the partitioned allowances mapping
+   * @param owner account's address
+   * @param spender spender's address
+   * @param partition partition key (item/token id) as a 32-byte value
+   */
+  calculatePartitionedAddressAllowanceSlot(
+    allowanceSlot: string,
+    owner: string,
+    spender: string,
+    partition: string,
+  ) {
+    const ownerHash = ethers.utils.keccak256(
+      ethers.utils.concat([ethers.utils.hexZeroPad(owner, 32), allowanceSlot]),
+    );
+    const partitionHash = ethers.utils.keccak256(
+      ethers.utils.concat([ethers.utils.hexZeroPad(partition, 32), ownerHash]),
+    );
+    return ethers.utils.keccak256(
+      ethers.utils.concat([
+        ethers.utils.hexZeroPad(spender, 32),
+        partitionHash,
       ]),
     );
   }
@@ -699,6 +774,7 @@ export class TenderlySimulator {
       owner,
       foundSlot.isVyper,
       foundSlot.isSolady,
+      foundSlot.partition,
     );
 
     const address = foundSlot.stateProxy ?? token;
@@ -748,6 +824,7 @@ export class TenderlySimulator {
       spender,
       foundSlot.isVyper,
       foundSlot.isSolady,
+      foundSlot.partition,
     );
 
     const address = foundSlot.stateProxy ?? token;
@@ -771,6 +848,21 @@ export class TenderlySimulator {
       baselineValue,
       false, // allowances are stored raw, require an exact match
     );
+  }
+
+  /**
+   * Builds a `FoundSlot` from a matched SLOAD. `storage_address` is where the
+   * read actually happened: if it differs from the token, the state lives on
+   * an external contract (state proxy) and overrides must target it
+   */
+  private buildFoundSlot(
+    token: string,
+    readSlotAddress: string,
+    base: Omit<FoundSlot, 'stateProxy'>,
+  ): FoundSlot {
+    return readSlotAddress !== token.toLowerCase()
+      ? { ...base, stateProxy: readSlotAddress }
+      : { ...base };
   }
 
   /**
@@ -818,7 +910,6 @@ export class TenderlySimulator {
       .map(call => ({
         slot: call.storage_slot?.[0],
         address: call.storage_address,
-        parentCallType: call.parentCall ? call.parentCall.call_type : null,
       }))
       .filter(({ slot }) => !!slot);
 
@@ -831,18 +922,10 @@ export class TenderlySimulator {
       ({ slot }) => slot === soladyBalanceOfSlot,
     );
     if (foundSoladySlot) {
-      const candidate: FoundSlot =
-        foundSoladySlot.address !== token.toLowerCase() &&
-        foundSoladySlot.parentCallType !== 'DELEGATECALL'
-          ? {
-              slot: TenderlySimulator.SOLADY_BALANCE_SLOT_SEED,
-              isSolady: true,
-              stateProxy: foundSoladySlot.address,
-            }
-          : {
-              slot: TenderlySimulator.SOLADY_BALANCE_SLOT_SEED,
-              isSolady: true,
-            };
+      const candidate = this.buildFoundSlot(token, foundSoladySlot.address, {
+        slot: TenderlySimulator.SOLADY_BALANCE_SLOT_SEED,
+        isSolady: true,
+      });
 
       if (
         await this.verifyTokenBalanceSlot(
@@ -884,11 +967,11 @@ export class TenderlySimulator {
           ({ slot }) => slot === solitidyBalanceOfSlot,
         );
         if (foundSoliditySlot) {
-          const candidate: FoundSlot =
-            foundSoliditySlot.address !== token.toLowerCase() &&
-            foundSoliditySlot.parentCallType !== 'DELEGATECALL'
-              ? { slot: candidateSlot, stateProxy: foundSoliditySlot.address }
-              : { slot: candidateSlot };
+          const candidate = this.buildFoundSlot(
+            token,
+            foundSoliditySlot.address,
+            { slot: candidateSlot },
+          );
 
           if (
             await this.verifyTokenBalanceSlot(
@@ -915,15 +998,10 @@ export class TenderlySimulator {
         );
 
         if (foundVyperSlot) {
-          const candidate: FoundSlot =
-            foundVyperSlot.address !== token.toLowerCase() &&
-            foundVyperSlot.parentCallType !== 'DELEGATECALL'
-              ? {
-                  slot: candidateSlot,
-                  isVyper: true,
-                  stateProxy: foundVyperSlot.address,
-                }
-              : { slot: candidateSlot, isVyper: true };
+          const candidate = this.buildFoundSlot(token, foundVyperSlot.address, {
+            slot: candidateSlot,
+            isVyper: true,
+          });
 
           if (
             await this.verifyTokenBalanceSlot(
@@ -940,6 +1018,49 @@ export class TenderlySimulator {
             `Candidate 'balanceOf' slot ${candidateSlot} (vyper) for token ${token} on chain ${chainId} failed verification, continuing search`,
           );
         }
+      }
+    }
+
+    // try partitioned layout (e.g. ViciERC20's `balances[partition][owner]`),
+    // often held on an external state contract
+    for (let p = 0n; p < 4n; p += 1n) {
+      const partition = ethers.utils.defaultAbiCoder.encode(['uint'], [p]);
+      for (let i = 0n; i < 1_000n; i += 1n) {
+        const candidateSlot = ethers.utils.defaultAbiCoder.encode(
+          ['uint'],
+          [i],
+        );
+        const partitionedBalanceOfSlot =
+          this.calculatePartitionedAddressBalanceSlot(
+            candidateSlot,
+            account,
+            partition,
+          );
+        const foundPartitionedSlot = readSlots.find(
+          ({ slot }) => slot === partitionedBalanceOfSlot,
+        );
+        if (!foundPartitionedSlot) continue;
+
+        const candidate = this.buildFoundSlot(
+          token,
+          foundPartitionedSlot.address,
+          { slot: candidateSlot, partition },
+        );
+
+        if (
+          await this.verifyTokenBalanceSlot(
+            chainId,
+            token,
+            candidate,
+            baselineValue,
+          )
+        ) {
+          return candidate;
+        }
+
+        console.warn(
+          `Candidate 'balanceOf' slot ${candidateSlot} (partition ${p}) for token ${token} on chain ${chainId} failed verification, continuing search`,
+        );
       }
     }
 
@@ -995,7 +1116,6 @@ export class TenderlySimulator {
       .map(call => ({
         slot: call.storage_slot?.[0],
         address: call.storage_address,
-        parentCallType: call.parentCall ? call.parentCall.call_type : null,
       }))
       .filter(({ slot }) => !!slot);
 
@@ -1009,18 +1129,10 @@ export class TenderlySimulator {
       ({ slot }) => slot === soladyAllowanceSlot,
     );
     if (foundSoladySlot) {
-      const candidate: FoundSlot =
-        foundSoladySlot.address !== token.toLowerCase() &&
-        foundSoladySlot.parentCallType !== 'DELEGATECALL'
-          ? {
-              slot: TenderlySimulator.SOLADY_ALLOWANCE_SLOT_SEED,
-              isSolady: true,
-              stateProxy: foundSoladySlot.address,
-            }
-          : {
-              slot: TenderlySimulator.SOLADY_ALLOWANCE_SLOT_SEED,
-              isSolady: true,
-            };
+      const candidate = this.buildFoundSlot(token, foundSoladySlot.address, {
+        slot: TenderlySimulator.SOLADY_ALLOWANCE_SLOT_SEED,
+        isSolady: true,
+      });
 
       if (
         await this.verifyTokenAllowanceSlot(
@@ -1066,16 +1178,11 @@ export class TenderlySimulator {
         );
 
         if (foundSoliditySlot) {
-          const candidate: FoundSlot =
-            token.toLowerCase() !== foundSoliditySlot.address &&
-            foundSoliditySlot.parentCallType !== 'DELEGATECALL'
-              ? {
-                  slot: candidateSlot,
-                  stateProxy: foundSoliditySlot.address,
-                }
-              : {
-                  slot: candidateSlot,
-                };
+          const candidate = this.buildFoundSlot(
+            token,
+            foundSoliditySlot.address,
+            { slot: candidateSlot },
+          );
 
           if (
             await this.verifyTokenAllowanceSlot(
@@ -1105,18 +1212,10 @@ export class TenderlySimulator {
         );
 
         if (foundVyperSlot) {
-          const candidate: FoundSlot =
-            token.toLowerCase() !== foundVyperSlot.address &&
-            foundVyperSlot.parentCallType !== 'DELEGATECALL'
-              ? {
-                  slot: candidateSlot,
-                  isVyper: true,
-                  stateProxy: foundVyperSlot.address,
-                }
-              : {
-                  slot: candidateSlot,
-                  isVyper: true,
-                };
+          const candidate = this.buildFoundSlot(token, foundVyperSlot.address, {
+            slot: candidateSlot,
+            isVyper: true,
+          });
 
           if (
             await this.verifyTokenAllowanceSlot(
@@ -1133,6 +1232,50 @@ export class TenderlySimulator {
             `Candidate 'allowance' slot ${candidateSlot} (vyper) for token ${token} on chain ${chainId} failed verification, continuing search`,
           );
         }
+      }
+    }
+
+    // try partitioned layout (e.g. ViciERC20's `allowances[owner][partition][spender]`),
+    // often held on an external state contract
+    for (let p = 0n; p < 4n; p += 1n) {
+      const partition = ethers.utils.defaultAbiCoder.encode(['uint'], [p]);
+      for (let i = 0n; i < 1_000n; i += 1n) {
+        const candidateSlot = ethers.utils.defaultAbiCoder.encode(
+          ['uint'],
+          [i],
+        );
+        const partitionedAllowanceSlot =
+          this.calculatePartitionedAddressAllowanceSlot(
+            candidateSlot,
+            account,
+            spender,
+            partition,
+          );
+        const foundPartitionedSlot = readSlots.find(
+          ({ slot }) => slot === partitionedAllowanceSlot,
+        );
+        if (!foundPartitionedSlot) continue;
+
+        const candidate = this.buildFoundSlot(
+          token,
+          foundPartitionedSlot.address,
+          { slot: candidateSlot, partition },
+        );
+
+        if (
+          await this.verifyTokenAllowanceSlot(
+            chainId,
+            token,
+            candidate,
+            baselineValue,
+          )
+        ) {
+          return candidate;
+        }
+
+        console.warn(
+          `Candidate 'allowance' slot ${candidateSlot} (partition ${p}) for token ${token} on chain ${chainId} failed verification, continuing search`,
+        );
       }
     }
 
@@ -1179,6 +1322,7 @@ export class TenderlySimulator {
       allowanceSlot: allowanceSlot.slot,
       isVyper: balanceSlot.isVyper,
       isSolady: balanceSlot.isSolady,
+      partition: balanceSlot.partition,
       stateProxy: balanceSlot.stateProxy,
     };
 
@@ -1227,6 +1371,7 @@ export class TenderlySimulator {
       account,
       tokenSlots.isVyper,
       tokenSlots.isSolady,
+      tokenSlots.partition,
     );
     // add the balance override
     const address = tokenSlots.stateProxy ? tokenSlots.stateProxy : token;
@@ -1266,6 +1411,7 @@ export class TenderlySimulator {
       spender,
       tokenSlots.isVyper,
       tokenSlots.isSolady,
+      tokenSlots.partition,
     );
     // add the allowance override
     const address = tokenSlots.stateProxy ? tokenSlots.stateProxy : token;

--- a/src/tenderly-simulation.ts
+++ b/src/tenderly-simulation.ts
@@ -33,6 +33,12 @@ interface TokenStorageSlots {
   additionalOverrides?: StateOverride;
 }
 
+interface FoundSlot {
+  slot: string;
+  isVyper?: boolean;
+  stateProxy?: string;
+}
+
 interface SimulateTransactionRequest {
   from: string | null;
   to: string | null;
@@ -248,6 +254,9 @@ export class TenderlySimulator {
   static readonly DEFAULT_OWNER = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
   static readonly DEFAULT_SPENDER =
     '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+  // distinctive value written into a candidate slot during verification,
+  // unlikely to collide with any pre-existing balance/allowance
+  static readonly SLOT_VERIFICATION_AMOUNT = 123456789012345678901234567n;
 
   // singleton
   private static instance: TenderlySimulator;
@@ -545,16 +554,167 @@ export class TenderlySimulator {
     };
   }
 
+  private decodeUintOutput(output: string | undefined): bigint | null {
+    if (!output || output === '0x') {
+      return null;
+    }
+
+    try {
+      const [decoded] = ethers.utils.defaultAbiCoder.decode(
+        ['uint256'],
+        output,
+      );
+      return decoded.toBigInt();
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /**
+   * Simulates the given read call with the state override applied and checks
+   * that the override actually controls the returned value: the call must
+   * succeed and return a non-zero value different from the baseline.
+   * An exact match with `writtenValue` is not required — tokens with derived
+   * balances (e.g. stETH shares, aToken scaled balances) return a scaled value
+   */
+  private async simulateAndCheckOutput(
+    request: SimulateTransactionRequest,
+    writtenValue: bigint,
+    baselineValue: bigint,
+  ): Promise<boolean> {
+    try {
+      const { transaction, simulation } = await this.simulateTransaction(
+        request,
+        true, // force Tenderly simulation API
+      );
+
+      if (!simulation.status) {
+        return false;
+      }
+
+      const decoded = this.decodeUintOutput(
+        transaction.transaction_info.call_trace.output,
+      );
+
+      if (decoded === null || decoded === 0n || decoded === baselineValue) {
+        return false;
+      }
+
+      if (decoded !== writtenValue) {
+        console.warn(
+          `Slot override verification for token ${request.to}: written value ${writtenValue} but call returned ${decoded} (derived/scaled value), accepting slot`,
+        );
+      }
+
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  /**
+   * Verifies a candidate `balanceOf` mapping slot by overriding the derived
+   * slot with a distinctive value and checking that `balanceOf` reflects it
+   * @param chainId token chain id
+   * @param token token address
+   * @param foundSlot candidate slot to verify
+   * @param baselineValue `balanceOf` result without the override applied
+   */
+  async verifyTokenBalanceSlot(
+    chainId: number,
+    token: string,
+    foundSlot: FoundSlot,
+    baselineValue = 0n,
+  ): Promise<boolean> {
+    const owner = TenderlySimulator.DEFAULT_OWNER;
+    const amount = TenderlySimulator.SLOT_VERIFICATION_AMOUNT;
+
+    const slotToOverride = this.calculateAddressBalanceSlot(
+      foundSlot.slot,
+      owner,
+      foundSlot.isVyper,
+    );
+
+    const address = foundSlot.stateProxy ?? token;
+    const stateOverride: StateOverride = {
+      [address]: {
+        storage: {
+          [slotToOverride]: ethers.utils.defaultAbiCoder.encode(
+            ['uint'],
+            [amount],
+          ),
+        },
+      },
+    };
+
+    return this.simulateAndCheckOutput(
+      {
+        ...this.buildBalanceOfSimulationRequest(chainId, token, owner),
+        stateOverride,
+      },
+      amount,
+      baselineValue,
+    );
+  }
+
+  /**
+   * Verifies a candidate `allowance` mapping slot by overriding the derived
+   * slot with a distinctive value and checking that `allowance` reflects it
+   * @param chainId token chain id
+   * @param token token address
+   * @param foundSlot candidate slot to verify
+   * @param baselineValue `allowance` result without the override applied
+   */
+  async verifyTokenAllowanceSlot(
+    chainId: number,
+    token: string,
+    foundSlot: FoundSlot,
+    baselineValue = 0n,
+  ): Promise<boolean> {
+    const owner = TenderlySimulator.DEFAULT_OWNER;
+    const spender = TenderlySimulator.DEFAULT_SPENDER;
+    const amount = TenderlySimulator.SLOT_VERIFICATION_AMOUNT;
+
+    const slotToOverride = this.calculateAddressAllowanceSlot(
+      foundSlot.slot,
+      owner,
+      spender,
+      foundSlot.isVyper,
+    );
+
+    const address = foundSlot.stateProxy ?? token;
+    const stateOverride: StateOverride = {
+      [address]: {
+        storage: {
+          [slotToOverride]: ethers.utils.defaultAbiCoder.encode(
+            ['uint'],
+            [amount],
+          ),
+        },
+      },
+    };
+
+    return this.simulateAndCheckOutput(
+      {
+        ...this.buildAllowanceSimulationRequest(chainId, token, owner, spender),
+        stateOverride,
+      },
+      amount,
+      baselineValue,
+    );
+  }
+
   /**
    * Finds the slot of the `balanceOf` mapping in given token contract's storage.
-   * Supports `Solidity` and `Vyper` contracts
+   * Supports `Solidity` and `Vyper` contracts.
+   * Found slots are verified with an additional simulation before being returned
    * @param chainId token chain id
    * @param token token address
    */
   async findTokenBalanceOfSlot(
     chainId: number,
     token: string,
-  ): Promise<{ slot: string; isVyper?: boolean; stateProxy?: string }> {
+  ): Promise<FoundSlot> {
     const account = TenderlySimulator.DEFAULT_OWNER;
 
     const balanceOfSimulationRequest = this.buildBalanceOfSimulationRequest(
@@ -579,6 +739,9 @@ export class TenderlySimulator {
     }
 
     const callTrace = simulationDetails.transaction.transaction_info.call_trace;
+
+    // `balanceOf` result without any overrides, used as verification baseline
+    const baselineValue = this.decodeUintOutput(callTrace.output) ?? 0n;
 
     const sloadCalls = this.getSLOADCalls(callTrace);
     // token's storage slots that were read during the `balanceOf` call
@@ -614,10 +777,26 @@ export class TenderlySimulator {
           ({ slot }) => slot === solitidyBalanceOfSlot,
         );
         if (foundSoliditySlot) {
-          return foundSoliditySlot.address !== token.toLowerCase() &&
+          const candidate: FoundSlot =
+            foundSoliditySlot.address !== token.toLowerCase() &&
             foundSoliditySlot.parentCallType !== 'DELEGATECALL'
-            ? { slot: candidateSlot, stateProxy: foundSoliditySlot.address }
-            : { slot: candidateSlot };
+              ? { slot: candidateSlot, stateProxy: foundSoliditySlot.address }
+              : { slot: candidateSlot };
+
+          if (
+            await this.verifyTokenBalanceSlot(
+              chainId,
+              token,
+              candidate,
+              baselineValue,
+            )
+          ) {
+            return candidate;
+          }
+
+          console.warn(
+            `Candidate 'balanceOf' slot ${candidateSlot} for token ${token} on chain ${chainId} failed verification, continuing search`,
+          );
         }
         // try vyper slot
         const vyperBalanceOfSlot = this.calculateVyperAddressBalanceSlot(
@@ -629,33 +808,50 @@ export class TenderlySimulator {
         );
 
         if (foundVyperSlot) {
-          return foundVyperSlot.address === token.toLowerCase() &&
+          const candidate: FoundSlot =
+            foundVyperSlot.address !== token.toLowerCase() &&
             foundVyperSlot.parentCallType !== 'DELEGATECALL'
-            ? {
-                slot: candidateSlot,
-                isVyper: true,
-                stateProxy: foundVyperSlot.address,
-              }
-            : { slot: candidateSlot, isVyper: true };
+              ? {
+                  slot: candidateSlot,
+                  isVyper: true,
+                  stateProxy: foundVyperSlot.address,
+                }
+              : { slot: candidateSlot, isVyper: true };
+
+          if (
+            await this.verifyTokenBalanceSlot(
+              chainId,
+              token,
+              candidate,
+              baselineValue,
+            )
+          ) {
+            return candidate;
+          }
+
+          console.warn(
+            `Candidate 'balanceOf' slot ${candidateSlot} (vyper) for token ${token} on chain ${chainId} failed verification, continuing search`,
+          );
         }
       }
     }
 
     throw new Error(
-      `Could not find a 'balanceOf' mapping slot for token ${token} on chain ${chainId}`,
+      `Could not find a verified 'balanceOf' mapping slot for token ${token} on chain ${chainId}`,
     );
   }
 
   /**
-   * Finds the slot of the `allowance` mapping in given token contract's storage
-   * Supports `Solidity` and `Vyper` contracts
+   * Finds the slot of the `allowance` mapping in given token contract's storage.
+   * Supports `Solidity` and `Vyper` contracts.
+   * Found slots are verified with an additional simulation before being returned
    * @param chainId token chain id
    * @param token token address
    */
   async findTokenAllowanceSlot(
     chainId: number,
     token: string,
-  ): Promise<{ slot: string; isVyper?: boolean; stateProxy?: string }> {
+  ): Promise<FoundSlot> {
     const account = TenderlySimulator.DEFAULT_OWNER;
     const spender = TenderlySimulator.DEFAULT_SPENDER;
 
@@ -683,7 +879,8 @@ export class TenderlySimulator {
 
     const callTrace = simulationDetails.transaction.transaction_info.call_trace;
 
-    // console.log(callTrace);
+    // `allowance` result without any overrides, used as verification baseline
+    const baselineValue = this.decodeUintOutput(callTrace.output) ?? 0n;
 
     const sloadCalls = this.getSLOADCalls(callTrace);
     // token's storage slots that were read during the `allowance` call
@@ -694,8 +891,6 @@ export class TenderlySimulator {
         parentCallType: call.parentCall ? call.parentCall.call_type : null,
       }))
       .filter(({ slot }) => !!slot);
-
-    console.log(readSlots);
 
     const startingPoints = [
       // regular contract
@@ -725,15 +920,31 @@ export class TenderlySimulator {
         );
 
         if (foundSoliditySlot) {
-          return token.toLowerCase() !== foundSoliditySlot.address &&
+          const candidate: FoundSlot =
+            token.toLowerCase() !== foundSoliditySlot.address &&
             foundSoliditySlot.parentCallType !== 'DELEGATECALL'
-            ? {
-                slot: candidateSlot,
-                stateProxy: foundSoliditySlot.address,
-              }
-            : {
-                slot: candidateSlot,
-              };
+              ? {
+                  slot: candidateSlot,
+                  stateProxy: foundSoliditySlot.address,
+                }
+              : {
+                  slot: candidateSlot,
+                };
+
+          if (
+            await this.verifyTokenAllowanceSlot(
+              chainId,
+              token,
+              candidate,
+              baselineValue,
+            )
+          ) {
+            return candidate;
+          }
+
+          console.warn(
+            `Candidate 'allowance' slot ${candidateSlot} for token ${token} on chain ${chainId} failed verification, continuing search`,
+          );
         }
 
         // try vyper
@@ -748,21 +959,39 @@ export class TenderlySimulator {
         );
 
         if (foundVyperSlot) {
-          return token.toLowerCase() !== foundVyperSlot.address &&
+          const candidate: FoundSlot =
+            token.toLowerCase() !== foundVyperSlot.address &&
             foundVyperSlot.parentCallType !== 'DELEGATECALL'
-            ? {
-                slot: candidateSlot,
-                stateProxy: foundVyperSlot.address,
-              }
-            : {
-                slot: candidateSlot,
-              };
+              ? {
+                  slot: candidateSlot,
+                  isVyper: true,
+                  stateProxy: foundVyperSlot.address,
+                }
+              : {
+                  slot: candidateSlot,
+                  isVyper: true,
+                };
+
+          if (
+            await this.verifyTokenAllowanceSlot(
+              chainId,
+              token,
+              candidate,
+              baselineValue,
+            )
+          ) {
+            return candidate;
+          }
+
+          console.warn(
+            `Candidate 'allowance' slot ${candidateSlot} (vyper) for token ${token} on chain ${chainId} failed verification, continuing search`,
+          );
         }
       }
     }
 
     throw new Error(
-      `Could not find a 'allowance' mapping slot for token ${token} on chain ${chainId}`,
+      `Could not find a verified 'allowance' mapping slot for token ${token} on chain ${chainId}`,
     );
   }
 

--- a/tests/tenderly-simulation.test.ts
+++ b/tests/tenderly-simulation.test.ts
@@ -111,6 +111,18 @@ describe('Tenderly', () => {
       // assert
       expect(foundSlot.slot).toEqual(expectedSlot);
     });
+
+    it('should find Base SOL (Solady) `balanceOf` storage slot seed', async () => {
+      const foundSlot = await tenderly.findTokenBalanceOfSlot(
+        8453,
+        '0x311935cd80b76769bf2ecc9d8ab7635b2139cf82', // Solana (SOL) on Base, Solady ERC20 behind a beacon proxy
+      );
+      // assert
+      expect(foundSlot.slot).toEqual(
+        TenderlySimulator.SOLADY_BALANCE_SLOT_SEED,
+      );
+      expect(foundSlot.isSolady).toEqual(true);
+    });
   });
 
   describe('findTokenAllowanceSlot', () => {
@@ -160,6 +172,18 @@ describe('Tenderly', () => {
       expect(foundSlot.stateProxy).toEqual(
         '0x5b1b5fea1b99d83ad479df0c222f0492385381dd',
       );
+    });
+
+    it('should find Base SOL (Solady) `allowance` storage slot seed', async () => {
+      const foundSlot = await tenderly.findTokenAllowanceSlot(
+        8453,
+        '0x311935cd80b76769bf2ecc9d8ab7635b2139cf82', // Solana (SOL) on Base, Solady ERC20 behind a beacon proxy
+      );
+      // assert
+      expect(foundSlot.slot).toEqual(
+        TenderlySimulator.SOLADY_ALLOWANCE_SLOT_SEED,
+      );
+      expect(foundSlot.isSolady).toEqual(true);
     });
   });
 });

--- a/tests/tenderly-simulation.test.ts
+++ b/tests/tenderly-simulation.test.ts
@@ -123,6 +123,22 @@ describe('Tenderly', () => {
       );
       expect(foundSlot.isSolady).toEqual(true);
     });
+
+    it('should find Arbitrum VCNT (partitioned) `balanceOf` storage slot', async () => {
+      const expectedSlot = ethers.utils.defaultAbiCoder.encode(['uint'], [108]);
+      const foundSlot = await tenderly.findTokenBalanceOfSlot(
+        42161,
+        '0x60bf4e7cf16ff34513514b968483b54beff42a81', // ViciCoin, `balances[1][owner]` on an external state contract
+      );
+      // assert
+      expect(foundSlot.slot).toEqual(expectedSlot);
+      expect(foundSlot.partition).toEqual(
+        ethers.utils.defaultAbiCoder.encode(['uint'], [1]),
+      );
+      expect(foundSlot.stateProxy).toEqual(
+        '0x80e2c59593a5a6fe42f7c49220f7a42e30f105ad',
+      );
+    });
   });
 
   describe('findTokenAllowanceSlot', () => {
@@ -184,6 +200,22 @@ describe('Tenderly', () => {
         TenderlySimulator.SOLADY_ALLOWANCE_SLOT_SEED,
       );
       expect(foundSlot.isSolady).toEqual(true);
+    });
+
+    it('should find Base VCNT (partitioned) `allowance` storage slot', async () => {
+      const expectedSlot = ethers.utils.defaultAbiCoder.encode(['uint'], [110]);
+      const foundSlot = await tenderly.findTokenAllowanceSlot(
+        8453,
+        '0xdcf5130274753c8050ab061b1a1dcbf583f5bfd0', // ViciCoin, `allowances[owner][1][spender]` on an external state contract
+      );
+      // assert
+      expect(foundSlot.slot).toEqual(expectedSlot);
+      expect(foundSlot.partition).toEqual(
+        ethers.utils.defaultAbiCoder.encode(['uint'], [1]),
+      );
+      expect(foundSlot.stateProxy).toEqual(
+        '0x4844d11c51e6e85c1ed419dc77455894cdc5808e',
+      );
     });
   });
 });


### PR DESCRIPTION
## Description

`TenderlySimulator.findTokenBalanceOfSlot` / `findTokenAllowanceSlot` brute-force candidate mapping base slots and match them against `SLOAD`s from a `balanceOf`/`allowance` simulation trace. Previously the first match was returned unverified and cached forever, discovery only understood Solidity/Vyper mapping layouts, and state-proxy detection was unreliable. This PR fixes all of the storage-layout failures from the fallback replay campaign (SOL, TOWNS, NULL, uPEG, VCNT).

## Changes

### Slot verification

- After a candidate matches, run one additional simulation that writes a distinctive magic value (`SLOT_VERIFICATION_AMOUNT`) into the derived slot and re-calls `balanceOf`/`allowance`. The candidate is accepted only if the call succeeds and returns the expected value. Failed candidates are logged and the scan continues.
- **Balances** accept a scaled (non-exact) result — derived balances like stETH shares and aToken liquidity-index scaling return a transformed value. **Allowances** require an exact match, as they are stored raw.

### Solady ERC20 layout

Solady ERC20 (bridged SOL on Base, TOWNS, NULL, uPEG — some behind EIP-1967/beacon proxies) doesn't use Solidity mappings:

- balance slot = `keccak256(owner ++ 8 zero bytes ++ 0x87a211a2)`
- allowance slot = `keccak256(owner ++ 8 zero bytes ++ 0x7f5e9f20 ++ spender)`

The seeds are fixed library constants, so discovery checks them directly against the trace's `SLOAD`s and stores the seed as the token's "slot" with an `isSolady` flag.

### Partitioned layout (ViciCoin/VCNT)

ViciERC20 keeps token state on an external ops/state contract with partitioned mappings keyed by an item id (`1` for the ERC20):

- balance = `balances[partition][owner]` → `keccak256(owner ++ keccak256(partition ++ slot))`
- allowance = `allowances[owner][partition][spender]` → `keccak256(spender ++ keccak256(partition ++ keccak256(owner ++ slot)))`

Discovery scans partition ids 0–3 across base slots 0–999 after the standard layouts miss, and stores the matched `partition`. Verified live: VCNT resolves to base slots 108/110, partition 1, on its state contract (Arbitrum `0x80e2c5…`, Base `0x4844d1…`).

### State proxy detection fix

`stateProxy` was only assigned when the matched SLOAD's parent frame wasn't a `DELEGATECALL`, which broke tokens whose external state contract runs behind its own proxy (VCNT). `storage_address` is authoritative on its own — the condition is now simply "storage address differs from the token". Also fixed the Vyper branch's inverted condition and missing `isVyper` flag, and removed a stray debug log.

## Not fixable via storage slots

BRIAN (`0xb200…cb301` on Base) is a **B20 native token** (Base Beryl upgrade): a Rust precompile with `0xef` placeholder code and no EVM storage — its `balanceOf` performs zero `SLOAD`s, so no state override can fund an account. B20 tokens need a different funding mechanism (e.g. simulating `transfer` from a large holder).

## Cost

Verification adds one extra simulation per found slot (typically two per token), only on cache misses. Cached slots (redis / `tests/token-storage-slots.json`) are still trusted as-is.

## Testing

All 17 tests in `tests/tenderly-simulation.test.ts` pass against the live Tenderly API: USDC/USDT (plain mappings), stETH and aEthDai (derived/scaled balances), SNX (state proxy), Base SOL (Solady behind a beacon proxy), and VCNT on Arbitrum + Base (partitioned layout on a proxied state contract).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how swap simulations fund token balances/allowances via Tenderly state overrides; wrong slots would break replays, but verification and new layout support reduce that risk on cache misses.
> 
> **Overview**
> **TenderlySimulator** no longer returns the first SLOAD-matched `balanceOf`/`allowance` slot: each candidate is checked with an extra simulation that writes `SLOT_VERIFICATION_AMOUNT` into the derived storage slot and re-reads the view call. Balances may accept scaled outputs (stETH/aTokens); allowances require an exact match. Failed candidates are logged and the scan continues.
> 
> Discovery and overrides are extended for **Solady ERC20** (fixed slot seeds + `isSolady`) and **partitioned** layouts such as ViciERC20 (`partition` + new `calculatePartitioned*` / `calculateSolady*` helpers). Cached `TokenStorageSlots` and `addTokenBalanceOverride` / `addAllowanceOverride` pass through `isSolady` and `partition`.
> 
> **State proxy** handling is simplified: `stateProxy` is set whenever `storage_address` differs from the token (no `DELEGATECALL` gate); Vyper allowance discovery now sets `isVyper` correctly. Debug logging is removed. Package version **5.0.10**; live Tenderly tests cover Base SOL (Solady) and VCNT (partitioned) on Arbitrum/Base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2892da141f4a5eb974da798827b517eaa6302f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->