### PR TITLE
feat: support B20 native token storage slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/tenderly-simulation.ts
+++ b/src/tenderly-simulation.ts
@@ -270,6 +270,14 @@ export class TenderlySimulator {
   // https://github.com/Vectorized/solady/blob/main/src/tokens/ERC20.sol
   static readonly SOLADY_BALANCE_SLOT_SEED = '0x87a211a2';
   static readonly SOLADY_ALLOWANCE_SLOT_SEED = '0x7f5e9f20';
+  // B20 native tokens (Base Beryl upgrade) are Rust precompiles reading
+  // regular Solidity mappings under the ERC-7201 `base.b20` namespace
+  // (root 0x…434000): balances at offset 4, allowances at offset 5
+  // https://github.com/base/base crates/common/precompiles/src/common/core_storage.rs
+  static readonly B20_BALANCES_SLOT =
+    '0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434004';
+  static readonly B20_ALLOWANCES_SLOT =
+    '0xc78b71fee795ddd74aff64ea9b2474194c938c3196430e10bb5f01ed48434005';
 
   // singleton
   private static instance: TenderlySimulator;
@@ -1064,6 +1072,23 @@ export class TenderlySimulator {
       }
     }
 
+    // B20 native tokens serve `balanceOf` from a Rust precompile that reads
+    // the token's storage directly, so no SLOADs appear in the trace — try
+    // the known B20 layout blindly and let verification decide
+    const b20Candidate: FoundSlot = {
+      slot: TenderlySimulator.B20_BALANCES_SLOT,
+    };
+    if (
+      await this.verifyTokenBalanceSlot(
+        chainId,
+        token,
+        b20Candidate,
+        baselineValue,
+      )
+    ) {
+      return b20Candidate;
+    }
+
     throw new Error(
       `Could not find a verified 'balanceOf' mapping slot for token ${token} on chain ${chainId}`,
     );
@@ -1277,6 +1302,23 @@ export class TenderlySimulator {
           `Candidate 'allowance' slot ${candidateSlot} (partition ${p}) for token ${token} on chain ${chainId} failed verification, continuing search`,
         );
       }
+    }
+
+    // B20 native tokens serve `allowance` from a Rust precompile that reads
+    // the token's storage directly, so no SLOADs appear in the trace — try
+    // the known B20 layout blindly and let verification decide
+    const b20Candidate: FoundSlot = {
+      slot: TenderlySimulator.B20_ALLOWANCES_SLOT,
+    };
+    if (
+      await this.verifyTokenAllowanceSlot(
+        chainId,
+        token,
+        b20Candidate,
+        baselineValue,
+      )
+    ) {
+      return b20Candidate;
     }
 
     throw new Error(

--- a/tests/tenderly-simulation.test.ts
+++ b/tests/tenderly-simulation.test.ts
@@ -139,6 +139,15 @@ describe('Tenderly', () => {
         '0x80e2c59593a5a6fe42f7c49220f7a42e30f105ad',
       );
     });
+
+    it('should find Base BRIAN (B20 native token) `balanceOf` storage slot', async () => {
+      const foundSlot = await tenderly.findTokenBalanceOfSlot(
+        8453,
+        '0xb2000000000000000000007bf6d5cbb0e24cb301', // Coinbase Man (BRIAN), B20 Rust precompile
+      );
+      // assert
+      expect(foundSlot.slot).toEqual(TenderlySimulator.B20_BALANCES_SLOT);
+    });
   });
 
   describe('findTokenAllowanceSlot', () => {
@@ -216,6 +225,15 @@ describe('Tenderly', () => {
       expect(foundSlot.stateProxy).toEqual(
         '0x4844d11c51e6e85c1ed419dc77455894cdc5808e',
       );
+    });
+
+    it('should find Base BRIAN (B20 native token) `allowance` storage slot', async () => {
+      const foundSlot = await tenderly.findTokenAllowanceSlot(
+        8453,
+        '0xb2000000000000000000007bf6d5cbb0e24cb301', // Coinbase Man (BRIAN), B20 Rust precompile
+      );
+      // assert
+      expect(foundSlot.slot).toEqual(TenderlySimulator.B20_ALLOWANCES_SLOT);
     });
   });
 });


### PR DESCRIPTION
## Description

Follow-up to #1210. B20 tokens (Base's native token standard from the Beryl upgrade, June 2026 — e.g. Coinbase Man/BRIAN `0xb2000000000000000000007bf6d5cbb0e24cb301`) are Rust precompiles: their account code is a 1-byte `0xef` marker and their logic runs natively in the node, so `balanceOf`/`allowance` calls produce **zero `SLOAD`s in simulation traces** and trace-based slot discovery can never match anything.

## How B20 actually stores state

Reading the implementation ([`base/base` — `crates/common/precompiles/src/common/core_storage.rs`](https://github.com/base/base)): token state lives in the token account's **ordinary EVM storage trie**, as standard Solidity mappings under the ERC-7201 `base.b20` namespace (root `0xc78b…434000`):

- balances: `Mapping<Address, U256>` at root + 4 → `keccak256(owner ++ root+4)`
- allowances: nested mapping at root + 5 → `keccak256(spender ++ keccak256(owner ++ root+5))`

The precompile reads/writes these slots through native db access instead of `SLOAD`/`SSTORE` opcodes — which is why traces show nothing, while `eth_getStorageAt` and state overrides work normally. Verified: the derived slot holds a real holder's exact balance on-chain, and Tenderly state overrides on those slots are honored by the precompile (both balance and allowance return the overridden value exactly).

## Change

When trace matching finds no candidate (all layouts miss), the finders now blindly try the fixed B20 slots and let the verification simulation (added in #1210) accept or reject them. One extra simulation, only on the previous hard-failure path.

## Testing

All 19 tests in `tests/tenderly-simulation.test.ts` pass against the live Tenderly API, including two new BRIAN (B20) tests for `balanceOf` and `allowance` slot discovery.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap-simulation storage overrides for a new token layout on Base; existing discovery paths are unchanged, and wrong slots are gated by verification.
> 
> **Overview**
> **Tenderly slot discovery** now supports Base **B20** native tokens (Rust precompiles with no `SLOAD`s in traces) by adding fixed ERC-7201 `base.b20` mapping root slots for balances and allowances on `TenderlySimulator`.
> 
> When trace-based search still finds nothing, `findTokenBalanceOfSlot` and `findTokenAllowanceSlot` try those **B20** candidates and rely on the existing verification simulation to accept or reject them—one extra simulation only on the previous failure path. Package version bumps to **5.0.11**, with live Tenderly tests for Base BRIAN `balanceOf` and `allowance`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609844133b3e519ebe197e5142b4b7afbf210181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->