### PR TITLE
feat(DEXLIB-196): expose targetExchange in firm-quote pricing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.1-0",
+  "version": "5.1.1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.0",
+  "version": "5.1.1-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/bebop/bebop.ts
+++ b/src/dex/bebop/bebop.ts
@@ -478,6 +478,7 @@ export class Bebop
           exchange: this.dexKey,
           gasCost: BEBOP_GAS_COST,
           poolAddresses: [this.settlementAddress],
+          targetExchange: this.settlementAddress,
         },
       ];
     } catch (e: unknown) {

--- a/src/dex/cables/cables.ts
+++ b/src/dex/cables/cables.ts
@@ -589,6 +589,7 @@ export class Cables
           exchange: this.dexKey,
           gasCost: CABLES_GAS_COST,
           poolAddresses: [this.mainnetRFQAddress],
+          targetExchange: this.mainnetRFQAddress,
           poolIdentifiers: pools,
           data: {},
         },

--- a/src/dex/dexalot/dexalot.ts
+++ b/src/dex/dexalot/dexalot.ts
@@ -537,6 +537,7 @@ export class Dexalot
           exchange: this.dexKey,
           gasCost: DEXALOT_GAS_COST,
           poolAddresses: [this.dexalotRouterAddress],
+          targetExchange: this.dexalotRouterAddress,
         },
       ];
     } catch (e: unknown) {

--- a/src/dex/generic-rfq/generic-rfq.ts
+++ b/src/dex/generic-rfq/generic-rfq.ts
@@ -215,6 +215,7 @@ export class GenericRFQ extends ParaSwapLimitOrders {
         exchange: this.dexKey,
         poolIdentifiers: [expectedIdentifier],
         poolAddresses: [this.augustusRFQAddress],
+        targetExchange: this.augustusRFQAddress,
         prices: outputs,
         unit,
         data: {

--- a/src/dex/hashflow/hashflow.ts
+++ b/src/dex/hashflow/hashflow.ts
@@ -517,6 +517,7 @@ export class Hashflow
             this.getPoolIdentifier(_srcToken.address, _destToken.address, mm),
           ],
           poolAddresses: [this.routerAddress],
+          targetExchange: this.routerAddress,
         } as PoolPrices<HashflowData>;
       });
 

--- a/src/dex/native/native.ts
+++ b/src/dex/native/native.ts
@@ -626,6 +626,7 @@ export class Native
       data: { quote: undefined },
       poolIdentifiers: [this.serializePoolIdentifier(entry)],
       poolAddresses: [this.routerAddress],
+      targetExchange: this.routerAddress,
       gasCost: NATIVE_GAS_COST,
       prices: priceResults,
       unit: this.toBigInt(unitQuote, destToken.decimals),

--- a/src/types.ts
+++ b/src/types.ts
@@ -249,6 +249,10 @@ export type PoolPrices<T> = {
   calldataGasCost?: number | number[];
   poolAddresses?: Array<Address>;
   poolIdentifiers?: Array<string>;
+  // The contract the swap call targets (router/settlement) — lets analytics
+  // attribute on-chain reverts to a venue. Optional; populated by firm-quote
+  // dexes whose target is known at pricing time.
+  targetExchange?: Address;
 };
 
 export type ConnectorToken = Token & { liquidityUSD?: number };


### PR DESCRIPTION
Adds an optional `targetExchange` to `PoolPrices` and populates it in the firm-quote dexes whose swap target is known at pricing time (Native, Dexalot, Hashflow, Bebop, Cables, GenericRFQ — the AugustusRFQ address for makers). Lets analytics attribute on-chain reverts to the venue contract each hop actually calls. SwaapV2 is excluded: its router only arrives with the firm quote. Metric is priced by api-go and gets the field there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional field on pricing types with no change to swap encoding or execution paths; consumers that ignore the new field behave as before.
> 
> **Overview**
> Adds an optional **`targetExchange`** field on **`PoolPrices`** so pricing responses can name the on-chain contract each hop will call (router/settlement), for analytics to tie reverts to venues.
> 
> **Bebop**, **Cables**, **Dexalot**, **GenericRFQ** (Augustus RFQ), **Hashflow**, and **Native** now set **`targetExchange`** in **`getPricesVolume`** to the same address already used as **`poolAddresses`** / swap target. Other DEXes are unchanged; firm-quote venues where the router is only known after a firm quote (e.g. SwaapV2) are intentionally omitted.
> 
> Package version is bumped to **5.1.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 249bbfd2f5fd00a25d90efbb28872d4afe61e21c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->