### PR TITLE
fix: restore AerodromeSlipstreamFactory3 (Base) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/uniswap-v3/config.ts
+++ b/src/dex/uniswap-v3/config.ts
@@ -462,6 +462,35 @@ export const UniswapV3Config: DexConfigMap<DexParams> = {
       liquidityField: 'liquidity',
     },
   },
+  AerodromeSlipstreamFactory3: {
+    [Network.BASE]: {
+      factory: '0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef',
+      quoter: '0x86D33DCbEC9c75897c6Ce521f33CF84009c4272e',
+      router: '0x33a47A122De0B5c429Ba79E6d17965B0e841c60e',
+      supportedFees: [20000n, 10000n, 3000n, 500n, 100n],
+      tickSpacings: [1n, 10n, 50n, 100n, 200n, 500n, 2000n],
+      tickSpacingsToFees: {
+        '1': 100n,
+        '10': 500n,
+        '50': 500n,
+        '100': 500n,
+        '200': 3000n,
+        '500': 20000n,
+        '2000': 10000n,
+      },
+      stateMulticall: '0x736518161516c1cfBD5bf5e7049FCBDC9b933987',
+      stateMultiCallAbi: VelodromeSlipstreamMulticallABi as AbiItem[],
+      eventPoolImplementation: VelodromeSlipstreamEventPool,
+      factoryImplementation: VelodromeSlipstreamFactory,
+      decodeStateMultiCallResultWithRelativeBitmaps:
+        decodeStateMultiCallResultWithRelativeBitmapsForVelodromeSlipstream,
+      uniswapMulticall: '0x091e99cb1C49331a94dD62755D168E941AbD0693',
+      chunksCount: 10,
+      initRetryFrequency: 10,
+      initHash: '0xc770898522D2A9c8Da7A10D63989b6b58305B665', // pool implementation address from factory contract is used instead of initHash here
+      liquidityField: 'liquidity',
+    },
+  },
   PangolinV3: {
     [Network.AVALANCHE]: {
       factory: '0x1128F23D0bc0A8396E9FBC3c0c68f5EA228B8256',

--- a/src/dex/uniswap-v3/forks/velodrome-slipstream/velodrome-slipstream.ts
+++ b/src/dex/uniswap-v3/forks/velodrome-slipstream/velodrome-slipstream.ts
@@ -67,6 +67,7 @@ export class VelodromeSlipstream extends UniswapV3 {
         'VelodromeSlipstreamNewFactory',
         'AerodromeSlipstream',
         'AerodromeSlipstreamNewFactory',
+        'AerodromeSlipstreamFactory3',
       ]),
     );
 

--- a/src/dex/uniswap-v3/uniswap-v3-e2e.test.ts
+++ b/src/dex/uniswap-v3/uniswap-v3-e2e.test.ts
@@ -1033,6 +1033,30 @@ describe('UniswapV3 E2E', () => {
         );
       });
     });
+
+    describe('AerodromeSlipstreamFactory3', () => {
+      const dexKey = 'AerodromeSlipstreamFactory3';
+      describe('Base', () => {
+        const network = Network.BASE;
+
+        const tokenASymbol: string = 'USDC';
+        const tokenBSymbol: string = 'WETH';
+
+        const tokenAAmount: string = '11000000';
+        const tokenBAmount: string = '1100000000000000';
+        const nativeTokenAmount = '1100000000000000';
+
+        testForNetwork(
+          network,
+          dexKey,
+          tokenASymbol,
+          tokenBSymbol,
+          tokenAAmount,
+          tokenBAmount,
+          nativeTokenAmount,
+        );
+      });
+    });
   });
 
   describe('PharaohV3', () => {

--- a/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
+++ b/src/dex/uniswap-v3/uniswap-v3-integration.test.ts
@@ -2570,6 +2570,144 @@ describe('Slipstream', () => {
     });
   });
 
