### PR TITLE
feat(EkuboV3): support Ve33 pools on Robinhood

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ When making fixes based on code review comments or feedback, add a concise descr
 <!-- Add new fixes at the top of this list -->
 <!-- Format: - **[Date] Issue**: Brief description of fix -->
 
+- **[2026-07] Ve33 state consistency**: Use `Ve33DataFetcher.getVe33QuoteData` to fetch Core quote state and the extension-managed fee atomically at one block. Decode `VoteWeightApplied` with its ABI instead of fixed byte offsets.
+
 - **[2025-01] Block manager unavailable in certain methods**: `dexHelper.blockManager` is not available in `getTopPoolsForToken()` and `updatePoolState()` methods since these are called on a service that does not have it implemented. Use direct RPC calls (e.g., `dexHelper.provider.getBlock('latest')`) instead when block data is needed in these methods.
 
 - **[2025-01] Remove unused ABIs when removing DEXes**: When removing DEX integrations, also remove their associated ABI files from `src/abi/` if no longer referenced. Use `grep` to verify ABIs are not imported elsewhere before deletion.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ When making fixes based on code review comments or feedback, add a concise descr
 <!-- Add new fixes at the top of this list -->
 <!-- Format: - **[Date] Issue**: Brief description of fix -->
 
+- **[2026-07] Sub-second block timestamps**: Do not force `block.timestamp` to advance by one second on Robinhood, where multiple 100ms blocks can share the same EVM timestamp second. Estimate from the greater of wall-clock time and the last observed timestamp.
+
 - **[2026-07] Ve33 state consistency**: Use `Ve33DataFetcher.getVe33QuoteData` to fetch Core quote state and the extension-managed fee atomically at one block. Decode `VoteWeightApplied` with its ABI and signature topic instead of fixed byte offsets.
 
 - **[2025-01] Block manager unavailable in certain methods**: `dexHelper.blockManager` is not available in `getTopPoolsForToken()` and `updatePoolState()` methods since these are called on a service that does not have it implemented. Use direct RPC calls (e.g., `dexHelper.provider.getBlock('latest')`) instead when block data is needed in these methods.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ When making fixes based on code review comments or feedback, add a concise descr
 <!-- Add new fixes at the top of this list -->
 <!-- Format: - **[Date] Issue**: Brief description of fix -->
 
+- **[2026-07] Ve33 initialization and regeneration**: Initialize pools discovered from events with `getVe33QuoteData` at the event block so the voted fee is never temporarily zero. Use the same bitmap search depth for initial loading and every Ve33 pool type's later state regeneration.
+
 - **[2026-07] Sub-second block timestamps**: Do not force `block.timestamp` to advance by one second on Robinhood, where multiple 100ms blocks can share the same EVM timestamp second. Estimate from the greater of wall-clock time and the last observed timestamp.
 
 - **[2026-07] Ve33 state consistency**: Use `Ve33DataFetcher.getVe33QuoteData` to fetch Core quote state and the extension-managed fee atomically at one block. Decode `VoteWeightApplied` with its ABI and signature topic instead of fixed byte offsets.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ When making fixes based on code review comments or feedback, add a concise descr
 <!-- Add new fixes at the top of this list -->
 <!-- Format: - **[Date] Issue**: Brief description of fix -->
 
-- **[2026-07] Ve33 state consistency**: Use `Ve33DataFetcher.getVe33QuoteData` to fetch Core quote state and the extension-managed fee atomically at one block. Decode `VoteWeightApplied` with its ABI instead of fixed byte offsets.
+- **[2026-07] Ve33 state consistency**: Use `Ve33DataFetcher.getVe33QuoteData` to fetch Core quote state and the extension-managed fee atomically at one block. Decode `VoteWeightApplied` with its ABI and signature topic instead of fixed byte offsets.
 
 - **[2025-01] Block manager unavailable in certain methods**: `dexHelper.blockManager` is not available in `getTopPoolsForToken()` and `updatePoolState()` methods since these are called on a service that does not have it implemented. Use direct RPC calls (e.g., `dexHelper.provider.getBlock('latest')`) instead when block data is needed in these methods.
 

--- a/src/abi/ekubo-v3/ve33-data-fetcher.json
+++ b/src/abi/ekubo-v3/ve33-data-fetcher.json
@@ -1,9 +1,47 @@
 [
   {
     "type": "function",
-    "name": "getPoolSwapFees",
-    "inputs": [{ "name": "poolIds", "type": "bytes32[]" }],
-    "outputs": [{ "name": "swapFees", "type": "uint64[]" }],
+    "name": "getVe33QuoteData",
+    "inputs": [
+      {
+        "name": "poolKeys",
+        "type": "tuple[]",
+        "components": [
+          { "name": "token0", "type": "address" },
+          { "name": "token1", "type": "address" },
+          { "name": "config", "type": "bytes32" }
+        ]
+      },
+      { "name": "minBitmapsSearched", "type": "uint32" }
+    ],
+    "outputs": [
+      {
+        "name": "results",
+        "type": "tuple[]",
+        "components": [
+          {
+            "name": "quoteData",
+            "type": "tuple",
+            "components": [
+              { "name": "tick", "type": "int32" },
+              { "name": "sqrtRatio", "type": "uint96" },
+              { "name": "liquidity", "type": "uint128" },
+              { "name": "minTick", "type": "int32" },
+              { "name": "maxTick", "type": "int32" },
+              {
+                "name": "ticks",
+                "type": "tuple[]",
+                "components": [
+                  { "name": "number", "type": "int32" },
+                  { "name": "liquidityDelta", "type": "int128" }
+                ]
+              }
+            ]
+          },
+          { "name": "swapFee", "type": "uint64" }
+        ]
+      }
+    ],
     "stateMutability": "view"
   }
 ]

--- a/src/abi/ekubo-v3/ve33-data-fetcher.json
+++ b/src/abi/ekubo-v3/ve33-data-fetcher.json
@@ -1,0 +1,9 @@
+[
+  {
+    "type": "function",
+    "name": "getPoolSwapFees",
+    "inputs": [{ "name": "poolIds", "type": "bytes32[]" }],
+    "outputs": [{ "name": "swapFees", "type": "uint64[]" }],
+    "stateMutability": "view"
+  }
+]