+  describe('AerodromeSlipstreamFactory3', () => {
+    const dexKey = 'AerodromeSlipstreamFactory3';
+
+    describe('Base', () => {
+      let blockNumber: number;
+      let slipstream: VelodromeSlipstream;
+
+      const network = Network.BASE;
+      const dexHelper = new DummyDexHelper(network);
+      const TokenASymbol = 'USDC';
+      const TokenA = Tokens[network][TokenASymbol];
+
+      const TokenBSymbol = 'WETH';
+      const TokenB = Tokens[network][TokenBSymbol];
+
+      const QuoterV2 = UniswapV3Config[dexKey][network].quoter;
+
+      beforeEach(async () => {
+        blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+        slipstream = new VelodromeSlipstream(network, dexKey, dexHelper);
+      });
+
+      it('getPoolIdentifiers and getPricesVolume SELL', async () => {
+        const amounts = [0n, BI_POWS[6], BI_POWS[6] * 2n];
+
+        const pools = await slipstream.getPoolIdentifiers(
+          TokenA,
+          TokenB,
+          SwapSide.SELL,
+          blockNumber,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+          pools,
+        );
+
+        expect(pools.length).toBeGreaterThan(0);
+
+        const poolPrices = await slipstream.getPricesVolume(
+          TokenA,
+          TokenB,
+          amounts,
+          SwapSide.SELL,
+          blockNumber,
+          pools,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+          poolPrices,
+        );
+
+        expect(poolPrices).not.toBeNull();
+        checkPoolPrices(poolPrices!, amounts, SwapSide.SELL, dexKey);
+
+        let falseChecksCounter = 0;
+        await Promise.all(
+          poolPrices!.map(async price => {
+            const tickSpacing =
+              slipstream.eventPools[price.poolIdentifiers![0]]!.tickSpacing!;
+            const res = await checkOnChainPricing(
+              dexHelper,
+              slipstream,
+              'quoteExactInputSingle',
+              blockNumber,
+              QuoterV2,
+              price.prices,
+              TokenA.address,
+              TokenB.address,
+              tickSpacing,
+              amounts,
+              velodromeQuoterIface,
+            );
+            if (res === false) falseChecksCounter++;
+          }),
+        );
+
+        expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
+      });
+
+      it('getPoolIdentifiers and getPricesVolume BUY', async () => {
+        const amounts = [0n, BI_POWS[15], BI_POWS[15] * 2n];
+
+        const pools = await slipstream.getPoolIdentifiers(
+          TokenA,
+          TokenB,
+          SwapSide.BUY,
+          blockNumber,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Identifiers: `,
+          pools,
+        );
+
+        expect(pools.length).toBeGreaterThan(0);
+
+        const poolPrices = await slipstream.getPricesVolume(
+          TokenA,
+          TokenB,
+          amounts,
+          SwapSide.BUY,
+          blockNumber,
+          pools,
+        );
+        console.log(
+          `${TokenASymbol} <> ${TokenBSymbol} Pool Prices: `,
+          poolPrices,
+        );
+
+        expect(poolPrices).not.toBeNull();
+        checkPoolPrices(poolPrices!, amounts, SwapSide.BUY, dexKey);
+
+        let falseChecksCounter = 0;
+        await Promise.all(
+          poolPrices!.map(async price => {
+            const tickSpacing =
+              slipstream.eventPools[price.poolIdentifiers![0]]!.tickSpacing!;
+            const res = await checkOnChainPricing(
+              dexHelper,
+              slipstream,
+              'quoteExactOutputSingle',
+              blockNumber,
+              QuoterV2,
+              price.prices,
+              TokenA.address,
+              TokenB.address,
+              tickSpacing,
+              amounts,
+              velodromeQuoterIface,
+            );
+            if (res === false) falseChecksCounter++;
+          }),
+        );
+
+        expect(falseChecksCounter).toBeLessThan(poolPrices!.length);
+      });
+    });
+  });
+
   describe('VelodromeSlipstream', () => {
     const dexKey = 'VelodromeSlipstream';
 


### PR DESCRIPTION
Fixes [DEXLIB-213](https://linear.app/veloradex/issue/DEXLIB-213) (Urgent).

## Problem

`aerodromeslipstreamfactory3` is enabled for api-go **pricing** on Base, but api-go's `/api/v1/dexs/8453` advertises `getDexParam: null` for it. Per that contract the api-server must encode locally via dex-lib — and dex-lib has no such adapter, so every transaction build for a route through this exchange throws:

```
Error: aerodromeslipstreamfactory3 dex is not supported for network(8453)!
```

Impact measured on `prod-api-server-8453`: **~250–290k failed builds/day** since 2026-07-20 ~10:00 UTC (~34% 500 rate on `/swap`, ~18% on `/transactions`), and this key accounts for 8,971 of 8,972 build failures in a sampled hour. Volume for the exchange has been exactly $0.00/day since 2026-07-17, against a ~$315k/day average over Jul 1–16.

## Why it was missing

The config was never on `master`. It was added on the unmerged branch `feat/aerodrome-slipstream-factory3` (`16f7bb9a1`) and published to npm from there as `5.0.2-native-dex-math.5` and `5.0.6`. Once releases resumed from `master` at `5.0.7`, the key disappeared from published tarballs. A later refinement (`db6152bdd`) also sits on an unmerged branch.

Jul 17–19 was quiet because an *unknown* dex key is harmless — never registered, never priced. The 500s began only once the key was made priceable again on Jul 20.

## Changes

- `src/dex/uniswap-v3/config.ts` — restore the `AerodromeSlipstreamFactory3` Base entry (factory `0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef`, quoter `0x86D33DCbEC9c75897c6Ce521f33CF84009c4272e`, router `0x33a47A122De0B5c429Ba79E6d17965B0e841c60e`).
- `src/dex/uniswap-v3/forks/velodrome-slipstream/velodrome-slipstream.ts` — register the key in `dexKeysWithNetwork`.
- `uniswap-v3-integration.test.ts` / `uniswap-v3-e2e.test.ts` — restore the USDC/WETH Base test blocks.

This takes the later `db6152bdd` variant rather than a literal `5.0.6` restore, which differs in two ways:

- `supportedFees: [20000n, 10000n, 3000n, 500n, 100n]` instead of the shared `SUPPORTED_FEES` (which omits `20000n`). `5.0.6` was arguably buggy here — `tickSpacingsToFees` maps tickSpacing `500 → 20000n`, a fee absent from `SUPPORTED_FEES`.
- adds `liquidityField: 'liquidity'`, matching the sibling `AerodromeSlipstreamNewFactory`.

No `subgraphURL` exists for this factory, so `getTopPoolsForToken` returns empty for this key and the integration tests omit that case — same as the original branch.

## Relationship to the api-go fix

This is the dex-lib half. It makes the `getDexParam: null` fallback path work, so the 500s stop regardless of what api-go does. It is complementary to — not a replacement for — the two api-server/api-go items in the ticket:

1. api-go returning `getDexParam: { needWrapNative: true }` for the key on 8453, which routes encoding natively and bypasses dex-lib entirely.
2. Hardening `chain-manager.ts` to gate the api-go key merge on `inDexLib[key] || apiGoEncodable[key]` and log anything excluded — the structural gap that let 250k/day silent 500s through instead of one startup warning.

Either this PR or (1) resolves the outage; (3) prevents a recurrence.

## Testing

- `pnpm check:tsc`, eslint, and prettier pass (verified via pre-commit hooks).
- Integration and e2e tests were **not** run — they require live Base RPC / Tenderly and are slow. They should be run before merge:
  ```
  pnpm test src/dex/uniswap-v3/uniswap-v3-integration.test.ts -t AerodromeSlipstreamFactory3
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-enables live swap encoding on a high-traffic Base venue; wrong factory/fee/tick config would break builds or mis-quote, but the change mirrors sibling Aerodrome Slipstream factories and is mostly config plus test coverage.
> 
> **Overview**
> Restores **AerodromeSlipstreamFactory3** on Base so dex-lib can price and encode swaps for a factory that api-go already exposes but previously had no adapter—fixing transaction builds that failed with “dex is not supported for network(8453)”.
> 
> Adds a new `UniswapV3Config` entry with factory/quoter/router addresses, Velodrome Slipstream pool wiring, tick-spacing-to-fee maps (including **20000n** in `supportedFees`), and `liquidityField: 'liquidity'`. There is no `subgraphURL` for this key.
> 
> Registers **`AerodromeSlipstreamFactory3`** in `VelodromeSlipstream.dexKeysWithNetwork` so it uses the existing Slipstream implementation.
> 
> Bumps package version **5.1.1 → 5.1.2** and adds Base **USDC/WETH** integration and e2e test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1370efdad240c296f67b8dc50fff2ae69121b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->