--- a/src/abi/ekubo-v3/ve33.json
+++ b/src/abi/ekubo-v3/ve33.json
@@ -1,0 +1,15 @@
+[
+  {
+    "type": "event",
+    "name": "VoteWeightApplied",
+    "inputs": [
+      { "name": "owner", "type": "address", "indexed": false },
+      { "name": "stakeId", "type": "bytes32", "indexed": false },
+      { "name": "poolId", "type": "bytes32", "indexed": false },
+      { "name": "weight", "type": "uint128", "indexed": false },
+      { "name": "votedSwapFee", "type": "uint64", "indexed": false },
+      { "name": "swapFee", "type": "uint64", "indexed": false }
+    ],
+    "anonymous": false
+  }
+]

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,6 +42,7 @@ export enum Network {
   UNICHAIN = 130,
   POLYGON = 137,
   SONIC = 146,
+  ROBINHOOD = 4663,
   BASE = 8453,
   PLASMA = 9745,
   ARBITRUM = 42161,

--- a/src/dex/ekubo-v3/config.ts
+++ b/src/dex/ekubo-v3/config.ts
@@ -17,11 +17,10 @@ export const TWAMM_DATA_FETCHER_ADDRESS =
 export const BOOSTED_FEES_DATA_FETCHER_ADDRESS =
   '0x7A2fF5819Dc71Bb99133a97c38dA512E60c30475';
 export const ROUTER_ADDRESS = '0xd26f20001a72a18C002b00e6710000d68700ce00';
-// TODO(robinhood-deployment): replace these placeholders after deployment.
-// 0xd1 is the Ve33 extension's registered call-point prefix.
-export const VE33_ADDRESS = '0xd100000000000000000000000000000000000000';
+export const VE33_ADDRESS = '0xD18685a514E59b06d59824e16Db07e73345d9953';
 export const VE33_DATA_FETCHER_ADDRESS =
-  '0x0000000000000000000000000000000000000001';
+  '0x61F03754b1c7A7F0E584FD8869c00Ba898ab888d';
+// TODO(robinhood-deployment): replace after the router is deployed.
 export const ROBINHOOD_ROUTER_ADDRESS =
   '0x0000000000000000000000000000000000000002';
 

--- a/src/dex/ekubo-v3/config.ts
+++ b/src/dex/ekubo-v3/config.ts
@@ -17,16 +17,33 @@ export const TWAMM_DATA_FETCHER_ADDRESS =
 export const BOOSTED_FEES_DATA_FETCHER_ADDRESS =
   '0x7A2fF5819Dc71Bb99133a97c38dA512E60c30475';
 export const ROUTER_ADDRESS = '0xd26f20001a72a18C002b00e6710000d68700ce00';
+// TODO(robinhood-deployment): replace these placeholders after deployment.
+// 0xd1 is the Ve33 extension's registered call-point prefix.
+export const VE33_ADDRESS = '0xd100000000000000000000000000000000000000';
+export const VE33_DATA_FETCHER_ADDRESS =
+  '0x0000000000000000000000000000000000000001';
+export const ROBINHOOD_ROUTER_ADDRESS =
+  '0x0000000000000000000000000000000000000002';
 
-export type EkuboSupportedNetwork = Network.MAINNET | Network.ARBITRUM;
+export type EkuboSupportedNetwork =
+  | Network.MAINNET
+  | Network.ARBITRUM
+  | Network.ROBINHOOD;
 
 export const EKUBO_V3_CONFIG: DexConfigMap<DexParams> = {
   [DEX_KEY]: {
     [Network.MAINNET]: {
       subgraphId: '6MLKVikss1iYdhhggAR1w6Vqw2Z386AqNLMZYr8qaeG9',
+      router: ROUTER_ADDRESS,
     },
     [Network.ARBITRUM]: {
       subgraphId: 'FdPuN6GM73kviG7XfLG72yHKqFczeSd4yzEXeBxESvtG',
+      router: ROUTER_ADDRESS,
+    },
+    [Network.ROBINHOOD]: {
+      // TODO(robinhood-deployment): replace with the Robinhood Ekubo subgraph ID.
+      subgraphId: '',
+      router: ROBINHOOD_ROUTER_ADDRESS,
     },
   },
 } satisfies Record<typeof DEX_KEY, Record<EkuboSupportedNetwork, unknown>>;

--- a/src/dex/ekubo-v3/ekubo-v3-pool-manager.test.ts
+++ b/src/dex/ekubo-v3/ekubo-v3-pool-manager.test.ts
@@ -1,13 +1,16 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
+import { BigNumber } from 'ethers';
 import { Network } from '../../constants';
 import {
   EkuboV3PoolManager,
   PoolInitialization,
   SubgraphData,
 } from './ekubo-v3-pool-manager';
-import { DEX_KEY, EKUBO_V3_CONFIG } from './config';
+import { DEX_KEY, EKUBO_V3_CONFIG, VE33_ADDRESS } from './config';
 import { ekuboContracts } from './utils';
 import { IDexHelper } from '../../dex-helper';
+import { PoolConfig, PoolKey, StableswapPoolTypeConfig } from './pools/utils';
+import { VE33_MIN_BITMAPS_SEARCHED } from './pools/ve33';
 
 const hex16 = (n: number) => `0x${n.toString(16).padStart(32, '0')}`;
 
@@ -40,6 +43,7 @@ const makeTestCtx = () => {
 
   const dexHelper = {
     provider,
+    config: { isSlave: true },
     httpRequest: { querySubgraph },
     blockManager: { subscribeToLogs },
   } as unknown as IDexHelper;
@@ -166,5 +170,78 @@ describe('EkuboV3PoolManager subgraph pagination', () => {
     expect((res.poolKeysRes as Error).message).toBe(
       'Subgraph pool key retrieval failed',
     );
+  });
+});
+
+describe('EkuboV3PoolManager Ve33 initialization', () => {
+  test('fetches the dynamic fee and uses consistent bitmap depth on regeneration', async () => {
+    const { dexHelper, contracts, logger } = makeTestCtx();
+    const manager = new EkuboV3PoolManager(
+      DEX_KEY,
+      logger,
+      dexHelper,
+      contracts,
+      EKUBO_V3_CONFIG[DEX_KEY][Network.ROBINHOOD].subgraphId,
+    );
+    const getVe33QuoteData = jest.fn().mockResolvedValue([
+      {
+        quoteData: {
+          tick: 0,
+          sqrtRatio: BigNumber.from(0),
+          liquidity: BigNumber.from(1_000_000),
+          minTick: 0,
+          maxTick: 0,
+          ticks: [],
+        },
+        swapFee: BigNumber.from(123),
+      },
+    ]);
+    contracts.ve33.quoteDataFetcher = {
+      getVe33QuoteData,
+    } as any;
+
+    const poolKeys = [
+      new PoolKey(
+        1n,
+        2n,
+        new PoolConfig(
+          BigInt(VE33_ADDRESS),
+          0n,
+          StableswapPoolTypeConfig.fullRangeConfig(),
+        ),
+      ),
+      new PoolKey(
+        1n,
+        3n,
+        new PoolConfig(
+          BigInt(VE33_ADDRESS),
+          0n,
+          new StableswapPoolTypeConfig(0, 1),
+        ),
+      ),
+    ];
+
+    for (const poolKey of poolKeys) {
+      await (manager as any).handlePoolInitialized(
+        { poolKey: poolKey.toAbi(), sqrtRatio: 0n, tick: 0 },
+        { number: 123 },
+      );
+
+      const pool = manager.poolsByBI.get(poolKey.numId);
+      expect(pool).toBeDefined();
+      expect((pool as any).getState(123).swapFee).toBe(123n);
+      await pool!.updateState(124);
+    }
+
+    expect(getVe33QuoteData).toHaveBeenCalledTimes(4);
+    for (const call of getVe33QuoteData.mock.calls) {
+      expect(call[1]).toBe(VE33_MIN_BITMAPS_SEARCHED);
+    }
+    expect(getVe33QuoteData.mock.calls.map(call => call[2])).toEqual([
+      { blockTag: 123 },
+      { blockTag: 124 },
+      { blockTag: 123 },
+      { blockTag: 124 },
+    ]);
   });
 });

--- a/src/dex/ekubo-v3/ekubo-v3-pool-manager.ts
+++ b/src/dex/ekubo-v3/ekubo-v3-pool-manager.ts
@@ -39,6 +39,7 @@ import { TwammPool, TwammPoolState } from './pools/twamm';
 import { BoostedFeesPool, BoostedFeesPoolState } from './pools/boosted-fees';
 import { ExtensionType, extensionType } from './extension-type';
 import {
+  VE33_MIN_BITMAPS_SEARCHED,
   Ve33ConcentratedPool,
   Ve33FullRangePool,
   Ve33StableswapPool,
@@ -97,7 +98,6 @@ const SUBGRAPH_QUERY = `query ($lastId: Bytes!) {
 }`;
 
 const MIN_BITMAPS_SEARCHED = 2;
-const VE33_MIN_BITMAPS_SEARCHED = 10;
 const MAX_BATCH_SIZE = 100;
 
 const MAX_SUBGRAPH_RETRIES = 10;
@@ -271,7 +271,7 @@ export class EkuboV3PoolManager implements EventSubscriber {
         }
 
         try {
-          this.handlePoolInitialized(
+          await this.handlePoolInitialized(
             this.contracts.core.interface.decodeEventLog(
               this.poolInitializedFragment,
               log.data,
@@ -933,10 +933,10 @@ export class EkuboV3PoolManager implements EventSubscriber {
     this.poolsByString.clear();
   }
 
-  private handlePoolInitialized(
+  private async handlePoolInitialized(
     ev: Result,
     blockHeader: Readonly<BlockHeader>,
-  ) {
+  ): Promise<void> {
     const poolKey = PoolKey.fromAbi(ev.poolKey);
     const { extension } = poolKey.config;
     const blockNumber = blockHeader.number;
@@ -965,6 +965,18 @@ export class EkuboV3PoolManager implements EventSubscriber {
       this.setPool(pool);
     };
 
+    const fetchAndAddPool = async <C extends PoolTypeConfig>(
+      constructor: {
+        new (...args: [...typeof commonArgs, PoolKey<C>]): IEkuboPool<C>;
+      },
+      poolKey: PoolKey<C>,
+    ): Promise<void> => {
+      const pool = new constructor(...commonArgs, poolKey);
+      pool.isTracking = this.isTracking;
+      await pool.updateState(blockNumber);
+      this.setPool(pool);
+    };
+
     if (isStableswapKey(poolKey)) {
       switch (extensionType(extension)) {
         case ExtensionType.NoSwapCallPoints:
@@ -986,13 +998,9 @@ export class EkuboV3PoolManager implements EventSubscriber {
             TwammPoolState.fromPoolInitialization(state),
           );
         case ExtensionType.Ve33:
-          const ve33State = {
-            ...FullRangePoolState.fromPoolInitialization(state),
-            swapFee: 0n,
-          };
           return poolKey.config.poolTypeConfig.isFullRange()
-            ? addPool(Ve33FullRangePool, poolKey, ve33State)
-            : addPool(Ve33StableswapPool, poolKey, ve33State);
+            ? fetchAndAddPool(Ve33FullRangePool, poolKey)
+            : fetchAndAddPool(Ve33StableswapPool, poolKey);
         default:
           this.logger.debug(
             `Ignoring unknown pool extension ${hexZeroPad(
@@ -1017,10 +1025,7 @@ export class EkuboV3PoolManager implements EventSubscriber {
             BoostedFeesPoolState.fromPoolInitialization(state),
           );
         case ExtensionType.Ve33:
-          return addPool(Ve33ConcentratedPool, poolKey, {
-            ...concentratedPoolState,
-            swapFee: 0n,
-          });
+          return fetchAndAddPool(Ve33ConcentratedPool, poolKey);
         default:
           this.logger.debug(
             `Ignoring unknown pool extension ${hexZeroPad(

--- a/src/dex/ekubo-v3/ekubo-v3-pool-manager.ts
+++ b/src/dex/ekubo-v3/ekubo-v3-pool-manager.ts
@@ -23,6 +23,7 @@ import {
   MEV_CAPTURE_ADDRESS,
   ORACLE_ADDRESS,
   TWAMM_ADDRESS,
+  VE33_ADDRESS,
 } from './config';
 import { FullRangePool, FullRangePoolState } from './pools/full-range';
 import { StableswapPool } from './pools/stableswap';
@@ -32,11 +33,18 @@ import { MevCapturePool } from './pools/mev-capture';
 import { TwammPool, TwammPoolState } from './pools/twamm';
 import { BoostedFeesPool, BoostedFeesPoolState } from './pools/boosted-fees';
 import { ExtensionType, extensionType } from './extension-type';
+import {
+  Ve33ConcentratedPool,
+  Ve33FullRangePool,
+  Ve33PoolState,
+  Ve33StableswapPool,
+} from './pools/ve33';
 
 export const EVENT_EMITTERS = [
   CORE_ADDRESS,
   TWAMM_ADDRESS,
   BOOSTED_FEES_CONCENTRATED_ADDRESS,
+  VE33_ADDRESS,
 ];
 
 const SUBGRAPH_PAGE_SIZE = 1000;
@@ -45,6 +53,7 @@ const SUBGRAPH_EXTENSIONS = [
   TWAMM_ADDRESS,
   MEV_CAPTURE_ADDRESS,
   BOOSTED_FEES_CONCENTRATED_ADDRESS,
+  VE33_ADDRESS,
 ];
 const SUBGRAPH_QUERY = `query ($lastId: Bytes!) {
   _meta {
@@ -151,6 +160,7 @@ export class EkuboV3PoolManager implements EventSubscriber {
         contract: boostedFeesContract,
         interface: boostedFeesIface,
       },
+      ve33: { contract: ve33Contract, interface: ve33Iface },
     } = contracts;
 
     this.poolInitializedFragment = coreIface.getEvent('PoolInitialized');
@@ -188,6 +198,12 @@ export class EkuboV3PoolManager implements EventSubscriber {
         [
           boostedFeesIface.getEventTopic('PoolBoosted'),
           parsePoolIdByLogDataOffsetFn(0),
+        ],
+      ]),
+      [ve33Contract.address]: new Map([
+        [
+          ve33Iface.getEventTopic('VoteWeightApplied'),
+          parsePoolIdByLogDataOffsetFn(64),
         ],
       ]),
     };
@@ -500,50 +516,62 @@ export class EkuboV3PoolManager implements EventSubscriber {
       this.clearPools();
     }
 
-    const [twammPoolKeys, boostedFeesPoolKeys, otherPoolKeys] = poolKeys.reduce<
-      [
-        PoolKeyWithInitBlockNumber<StableswapPoolTypeConfig>[],
-        PoolKeyWithInitBlockNumber<ConcentratedPoolTypeConfig>[],
-        PoolKeyWithInitBlockNumber<
-          StableswapPoolTypeConfig | ConcentratedPoolTypeConfig
-        >[],
-      ]
-    >(
-      (
-        [twammPoolKeys, boostedFeesPoolKeys, otherPoolKeys],
-        poolKeyWithInitBlockNumber,
-      ) => {
-        switch (
-          extensionType(poolKeyWithInitBlockNumber.key.config.extension)
-        ) {
-          case ExtensionType.Twamm:
-            twammPoolKeys.push(
-              poolKeyWithInitBlockNumber as PoolKeyWithInitBlockNumber<StableswapPoolTypeConfig>,
-            );
-            break;
-          case ExtensionType.BoostedFeesConcentrated:
-            boostedFeesPoolKeys.push(
-              poolKeyWithInitBlockNumber as PoolKeyWithInitBlockNumber<ConcentratedPoolTypeConfig>,
-            );
-            break;
-          case ExtensionType.NoSwapCallPoints:
-          case ExtensionType.Oracle:
-          case ExtensionType.MevCapture:
-            otherPoolKeys.push(poolKeyWithInitBlockNumber);
-            break;
-          default:
-            this.logger.debug(
-              `Ignoring unknown pool extension ${hexZeroPad(
-                hexlify(poolKeyWithInitBlockNumber.key.config.extension),
-                20,
-              )}`,
-            );
-        }
+    const [twammPoolKeys, boostedFeesPoolKeys, ve33PoolKeys, otherPoolKeys] =
+      poolKeys.reduce<
+        [
+          PoolKeyWithInitBlockNumber<StableswapPoolTypeConfig>[],
+          PoolKeyWithInitBlockNumber<ConcentratedPoolTypeConfig>[],
+          PoolKeyWithInitBlockNumber<
+            StableswapPoolTypeConfig | ConcentratedPoolTypeConfig
+          >[],
+          PoolKeyWithInitBlockNumber<
+            StableswapPoolTypeConfig | ConcentratedPoolTypeConfig
+          >[],
+        ]
+      >(
+        (
+          [twammPoolKeys, boostedFeesPoolKeys, ve33PoolKeys, otherPoolKeys],
+          poolKeyWithInitBlockNumber,
+        ) => {
+          switch (
+            extensionType(poolKeyWithInitBlockNumber.key.config.extension)
+          ) {
+            case ExtensionType.Twamm:
+              twammPoolKeys.push(
+                poolKeyWithInitBlockNumber as PoolKeyWithInitBlockNumber<StableswapPoolTypeConfig>,
+              );
+              break;
+            case ExtensionType.BoostedFeesConcentrated:
+              boostedFeesPoolKeys.push(
+                poolKeyWithInitBlockNumber as PoolKeyWithInitBlockNumber<ConcentratedPoolTypeConfig>,
+              );
+              break;
+            case ExtensionType.Ve33:
+              ve33PoolKeys.push(poolKeyWithInitBlockNumber);
+              break;
+            case ExtensionType.NoSwapCallPoints:
+            case ExtensionType.Oracle:
+            case ExtensionType.MevCapture:
+              otherPoolKeys.push(poolKeyWithInitBlockNumber);
+              break;
+            default:
+              this.logger.debug(
+                `Ignoring unknown pool extension ${hexZeroPad(
+                  hexlify(poolKeyWithInitBlockNumber.key.config.extension),
+                  20,
+                )}`,
+              );
+          }
 
-        return [twammPoolKeys, boostedFeesPoolKeys, otherPoolKeys];
-      },
-      [[], [], []],
-    );
+          return [
+            twammPoolKeys,
+            boostedFeesPoolKeys,
+            ve33PoolKeys,
+            otherPoolKeys,
+          ];
+        },
+        [[], [], [], []],
+      );
 
     const promises: Promise<void>[] = [];
 
@@ -691,6 +719,38 @@ export class EkuboV3PoolManager implements EventSubscriber {
           >(TwammPool, undefined, initBlockNumber, key);
         } catch (err) {
           this.logger.error(`Failed to construct pool ${key.stringId}: ${err}`);
+        }
+      }),
+    );
+
+    promises.push(
+      ...ve33PoolKeys.map(async ({ key, initBlockNumber }) => {
+        try {
+          if (isStableswapKey(key)) {
+            if (key.config.poolTypeConfig.isFullRange()) {
+              await addPool<
+                StableswapPoolTypeConfig,
+                Ve33PoolState<FullRangePoolState.Object>,
+                Ve33FullRangePool
+              >(Ve33FullRangePool, undefined, initBlockNumber, key);
+            } else {
+              await addPool<
+                StableswapPoolTypeConfig,
+                Ve33PoolState<FullRangePoolState.Object>,
+                Ve33StableswapPool
+              >(Ve33StableswapPool, undefined, initBlockNumber, key);
+            }
+          } else if (isConcentratedKey(key)) {
+            await addPool<
+              ConcentratedPoolTypeConfig,
+              Ve33PoolState<ConcentratedPoolState.Object>,
+              Ve33ConcentratedPool
+            >(Ve33ConcentratedPool, undefined, initBlockNumber, key);
+          }
+        } catch (err) {
+          this.logger.error(
+            `Failed to construct Ve33 pool ${key.stringId}: ${err}`,
+          );
         }
       }),
     );
@@ -883,6 +943,14 @@ export class EkuboV3PoolManager implements EventSubscriber {
             poolKey,
             TwammPoolState.fromPoolInitialization(state),
           );
+        case ExtensionType.Ve33:
+          const ve33State = {
+            ...FullRangePoolState.fromPoolInitialization(state),
+            swapFee: 0n,
+          };
+          return poolKey.config.poolTypeConfig.isFullRange()
+            ? addPool(Ve33FullRangePool, poolKey, ve33State)
+            : addPool(Ve33StableswapPool, poolKey, ve33State);
         default:
           this.logger.debug(
             `Ignoring unknown pool extension ${hexZeroPad(
@@ -906,6 +974,11 @@ export class EkuboV3PoolManager implements EventSubscriber {
             poolKey,
             BoostedFeesPoolState.fromPoolInitialization(state),
           );
+        case ExtensionType.Ve33:
+          return addPool(Ve33ConcentratedPool, poolKey, {
+            ...concentratedPoolState,
+            swapFee: 0n,
+          });
         default:
           this.logger.debug(
             `Ignoring unknown pool extension ${hexZeroPad(

--- a/src/dex/ekubo-v3/ekubo-v3-pool-manager.ts
+++ b/src/dex/ekubo-v3/ekubo-v3-pool-manager.ts
@@ -209,7 +209,11 @@ export class EkuboV3PoolManager implements EventSubscriber {
         [
           ve33Iface.getEventTopic('VoteWeightApplied'),
           data =>
-            BigInt(ve33Iface.decodeEventLog('VoteWeightApplied', data).poolId),
+            BigInt(
+              ve33Iface.decodeEventLog('VoteWeightApplied', data, [
+                ve33Iface.getEventTopic('VoteWeightApplied'),
+              ]).poolId,
+            ),
         ],
       ]),
     };

--- a/src/dex/ekubo-v3/ekubo-v3-pool-manager.ts
+++ b/src/dex/ekubo-v3/ekubo-v3-pool-manager.ts
@@ -1,5 +1,10 @@
 import { Result } from '@ethersproject/abi';
-import { BasicQuoteData, BoostedFeesQuoteData, EkuboContracts } from './types';
+import {
+  BasicQuoteData,
+  BoostedFeesQuoteData,
+  EkuboContracts,
+  Ve33QuoteData,
+} from './types';
 import { DeepReadonly } from 'ts-essentials';
 import { BlockHeader } from 'web3-eth';
 import { Log, Logger, Token } from '../../types';
@@ -36,7 +41,6 @@ import { ExtensionType, extensionType } from './extension-type';
 import {
   Ve33ConcentratedPool,
   Ve33FullRangePool,
-  Ve33PoolState,
   Ve33StableswapPool,
 } from './pools/ve33';
 
@@ -93,6 +97,7 @@ const SUBGRAPH_QUERY = `query ($lastId: Bytes!) {
 }`;
 
 const MIN_BITMAPS_SEARCHED = 2;
+const VE33_MIN_BITMAPS_SEARCHED = 10;
 const MAX_BATCH_SIZE = 100;
 
 const MAX_SUBGRAPH_RETRIES = 10;
@@ -203,7 +208,8 @@ export class EkuboV3PoolManager implements EventSubscriber {
       [ve33Contract.address]: new Map([
         [
           ve33Iface.getEventTopic('VoteWeightApplied'),
-          parsePoolIdByLogDataOffsetFn(64),
+          data =>
+            BigInt(ve33Iface.decodeEventLog('VoteWeightApplied', data).poolId),
         ],
       ]),
     };
@@ -723,37 +729,69 @@ export class EkuboV3PoolManager implements EventSubscriber {
       }),
     );
 
-    promises.push(
-      ...ve33PoolKeys.map(async ({ key, initBlockNumber }) => {
-        try {
-          if (isStableswapKey(key)) {
-            if (key.config.poolTypeConfig.isFullRange()) {
-              await addPool<
-                StableswapPoolTypeConfig,
-                Ve33PoolState<FullRangePoolState.Object>,
-                Ve33FullRangePool
-              >(Ve33FullRangePool, undefined, initBlockNumber, key);
-            } else {
-              await addPool<
-                StableswapPoolTypeConfig,
-                Ve33PoolState<FullRangePoolState.Object>,
-                Ve33StableswapPool
-              >(Ve33StableswapPool, undefined, initBlockNumber, key);
-            }
-          } else if (isConcentratedKey(key)) {
-            await addPool<
-              ConcentratedPoolTypeConfig,
-              Ve33PoolState<ConcentratedPoolState.Object>,
-              Ve33ConcentratedPool
-            >(Ve33ConcentratedPool, undefined, initBlockNumber, key);
-          }
-        } catch (err) {
-          this.logger.error(
-            `Failed to construct Ve33 pool ${key.stringId}: ${err}`,
-          );
-        }
-      }),
-    );
+    for (
+      let batchStart = 0;
+      batchStart < ve33PoolKeys.length;
+      batchStart += MAX_BATCH_SIZE
+    ) {
+      const batch = ve33PoolKeys.slice(batchStart, batchStart + MAX_BATCH_SIZE);
+
+      promises.push(
+        (
+          this.contracts.ve33.quoteDataFetcher.getVe33QuoteData(
+            batch.map(({ key }) => key.toAbi()),
+            VE33_MIN_BITMAPS_SEARCHED,
+            { blockTag: blockNumber },
+          ) as Promise<Ve33QuoteData[]>
+        )
+          .then(async fetchedData => {
+            await Promise.all(
+              fetchedData.map(async (data, i) => {
+                const { key, initBlockNumber } = batch[i];
+                const swapFee = data.swapFee.toBigInt();
+
+                try {
+                  if (isStableswapKey(key)) {
+                    const state = {
+                      ...FullRangePoolState.fromQuoter(data.quoteData),
+                      swapFee,
+                    };
+                    await (key.config.poolTypeConfig.isFullRange()
+                      ? addPool(Ve33FullRangePool, state, initBlockNumber, key)
+                      : addPool(
+                          Ve33StableswapPool,
+                          state,
+                          initBlockNumber,
+                          key,
+                        ));
+                  } else if (isConcentratedKey(key)) {
+                    await addPool(
+                      Ve33ConcentratedPool,
+                      {
+                        ...ConcentratedPoolState.fromQuoter(data.quoteData),
+                        swapFee,
+                      },
+                      initBlockNumber,
+                      key,
+                    );
+                  }
+                } catch (err) {
+                  this.logger.error(
+                    `Failed to construct Ve33 pool ${key.stringId}: ${err}`,
+                  );
+                }
+              }),
+            );
+          })
+          .catch((err: any) => {
+            this.logger.error(
+              `Fetching Ve33 batch failed. Pool keys: ${batch.map(
+                ({ key }) => key.stringId,
+              )}. Error: ${err}`,
+            );
+          }),
+      );
+    }
 
     const boostedFeesDataFetcher = this.contracts.boostedFees.quoteDataFetcher;
     const coreQuoteDataFetcher = this.contracts.core.quoteDataFetcher;

--- a/src/dex/ekubo-v3/ekubo-v3.ts
+++ b/src/dex/ekubo-v3/ekubo-v3.ts
@@ -212,7 +212,7 @@ export class EkuboV3 extends SimpleExchange implements IDex<EkuboData> {
         [data.poolKeyAbi, params, recipient],
       ),
       sendEthButSupportsInsertFromAmount: true,
-      targetExchange: ROUTER_ADDRESS,
+      targetExchange: this.config.router,
       dexFuncHasRecipient: true,
       returnAmountPos: undefined,
       amountsPacked128: true,

--- a/src/dex/ekubo-v3/extension-type.ts
+++ b/src/dex/ekubo-v3/extension-type.ts
@@ -3,6 +3,7 @@ import {
   MEV_CAPTURE_ADDRESS,
   ORACLE_ADDRESS,
   TWAMM_ADDRESS,
+  VE33_ADDRESS,
 } from './config';
 
 export const enum ExtensionType {
@@ -12,6 +13,7 @@ export const enum ExtensionType {
   Twamm,
   MevCapture,
   BoostedFeesConcentrated,
+  Ve33,
 }
 
 const KNOWN_EXTENSION_TYPES = new Map<bigint, ExtensionType>([
@@ -22,6 +24,7 @@ const KNOWN_EXTENSION_TYPES = new Map<bigint, ExtensionType>([
     BigInt(BOOSTED_FEES_CONCENTRATED_ADDRESS),
     ExtensionType.BoostedFeesConcentrated,
   ],
+  [BigInt(VE33_ADDRESS), ExtensionType.Ve33],
 ]);
 
 export function extensionType(extension: bigint): ExtensionType {

--- a/src/dex/ekubo-v3/pools/full-range.ts
+++ b/src/dex/ekubo-v3/pools/full-range.ts
@@ -7,7 +7,7 @@ import {
   EkuboContracts,
   PoolInitializationState,
 } from '../types';
-import { EkuboPool, Quote } from './pool';
+import { EkuboPool, NamedEventHandlers, Quote } from './pool';
 import { floatSqrtRatioToFixed } from './math/sqrt-ratio';
 import { computeStep, isPriceIncreasing } from './math/swap';
 import { MAX_SQRT_RATIO, MIN_SQRT_RATIO } from './math/tick';
@@ -28,6 +28,7 @@ export abstract class FullRangePoolBase<
     contracts: EkuboContracts,
     initBlockNumber: number,
     key: PoolKey<StableswapPoolTypeConfig>,
+    extraNamedEventHandlers: Record<string, NamedEventHandlers<S>> = {},
   ) {
     const {
       contract: { address },
@@ -35,7 +36,16 @@ export abstract class FullRangePoolBase<
       quoteDataFetcher,
     } = contracts.core;
 
-    super(parentName, dexHelper, logger, initBlockNumber, key, address, iface);
+    super(
+      parentName,
+      dexHelper,
+      logger,
+      initBlockNumber,
+      key,
+      address,
+      iface,
+      extraNamedEventHandlers,
+    );
 
     this.quoteDataFetcher = quoteDataFetcher;
   }

--- a/src/dex/ekubo-v3/pools/stableswap.ts
+++ b/src/dex/ekubo-v3/pools/stableswap.ts
@@ -3,7 +3,7 @@ import { Result } from '@ethersproject/abi';
 import { IDexHelper } from '../../../dex-helper/idex-helper';
 import { Logger } from '../../../types';
 import { EkuboContracts } from '../types';
-import { EkuboPool, Quote } from './pool';
+import { EkuboPool, NamedEventHandlers, Quote } from './pool';
 import { computeStep, isPriceIncreasing } from './math/swap';
 import {
   MAX_SQRT_RATIO,
@@ -32,6 +32,7 @@ export abstract class StableswapPoolBase<
     contracts: EkuboContracts,
     initBlockNumber: number,
     key: PoolKey<StableswapPoolTypeConfig>,
+    extraNamedEventHandlers: Record<string, NamedEventHandlers<S>> = {},
   ) {
     const {
       contract: { address },
@@ -39,7 +40,16 @@ export abstract class StableswapPoolBase<
       quoteDataFetcher,
     } = contracts.core;
 
-    super(parentName, dexHelper, logger, initBlockNumber, key, address, iface);
+    super(
+      parentName,
+      dexHelper,
+      logger,
+      initBlockNumber,
+      key,
+      address,
+      iface,
+      extraNamedEventHandlers,
+    );
 
     this.quoteDataFetcher = quoteDataFetcher;
 

--- a/src/dex/ekubo-v3/pools/timed.test.ts
+++ b/src/dex/ekubo-v3/pools/timed.test.ts
@@ -1,0 +1,21 @@
+import { Network } from '../../../constants';
+import { estimatedCurrentTime } from './timed';
+
+describe(estimatedCurrentTime, () => {
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(100_000);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('does not advance Robinhood time within the same timestamp second', () => {
+    expect(estimatedCurrentTime(100n, Network.ROBINHOOD)).toBe(100n);
+  });
+
+  test('retains the minimum slot duration on slower chains', () => {
+    expect(estimatedCurrentTime(100n, Network.ARBITRUM)).toBe(101n);
+    expect(estimatedCurrentTime(100n, Network.MAINNET)).toBe(112n);
+  });
+});

--- a/src/dex/ekubo-v3/pools/timed.ts
+++ b/src/dex/ekubo-v3/pools/timed.ts
@@ -5,6 +5,7 @@ import { EkuboSupportedNetwork } from '../config';
 const SLOT_DURATION_SECS_BY_CHAIN_ID: Record<EkuboSupportedNetwork, bigint> = {
   [Network.MAINNET]: 12n,
   [Network.ARBITRUM]: 1n,
+  [Network.ROBINHOOD]: 1n,
 };
 
 export type RateDeltaBoundary = readonly [

--- a/src/dex/ekubo-v3/pools/timed.ts
+++ b/src/dex/ekubo-v3/pools/timed.ts
@@ -5,7 +5,9 @@ import { EkuboSupportedNetwork } from '../config';
 const SLOT_DURATION_SECS_BY_CHAIN_ID: Record<EkuboSupportedNetwork, bigint> = {
   [Network.MAINNET]: 12n,
   [Network.ARBITRUM]: 1n,
-  [Network.ROBINHOOD]: 1n,
+  // Robinhood produces multiple blocks per timestamp second, so the next
+  // block is not guaranteed to advance block.timestamp.
+  [Network.ROBINHOOD]: 0n,
 };
 
 export type RateDeltaBoundary = readonly [

--- a/src/dex/ekubo-v3/pools/ve33.test.ts
+++ b/src/dex/ekubo-v3/pools/ve33.test.ts
@@ -1,0 +1,43 @@
+import { quoteVe33 } from './ve33';
+
+const ONE_PERCENT_FEE = (1n << 64n) / 100n;
+
+function underlyingQuote(calculatedAmount: bigint, consumedAmount: bigint) {
+  return {
+    calculatedAmount,
+    consumedAmount,
+    gasConsumed: 10,
+    skipAhead: 0,
+    stateAfter: { marker: 1 },
+  };
+}
+
+describe(quoteVe33, () => {
+  test('exact input takes the voted fee from actual output', () => {
+    const quote = quoteVe33(
+      underlyingQuote(999n, 500n),
+      1_000n,
+      ONE_PERCENT_FEE,
+    );
+
+    expect(quote.consumedAmount).toBe(500n);
+    expect(quote.calculatedAmount).toBe(989n);
+    expect(quote.stateAfter).toEqual({ marker: 1, swapFee: ONE_PERCENT_FEE });
+  });
+
+  test('exact output grosses up the required input', () => {
+    const quote = quoteVe33(
+      underlyingQuote(1_000n, -500n),
+      -500n,
+      ONE_PERCENT_FEE,
+    );
+
+    expect(quote.calculatedAmount).toBe(1_011n);
+  });
+
+  test('zero fee leaves the underlying amount unchanged', () => {
+    expect(
+      quoteVe33(underlyingQuote(999n, 1_000n), 1_000n, 0n).calculatedAmount,
+    ).toBe(999n);
+  });
+});

--- a/src/dex/ekubo-v3/pools/ve33.ts
+++ b/src/dex/ekubo-v3/pools/ve33.ts
@@ -4,7 +4,7 @@ import { hexDataSlice } from 'ethers/lib/utils';
 import { DeepReadonly } from 'ts-essentials';
 import { IDexHelper } from '../../../dex-helper/idex-helper';
 import { Logger } from '../../../types';
-import { BasicQuoteData, EkuboContracts } from '../types';
+import { BasicQuoteData, EkuboContracts, Ve33QuoteData } from '../types';
 import {
   ConcentratedPoolBase,
   ConcentratedPoolState,
@@ -79,16 +79,15 @@ async function fetchVe33State(
   tickSpacings: number,
   blockNumber?: number | 'latest',
 ): Promise<[BasicQuoteData, bigint]> {
-  const [quoteData, swapFees] = await Promise.all([
-    contracts.core.quoteDataFetcher.getQuoteData([key.toAbi()], tickSpacings, {
+  const results = (await contracts.ve33.quoteDataFetcher.getVe33QuoteData(
+    [key.toAbi()],
+    tickSpacings,
+    {
       blockTag: blockNumber,
-    }) as Promise<BasicQuoteData[]>,
-    contracts.ve33.quoteDataFetcher.getPoolSwapFees([key.numId], {
-      blockTag: blockNumber,
-    }) as Promise<BigNumber[]>,
-  ]);
+    },
+  )) as Ve33QuoteData[];
 
-  return [quoteData[0], swapFees[0].toBigInt()];
+  return [results[0].quoteData, results[0].swapFee.toBigInt()];
 }
 
 export class Ve33FullRangePool extends FullRangePoolBase<

--- a/src/dex/ekubo-v3/pools/ve33.ts
+++ b/src/dex/ekubo-v3/pools/ve33.ts
@@ -30,6 +30,7 @@ import {
 } from './utils';
 
 const EXTRA_BASE_GAS_COST_OF_ONE_VE33_SWAP = 30_000;
+export const VE33_MIN_BITMAPS_SEARCHED = 10;
 
 export type Ve33PoolState<S> = S & { swapFee: bigint };
 
@@ -121,7 +122,7 @@ export class Ve33FullRangePool extends FullRangePoolBase<
     const [data, swapFee] = await fetchVe33State(
       this.ve33Contracts,
       this.key,
-      0,
+      VE33_MIN_BITMAPS_SEARCHED,
       blockNumber,
     );
     return { ...FullRangePoolState.fromQuoter(data), swapFee };
@@ -191,7 +192,7 @@ export class Ve33StableswapPool extends StableswapPoolBase<
     const [data, swapFee] = await fetchVe33State(
       this.ve33Contracts,
       this.key,
-      0,
+      VE33_MIN_BITMAPS_SEARCHED,
       blockNumber,
     );
     return { ...FullRangePoolState.fromQuoter(data), swapFee };
@@ -268,7 +269,7 @@ export class Ve33ConcentratedPool extends ConcentratedPoolBase<
     const [data, swapFee] = await fetchVe33State(
       this.ve33Contracts,
       this.key,
-      10,
+      VE33_MIN_BITMAPS_SEARCHED,
       blockNumber,
     );
     return { ...ConcentratedPoolState.fromQuoter(data), swapFee };

--- a/src/dex/ekubo-v3/pools/ve33.ts
+++ b/src/dex/ekubo-v3/pools/ve33.ts
@@ -1,0 +1,319 @@
+import { Result } from '@ethersproject/abi';
+import { BigNumber } from 'ethers';
+import { hexDataSlice } from 'ethers/lib/utils';
+import { DeepReadonly } from 'ts-essentials';
+import { IDexHelper } from '../../../dex-helper/idex-helper';
+import { Logger } from '../../../types';
+import { BasicQuoteData, EkuboContracts } from '../types';
+import {
+  ConcentratedPoolBase,
+  ConcentratedPoolState,
+  quoteConcentrated,
+} from './concentrated';
+import {
+  FullRangePoolBase,
+  FullRangePoolState,
+  quoteFullRange,
+} from './full-range';
+import { amountBeforeFee, computeFee } from './math/swap';
+import { NamedEventHandlers, Quote } from './pool';
+import {
+  quoteStableswap,
+  StableswapPoolBase,
+  computeStableswapBounds,
+} from './stableswap';
+import {
+  ConcentratedPoolTypeConfig,
+  PoolKey,
+  StableswapPoolTypeConfig,
+  SwappedEvent,
+} from './utils';
+
+const EXTRA_BASE_GAS_COST_OF_ONE_VE33_SWAP = 30_000;
+
+export type Ve33PoolState<S> = S & { swapFee: bigint };
+
+export function quoteVe33<S extends object>(
+  quote: Quote<S>,
+  amount: bigint,
+  swapFee: bigint,
+): Quote<S & { swapFee: bigint }> {
+  const statefulQuote = quote as Quote<S> & { stateAfter: S };
+  let calculatedAmount = quote.calculatedAmount;
+
+  if (swapFee !== 0n && calculatedAmount !== 0n) {
+    if (amount >= 0n) {
+      calculatedAmount -= computeFee(calculatedAmount, swapFee);
+    } else {
+      calculatedAmount = amountBeforeFee(calculatedAmount, swapFee);
+    }
+  }
+
+  return {
+    ...statefulQuote,
+    calculatedAmount,
+    gasConsumed: quote.gasConsumed + EXTRA_BASE_GAS_COST_OF_ONE_VE33_SWAP,
+    stateAfter: { ...statefulQuote.stateAfter, swapFee },
+  } as Quote<S & { swapFee: bigint }>;
+}
+
+function ve33EventHandlers<S extends { swapFee: bigint }>(
+  contracts: EkuboContracts,
+  key: PoolKey<any>,
+): Record<string, NamedEventHandlers<S>> {
+  const { contract, interface: iface } = contracts.ve33;
+
+  return {
+    [contract.address]: new NamedEventHandlers(iface, {
+      VoteWeightApplied: (args, oldState) =>
+        BigInt(args.poolId) === key.numId
+          ? { ...oldState, swapFee: args.swapFee.toBigInt() }
+          : null,
+    }),
+  };
+}
+
+async function fetchVe33State(
+  contracts: EkuboContracts,
+  key: PoolKey<any>,
+  tickSpacings: number,
+  blockNumber?: number | 'latest',
+): Promise<[BasicQuoteData, bigint]> {
+  const [quoteData, swapFees] = await Promise.all([
+    contracts.core.quoteDataFetcher.getQuoteData([key.toAbi()], tickSpacings, {
+      blockTag: blockNumber,
+    }) as Promise<BasicQuoteData[]>,
+    contracts.ve33.quoteDataFetcher.getPoolSwapFees([key.numId], {
+      blockTag: blockNumber,
+    }) as Promise<BigNumber[]>,
+  ]);
+
+  return [quoteData[0], swapFees[0].toBigInt()];
+}
+
+export class Ve33FullRangePool extends FullRangePoolBase<
+  Ve33PoolState<FullRangePoolState.Object>
+> {
+  private readonly ve33Contracts: EkuboContracts;
+
+  public constructor(
+    parentName: string,
+    dexHelper: IDexHelper,
+    logger: Logger,
+    contracts: EkuboContracts,
+    initBlockNumber: number,
+    key: PoolKey<StableswapPoolTypeConfig>,
+  ) {
+    super(
+      parentName,
+      dexHelper,
+      logger,
+      contracts,
+      initBlockNumber,
+      key,
+      ve33EventHandlers(contracts, key),
+    );
+    this.ve33Contracts = contracts;
+  }
+
+  public override async generateState(
+    blockNumber?: number | 'latest',
+  ): Promise<DeepReadonly<Ve33PoolState<FullRangePoolState.Object>>> {
+    const [data, swapFee] = await fetchVe33State(
+      this.ve33Contracts,
+      this.key,
+      0,
+      blockNumber,
+    );
+    return { ...FullRangePoolState.fromQuoter(data), swapFee };
+  }
+
+  protected override _quote(
+    amount: bigint,
+    isToken1: boolean,
+    state: DeepReadonly<Ve33PoolState<FullRangePoolState.Object>>,
+    sqrtRatioLimit?: bigint,
+  ) {
+    return quoteVe33(
+      quoteFullRange(this.key, amount, isToken1, state, sqrtRatioLimit),
+      amount,
+      state.swapFee,
+    );
+  }
+
+  protected override handlePositionUpdated(
+    args: Result,
+    oldState: DeepReadonly<Ve33PoolState<FullRangePoolState.Object>>,
+  ) {
+    const state = FullRangePoolState.fromPositionUpdatedEvent(
+      oldState,
+      args.liquidityDelta.toBigInt(),
+    );
+    return state === null ? null : { ...state, swapFee: oldState.swapFee };
+  }
+
+  protected override handleSwappedEvent(
+    ev: SwappedEvent,
+    oldState: DeepReadonly<Ve33PoolState<FullRangePoolState.Object>>,
+  ) {
+    return {
+      ...FullRangePoolState.fromSwappedEvent(ev),
+      swapFee: oldState.swapFee,
+    };
+  }
+}
+
+export class Ve33StableswapPool extends StableswapPoolBase<
+  Ve33PoolState<FullRangePoolState.Object>
+> {
+  private readonly ve33Contracts: EkuboContracts;
+
+  public constructor(
+    parentName: string,
+    dexHelper: IDexHelper,
+    logger: Logger,
+    contracts: EkuboContracts,
+    initBlockNumber: number,
+    key: PoolKey<StableswapPoolTypeConfig>,
+  ) {
+    super(
+      parentName,
+      dexHelper,
+      logger,
+      contracts,
+      initBlockNumber,
+      key,
+      ve33EventHandlers(contracts, key),
+    );
+    this.ve33Contracts = contracts;
+  }
+
+  public override async generateState(blockNumber?: number | 'latest') {
+    const [data, swapFee] = await fetchVe33State(
+      this.ve33Contracts,
+      this.key,
+      0,
+      blockNumber,
+    );
+    return { ...FullRangePoolState.fromQuoter(data), swapFee };
+  }
+
+  protected override _quote(
+    amount: bigint,
+    isToken1: boolean,
+    state: DeepReadonly<Ve33PoolState<FullRangePoolState.Object>>,
+    sqrtRatioLimit?: bigint,
+  ) {
+    return quoteVe33(
+      quoteStableswap(
+        this.key.config.fee,
+        computeStableswapBounds(this.key.config.poolTypeConfig),
+        amount,
+        isToken1,
+        state,
+        sqrtRatioLimit,
+      ),
+      amount,
+      state.swapFee,
+    );
+  }
+
+  protected override handlePositionUpdated(
+    args: Result,
+    oldState: DeepReadonly<Ve33PoolState<FullRangePoolState.Object>>,
+  ) {
+    const state = FullRangePoolState.fromPositionUpdatedEvent(
+      oldState,
+      args.liquidityDelta.toBigInt(),
+    );
+    return state === null ? null : { ...state, swapFee: oldState.swapFee };
+  }
+
+  protected override handleSwappedEvent(
+    ev: SwappedEvent,
+    oldState: DeepReadonly<Ve33PoolState<FullRangePoolState.Object>>,
+  ) {
+    return {
+      ...FullRangePoolState.fromSwappedEvent(ev),
+      swapFee: oldState.swapFee,
+    };
+  }
+}
+
+export class Ve33ConcentratedPool extends ConcentratedPoolBase<
+  Ve33PoolState<ConcentratedPoolState.Object>
+> {
+  private readonly ve33Contracts: EkuboContracts;
+
+  public constructor(
+    parentName: string,
+    dexHelper: IDexHelper,
+    logger: Logger,
+    contracts: EkuboContracts,
+    initBlockNumber: number,
+    key: PoolKey<ConcentratedPoolTypeConfig>,
+  ) {
+    super(
+      parentName,
+      dexHelper,
+      logger,
+      contracts,
+      initBlockNumber,
+      key,
+      ve33EventHandlers(contracts, key),
+    );
+    this.ve33Contracts = contracts;
+  }
+
+  public override async generateState(blockNumber?: number | 'latest') {
+    const [data, swapFee] = await fetchVe33State(
+      this.ve33Contracts,
+      this.key,
+      10,
+      blockNumber,
+    );
+    return { ...ConcentratedPoolState.fromQuoter(data), swapFee };
+  }
+
+  protected override _quote(
+    amount: bigint,
+    isToken1: boolean,
+    state: DeepReadonly<Ve33PoolState<ConcentratedPoolState.Object>>,
+    sqrtRatioLimit?: bigint,
+  ) {
+    return quoteVe33(
+      quoteConcentrated(this.key, amount, isToken1, state, sqrtRatioLimit),
+      amount,
+      state.swapFee,
+    );
+  }
+
+  protected override handlePositionUpdated(
+    args: Result,
+    oldState: DeepReadonly<Ve33PoolState<ConcentratedPoolState.Object>>,
+  ) {
+    const state = ConcentratedPoolState.fromPositionUpdatedEvent(
+      oldState,
+      [
+        BigNumber.from(hexDataSlice(args.positionId, 24, 28))
+          .fromTwos(32)
+          .toNumber(),
+        BigNumber.from(hexDataSlice(args.positionId, 28, 32))
+          .fromTwos(32)
+          .toNumber(),
+      ],
+      args.liquidityDelta.toBigInt(),
+    );
+    return state === null ? null : { ...state, swapFee: oldState.swapFee };
+  }
+
+  protected override handleSwappedEvent(
+    ev: SwappedEvent,
+    oldState: DeepReadonly<Ve33PoolState<ConcentratedPoolState.Object>>,
+  ) {
+    return {
+      ...ConcentratedPoolState.fromSwappedEvent(oldState, ev),
+      swapFee: oldState.swapFee,
+    };
+  }
+}

--- a/src/dex/ekubo-v3/types.ts
+++ b/src/dex/ekubo-v3/types.ts
@@ -35,6 +35,7 @@ export type EkuboData = {
 
 export type DexParams = {
   subgraphId: string;
+  router: string;
 };
 
 export type EkuboContract = {
@@ -44,9 +45,13 @@ export type EkuboContract = {
 };
 
 export type EkuboContracts = Record<
-  'core' | 'twamm' | 'boostedFees',
+  'core' | 'twamm' | 'boostedFees' | 've33',
   EkuboContract
 >;
+
+export type Ve33QuoteData = {
+  swapFee: BigNumber;
+};
 
 export type BoostedFeesQuoteData = {
   sqrtRatio: BigNumber;

--- a/src/dex/ekubo-v3/types.ts
+++ b/src/dex/ekubo-v3/types.ts
@@ -50,6 +50,7 @@ export type EkuboContracts = Record<
 >;
 
 export type Ve33QuoteData = {
+  quoteData: BasicQuoteData;
   swapFee: BigNumber;
 };
 

--- a/src/dex/ekubo-v3/utils.ts
+++ b/src/dex/ekubo-v3/utils.ts
@@ -12,6 +12,8 @@ import TwammDataFetcherABI from '../../abi/ekubo-v3/twamm-data-fetcher.json';
 import TwammABI from '../../abi/ekubo-v3/twamm.json';
 import BoostedFeesDataFetcherABI from '../../abi/ekubo-v3/boosted-fees-data-fetcher.json';
 import BoostedFeesABI from '../../abi/ekubo-v3/boosted-fees.json';
+import Ve33ABI from '../../abi/ekubo-v3/ve33.json';
+import Ve33DataFetcherABI from '../../abi/ekubo-v3/ve33-data-fetcher.json';
 import {
   BOOSTED_FEES_CONCENTRATED_ADDRESS,
   BOOSTED_FEES_DATA_FETCHER_ADDRESS,
@@ -19,6 +21,8 @@ import {
   QUOTE_DATA_FETCHER_ADDRESS,
   TWAMM_ADDRESS,
   TWAMM_DATA_FETCHER_ADDRESS,
+  VE33_ADDRESS,
+  VE33_DATA_FETCHER_ADDRESS,
 } from './config';
 
 export const NATIVE_TOKEN_ADDRESS = 0x0000000000000000000000000000000000000000n;
@@ -74,6 +78,15 @@ export function ekuboContracts(provider: Provider): EkuboContracts {
       quoteDataFetcher: new Contract(
         BOOSTED_FEES_DATA_FETCHER_ADDRESS,
         BoostedFeesDataFetcherABI,
+        provider,
+      ),
+    },
+    ve33: {
+      contract: new Contract(VE33_ADDRESS, Ve33ABI, provider),
+      interface: new Interface(Ve33ABI),
+      quoteDataFetcher: new Contract(
+        VE33_DATA_FETCHER_ADDRESS,
+        Ve33DataFetcherABI,
         provider,
       ),
     },


### PR DESCRIPTION
## Summary

- add Robinhood (chain ID 4663) to the Ekubo V3 integration
- discover and track Ve33 full-range, stableswap, and concentrated pools
- initialize current Ve33 fees at the same pinned block as core pool state
- apply `VoteWeightApplied` events so quotes follow fee changes
- route execution through a per-network router configuration

## Pricing

Ve33 wraps a zero-core-fee pool with a dynamic Q64 fee. Exact-input quotes charge the fee on the calculated output; exact-output quotes gross up the calculated input with `amountBeforeFee`. This matches [Ve33.sol](https://github.com/EkuboProtocol/evm-contracts/blob/main/src/extensions/Ve33.sol) and the [Rust SDK quoter](https://github.com/EkuboProtocol/rust-sdk/blob/main/src/quoting/pools/ve33.rs).

Core quote state and current fees are batch-read atomically through merged `getVe33QuoteData` from [EkuboProtocol/evm-contracts#360](https://github.com/EkuboProtocol/evm-contracts/pull/360).

## Deployment note

Ve33 and Ve33DataFetcher now use the deterministic addresses deployed on Robinhood mainnet and testnet:

- Ve33: `0xD18685a514E59b06d59824e16Db07e73345d9953`
- Ve33DataFetcher: `0x61F03754b1c7A7F0E584FD8869c00Ba898ab888d`

The Robinhood router and subgraph remain placeholders, so this PR stays draft and is not ready for production traffic.

## Testing

- `tsc --noEmit`
- ESLint across `src/**/*.ts`
- 16 Ekubo V3 Jest suites: 161 tests and 35 snapshots passed
- staged formatting and secret-pattern checks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New pricing path for vote-driven fees and a new chain affect swap quotes and routing; Robinhood router/subgraph placeholders must be updated before production use.
> 
> **Overview**
> Adds **Robinhood (chain 4663)** to Ekubo V3 and wires **Ve33** full-range, stableswap, and concentrated pools into discovery, state, and quoting.
> 
> Ve33 pools load core quote state and the voted **swap fee** together via batched `getVe33QuoteData` (shared bitmap depth on subgraph load and on `generateState`). Event-driven pools call the same fetch on `PoolInitialized` so fees are not briefly zero. **`VoteWeightApplied`** is decoded with the Ve33 ABI to refresh `swapFee`; pool log routing uses that event’s topic for `poolId`.
> 
> Quotes apply the dynamic Q64 fee on top of zero-core-fee math (`quoteVe33`: fee on output for exact-in, gross-up for exact-out). Swap execution uses **`config.router`** per network instead of a single global router.
> 
> Robinhood-specific behavior: **`estimatedCurrentTime`** uses slot duration **0** so sub-second blocks sharing an EVM timestamp are not forced forward by one second. Ve33 and Ve33DataFetcher use deployed addresses; the Robinhood router and subgraph remain **deployment placeholders**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14a0fa7cc0001d8765f852de67ffc9318430ed73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

